### PR TITLE
Docs: add AutoType table

### DIFF
--- a/packages/docs/content/docs/for-library-authors/features/route-definition.mdx
+++ b/packages/docs/content/docs/for-library-authors/features/route-definition.mdx
@@ -212,35 +212,7 @@ methods.
 
 The first parameter provides access to all incoming request data. Available properties are:
 
-<TypeTable
-  type={{
-    path: {
-      description: "The matched route path (e.g., `/users/:id`)",
-      type: "string",
-      required: true,
-    },
-    method: {
-      description: "The HTTP method as string (e.g., `GET`, `POST`)",
-      type: "string",
-      required: true,
-    },
-    pathParams: {
-      description: "Extracted path parameters as object (e.g., `{ id: '123' }`)",
-      type: "Record<string, string>",
-      required: true,
-    },
-    query: {
-      description: "URLSearchParams object for query parameters",
-      type: "URLSearchParams",
-      required: true,
-    },
-    input: {
-      description: "Input validation context (only if inputSchema is defined)",
-      type: "InputContext",
-      required: true,
-    },
-  }}
-/>
+<AutoTypeTable path="fragno/src/api/request-input-context.ts" name="RequestInputContext" />
 
 The input property is only defined if an input schema is defined for the route.
 

--- a/packages/fragno/src/api/request-input-context.ts
+++ b/packages/fragno/src/api/request-input-context.ts
@@ -110,28 +110,44 @@ export class RequestInputContext<
   }
 
   // TODO(Wilco): We should support reading/modifying headers here.
-
+  /**
+   * The HTTP method as string (e.g., `GET`, `POST`)
+   */
   get method(): string {
     return this.#method;
   }
-
+  /**
+   * The matched route path (e.g., `/users/:id`)
+   * @remarks `string`
+   */
   get path(): TPath {
     return this.#path;
   }
-
+  /**
+   * Extracted path parameters as object (e.g., `{ id: '123' }`)
+   * @remarks `Record<string, string>`
+   */
   get pathParams(): ExtractPathParams<TPath> {
     return this.#pathParams;
   }
-
+  /**
+   * [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) object for query parameters
+   * @remarks `URLSearchParams`
+   */
   get query(): URLSearchParams {
     return this.#searchParams;
   }
-
   // TODO: Should probably remove this
+  /**
+   * @internal
+   */
   get rawBody(): RequestBodyType {
     return this.#body;
   }
-
+  /**
+   * Input validation context (only if inputSchema is defined)
+   * @remarks `InputContext`
+   */
   get input(): TInputSchema extends undefined
     ? undefined
     : {


### PR DESCRIPTION
Use `AutoType` component to link interface definitions in the docs directly. Cannot be used directly on the RequestInputContext class because private using `#` hides the properties. Tried it this way.

Render differences:
<img width="783" height="1397" alt="Screenshot From 2025-09-23 17-58-17" src="https://github.com/user-attachments/assets/e6d94322-b817-4268-84aa-4dbfb3b59a5f" />
