### PR TITLE
DB: destructure find() correctly in drizzle adapter

### DIFF
--- a/packages/fragno-db/src/adapters/drizzle/drizzle-query.ts
+++ b/packages/fragno-db/src/adapters/drizzle/drizzle-query.ts
@@ -113,10 +113,10 @@ export function fromDrizzle<T extends AnySchema>(
   }
 
   return {
-    find(tableName, builderFn) {
-      const uow = createUOW({ config: uowConfig });
-      uow.find(tableName, builderFn);
-      return uow.executeRetrieve();
+    async find(tableName, builderFn) {
+      const uow = createUOW({ config: uowConfig }).find(tableName, builderFn);
+      const [result] = await uow.executeRetrieve();
+      return result;
     },
 
     async findFirst(tableName, builderFn) {


### PR DESCRIPTION
`orm.find()` was returning an array of arrays `T[][]` instead of just an array `T[]`.

`UnitOfWork.executeRetrieve()` returns a **tuple** of all retrieval operation results: `[Result1[], Result2[], ...]`

This is by design - UOW supports multiple find operations in a single transaction for snapshot isolation.

In `drizzle-query.ts`, the `find()` convenience method was:
```typescript
async find(tableName, builderFn) {
  const uow = createUOW();
  uow.find(tableName, builderFn);  // Adds one find operation
  return uow.executeRetrieve();     // Returns [Result[]] - a tuple!
}
```

It forgot to unwrap the tuple, so it returned `[Result[]]` instead of `Result[]`.

```typescript
async find(tableName, builderFn) {
  const uow = createUOW().find(tableName, builderFn);  // Chain to capture return value
  const [result] = await uow.executeRetrieve();         // Destructure the tuple
  return result;                                         // Return just the array
}
```

**Key insight**: `uow.find()` returns a **new** UOW with updated type parameters (the retrieval results tuple type grows). We must chain or capture this return value for TypeScript to track the types correctly.