### PR TITLE
Add middleware support for database fragments and enhance request con…

### DIFF
--- a/.changeset/tame-melons-know.md
+++ b/.changeset/tame-melons-know.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/db": patch
+"@fragno-dev/core": patch
+---
+
+fix: make unit of work available in middleware

--- a/packages/fragno/src/api/fragment-builder.ts
+++ b/packages/fragno/src/api/fragment-builder.ts
@@ -41,6 +41,10 @@ export interface FragmentDefinition<
   ) => (
     handler: (this: TThisContext, ...args: Parameters<RouteHandler>) => ReturnType<RouteHandler>,
   ) => RouteHandler;
+  /** Optional wrapper for the entire request context (both middleware and handler) */
+  createRequestContextWrapper?: (
+    options: FragnoPublicConfig,
+  ) => <T>(callback: () => Promise<T>) => Promise<T>;
   /** Services that this fragment uses (can be required or optional) */
   usedServices?: {
     [K in keyof TUsedServices]: ServiceMetadata;


### PR DESCRIPTION
…text handling

- Implemented middleware functionality for database fragments, allowing authorization checks before accessing protected routes.
- Added `createRequestContextWrapper` to manage UnitOfWork lifecycle across middleware and handler execution.
- Updated `createHandlerWrapper` to bind route handlers to service context, enabling access to `this.getUnitOfWork()`.
- Enhanced tests to verify middleware behavior with authorized and unauthorized requests.
- Improved documentation for new methods and their intended use cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a request-level context wrapper to create/propagate UnitOfWork across middleware and handlers, and binds database route handlers to access `this.getUnitOfWork()`; includes tests and adapter tweaks.
> 
> - **Core (`@fragno-dev/core`)**
>   - **Request lifecycle**: Add `definition.createRequestContextWrapper` to wrap both middleware and handler execution; used in `handler` and `callRouteRaw` to scope UnitOfWork per request.
>   - **Handler binding**: Continue supporting `definition.createHandlerWrapper` to bind `this` for handlers; now focused solely on binding (UoW creation moved to request wrapper).
> - **DB (`@fragno-dev/db`)**
>   - **Fragment builder**: Implement `createRequestContextWrapper` that creates a UnitOfWork via ORM and exposes it through AsyncLocalStorage; `createHandlerWrapper` binds handlers to `serviceContext` enabling `this.getUnitOfWork()`.
>   - **Tests**: Add middleware auth test ensuring UoW availability in middleware; add `callRoute` test verifying UoW in handlers; extend mock adapter to provide `createUnitOfWork()`.
> - **Release**
>   - Changeset: patch bumps for `@fragno-dev/db` and `@fragno-dev/core` with fix "make unit of work available in middleware".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b3dc58a2c93387bcd01301eec4b80f8b8c6ab9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->