### PR TITLE
Core: optional query parameters can use reactive atoms

### DIFF
--- a/.changeset/five-ghosts-leave.md
+++ b/.changeset/five-ghosts-leave.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/core": patch
+---
+
+Optional query parameters can now be used with reactive state

--- a/packages/fragno/src/api/internal/path-type.test.ts
+++ b/packages/fragno/src/api/internal/path-type.test.ts
@@ -446,39 +446,39 @@ test("MaybeExtractPathParamsOrWiden type tests", () => {
 test("QueryParamsHint type tests", () => {
   // Basic usage with string union
   expectTypeOf<QueryParamsHint<"page" | "limit">>().toEqualTypeOf<
-    Partial<Record<"page" | "limit", string>> & Record<string, string>
+    Partial<Record<"page" | "limit", string>> & Record<string, string | undefined>
   >();
 
   // Single parameter hint
   expectTypeOf<QueryParamsHint<"search">>().toEqualTypeOf<
-    Partial<Record<"search", string>> & Record<string, string>
+    Partial<Record<"search", string>> & Record<string, string | undefined>
   >();
 
   // Empty hint (never) - should still allow any string keys
   expectTypeOf<QueryParamsHint<never>>().toEqualTypeOf<
-    Partial<Record<never, string>> & Record<string, string>
+    Partial<Record<never, string>> & Record<string, string | undefined>
   >();
 
   // With custom value type
   expectTypeOf<QueryParamsHint<"page" | "limit", number>>().toEqualTypeOf<
-    Partial<Record<"page" | "limit", number>> & Record<string, number>
+    Partial<Record<"page" | "limit", number>> & Record<string, number | undefined>
   >();
 
   // With boolean value type
   expectTypeOf<QueryParamsHint<"enabled" | "debug", boolean>>().toEqualTypeOf<
-    Partial<Record<"enabled" | "debug", boolean>> & Record<string, boolean>
+    Partial<Record<"enabled" | "debug", boolean>> & Record<string, boolean | undefined>
   >();
 
   // With union value type
   type StringOrNumber = string | number;
   expectTypeOf<QueryParamsHint<"value", StringOrNumber>>().toEqualTypeOf<
-    Partial<Record<"value", StringOrNumber>> & Record<string, StringOrNumber>
+    Partial<Record<"value", StringOrNumber>> & Record<string, StringOrNumber | undefined>
   >();
 
   // With custom object type
   type CustomType = { raw: string; parsed: boolean };
   expectTypeOf<QueryParamsHint<"data", CustomType>>().toEqualTypeOf<
-    Partial<Record<"data", CustomType>> & Record<string, CustomType>
+    Partial<Record<"data", CustomType>> & Record<string, CustomType | undefined>
   >();
 });
 

--- a/packages/fragno/src/api/internal/path.ts
+++ b/packages/fragno/src/api/internal/path.ts
@@ -124,7 +124,7 @@ export type HasPathParams<T extends string> = ExtractPathParamNames<T> extends n
 export type QueryParamsHint<TQueryParameters extends string, ValueType = string> = Partial<
   Record<TQueryParameters, ValueType>
 > &
-  Record<string, ValueType>;
+  Record<string, ValueType | undefined>;
 
 // Runtime utilities
 

--- a/packages/fragno/src/client/client-types.test.ts
+++ b/packages/fragno/src/client/client-types.test.ts
@@ -417,7 +417,7 @@ describe("FragnoClientMutatorData", () => {
       (args?: {
         body?: undefined;
         path?: Record<"id", string> | undefined;
-        query?: Record<string, string>;
+        query?: Record<string, string | undefined>;
       }) => Promise<undefined>
     >();
   });
@@ -437,7 +437,7 @@ describe("FragnoClientMutatorData", () => {
       (args?: {
         body?: undefined;
         path?: Record<"id", string> | undefined;
-        query?: Record<string, string>;
+        query?: Record<string, string | undefined>;
       }) => Promise<{
         id: number;
         name: string;
@@ -465,7 +465,7 @@ describe("FragnoClientMutatorData", () => {
             }
           | undefined;
         path?: Record<"id", string> | undefined;
-        query?: Record<string, string>;
+        query?: Record<string, string | undefined>;
       }) => Promise<undefined>
     >();
   });
@@ -486,7 +486,7 @@ describe("FragnoClientMutatorData", () => {
       (args?: {
         body?: undefined;
         path?: Record<"id", string> | undefined;
-        query?: Record<"id" | "name", string>;
+        query?: Record<"id" | "name", string | undefined>;
       }) => Promise<undefined>
     >();
   });


### PR DESCRIPTION
```ts
const [startingAfter, setStartingAfter] = useState<string | undefined>(undefined);
// Previously only strings were allowed for query params, i.e. there was no simple way to express an empty value

const { data } = stripeClient.useCustomers({
query: {
    startingAfter: startingAfter,
},
});
```