### PR TITLE
refactor(stripe): move to new Fragment builder system

### DIFF
--- a/packages/stripe/src/definition.ts
+++ b/packages/stripe/src/definition.ts
@@ -1,0 +1,185 @@
+import Stripe from "stripe";
+import type { AbstractQuery, TableToInsertValues } from "@fragno-dev/db/query";
+import type {
+  Logger,
+  StripeFragmentConfig,
+  StripeFragmentDeps,
+  StripeFragmentServices,
+} from "./types";
+import { stripeSchema } from "./database/schema";
+import { defineFragment } from "@fragno-dev/core/api/fragment-definition-builder";
+import { withDatabase } from "@fragno-dev/db/fragment-definition-builder";
+import { stripeSubscriptionToInternalSubscription } from "./utils";
+
+const LOG_PREFIX = "[Stripe Fragment]";
+const defaultLogger: Logger = {
+  info: (...data) => console.info(LOG_PREFIX, ...data),
+  error: (...data) => console.error(LOG_PREFIX, ...data),
+  warn: (...data) => console.warn(LOG_PREFIX, ...data),
+  debug: (...data) => console.debug(LOG_PREFIX, ...data),
+  log: (...data) => console.log(LOG_PREFIX, ...data),
+};
+
+const asExternalSubscription = <T extends { id: { externalId: string }; status: string }>(
+  subscription: T,
+) => ({
+  ...subscription,
+  id: subscription.id.externalId,
+  status: subscription.status as Stripe.Subscription.Status,
+});
+
+function createStripeServices(
+  deps: StripeFragmentDeps,
+  db: AbstractQuery<typeof stripeSchema>,
+): StripeFragmentServices {
+  const services: StripeFragmentServices = {
+    getStripeClient(): Stripe {
+      return deps.stripe;
+    },
+    createSubscription: async (
+      data: Omit<
+        TableToInsertValues<typeof stripeSchema.tables.subscription>,
+        "id" | "createdAt" | "updatedAt"
+      >,
+    ) => {
+      return (await db.create("subscription", data)).externalId;
+    },
+    updateSubscription: async (
+      id: string,
+      data: Partial<Omit<TableToInsertValues<typeof stripeSchema.tables.subscription>, "id">>,
+    ) => {
+      await db.update("subscription", id, (b) => b.set({ ...data, updatedAt: new Date() }));
+    },
+
+    getSubscriptionByStripeId: async (stripeSubscriptionId: string) => {
+      const result = await db.findFirst("subscription", (b) =>
+        b.whereIndex("idx_stripe_subscription_id", (eb) =>
+          eb("stripeSubscriptionId", "=", stripeSubscriptionId),
+        ),
+      );
+      if (!result) {
+        return null;
+      }
+
+      return asExternalSubscription(result);
+    },
+    getSubscriptionsByStripeCustomerId: async (stripeCustomerId: string) => {
+      return (
+        await db.find("subscription", (b) =>
+          b.whereIndex("idx_stripe_customer_id", (eb) =>
+            eb("stripeCustomerId", "=", stripeCustomerId),
+          ),
+        )
+      ).map(asExternalSubscription);
+    },
+    getSubscriptionById: async (id: string) => {
+      const result = await db.findFirst("subscription", (b) =>
+        b.whereIndex("primary", (eb) => eb("id", "=", id)),
+      );
+      if (!result) {
+        return null;
+      }
+      return asExternalSubscription(result);
+    },
+    getSubscriptionsByReferenceId: async (referenceId: string) => {
+      const result = await db.find("subscription", (b) =>
+        b.whereIndex("idx_reference_id", (eb) => eb("referenceId", "=", referenceId)),
+      );
+      if (result.length == 0) {
+        return [];
+      }
+      return result.map(asExternalSubscription);
+    },
+
+    deleteSubscription: async (id: string) => {
+      await db.delete("subscription", id);
+    },
+
+    deleteSubscriptionsByReferenceId: async (referenceId: string) => {
+      const uow = db
+        .createUnitOfWork()
+        .find("subscription", (b) =>
+          b.whereIndex("idx_reference_id", (eb) => eb("referenceId", "=", referenceId)),
+        );
+
+      const [subscriptions] = await uow.executeRetrieve();
+      subscriptions.forEach((sub) => sub && uow.delete("subscription", sub.id));
+
+      return await uow.executeMutations();
+    },
+
+    getAllSubscriptions: async () => {
+      return (await db.find("subscription", (b) => b.whereIndex("primary"))).map(
+        asExternalSubscription,
+      );
+    },
+
+    /* Retrieve Stripe Subscription and create/update/delete internal entity */
+    syncStripeSubscriptions: async (referenceId: string, stripeCustomerId: string) => {
+      const stripeSubscriptions = await deps.stripe.subscriptions.list({
+        customer: stripeCustomerId,
+        status: "all",
+      });
+
+      if (stripeSubscriptions.data.length === 0) {
+        await services.deleteSubscriptionsByReferenceId(referenceId);
+        return { success: true };
+      }
+
+      const uow = db
+        .createUnitOfWork()
+        .find("subscription", (b) =>
+          b.whereIndex("idx_reference_id", (eb) => eb("referenceId", "=", referenceId)),
+        );
+
+      const [existingSubscriptions] = await uow.executeRetrieve();
+
+      // Mutation phase: process all Stripe subscriptions (including canceled)
+      for (const stripeSubscription of stripeSubscriptions.data) {
+        const existingSubscription = existingSubscriptions.find(
+          (sub) => sub.stripeSubscriptionId === stripeSubscription.id,
+        );
+
+        if (existingSubscription) {
+          // Update existing subscription with optimistic concurrency control
+          uow.update("subscription", existingSubscription.id, (b) =>
+            b
+              .set({
+                ...stripeSubscriptionToInternalSubscription(stripeSubscription),
+                updatedAt: new Date(),
+              })
+              .check(),
+          );
+        } else {
+          // Create new subscription
+          uow.create("subscription", {
+            ...stripeSubscriptionToInternalSubscription(stripeSubscription),
+            referenceId: referenceId ?? null,
+            updatedAt: new Date(),
+          });
+        }
+      }
+
+      // Execute all mutations and return result
+      return uow.executeMutations();
+    },
+  };
+  return services;
+}
+
+export const stripeFragmentDefinition = defineFragment<StripeFragmentConfig>("stripe")
+  .extend(withDatabase(stripeSchema))
+  .withDependencies(({ config }) => {
+    const stripeClient = new Stripe(config.stripeSecretKey, config.stripeClientOptions ?? {});
+
+    return {
+      stripe: stripeClient,
+      log: config.logger ? config.logger : defaultLogger,
+    };
+  })
+  .providesBaseService(({ deps }) => {
+    return {
+      ...createStripeServices(deps, deps.db),
+    };
+  })
+  .build();

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -1,225 +1,36 @@
-import { createFragment, type FragnoPublicClientConfig } from "@fragno-dev/core";
-import { createClientBuilder } from "@fragno-dev/core/client";
-import type { AbstractQuery, TableToInsertValues } from "@fragno-dev/db/query";
-
-import {
-  defineFragmentWithDatabase,
-  type FragnoPublicConfigWithDatabase,
-} from "@fragno-dev/db/fragment";
-
-import Stripe from "stripe";
-import type {
-  Logger,
-  StripeFragmentConfig,
-  StripeFragmentDeps,
-  StripeFragmentServices,
-} from "./types";
-import { stripeSchema } from "./database/schema";
+import type { FragnoPublicClientConfig } from "@fragno-dev/core";
+import { createClientBuilderNew } from "@fragno-dev/core/client";
+import type { FragnoPublicConfigWithDatabase } from "@fragno-dev/db/fragment";
+import type { StripeFragmentConfig } from "./types";
+import { stripeFragmentDefinition } from "./definition";
 import { webhookRoutesFactory } from "./routes/webhooks";
 import { customersRoutesFactory } from "./routes/customers";
 import { subscriptionsRoutesFactory } from "./routes/subscriptions";
 import { productsRoutesFactory } from "./routes/products";
 import { pricesRoutesFactory } from "./routes/prices";
-import { stripeSubscriptionToInternalSubscription } from "./utils";
+import { instantiate } from "@fragno-dev/core/api/fragment-instantiator";
 
-const LOG_PREFIX = "[Stripe Fragment]";
-const defaultLogger: Logger = {
-  info: (...data) => console.info(LOG_PREFIX, ...data),
-  error: (...data) => console.error(LOG_PREFIX, ...data),
-  warn: (...data) => console.warn(LOG_PREFIX, ...data),
-  debug: (...data) => console.debug(LOG_PREFIX, ...data),
-  log: (...data) => console.log(LOG_PREFIX, ...data),
-};
-
-export const stripeFragmentDefinition = defineFragmentWithDatabase<StripeFragmentConfig>("stripe")
-  .withDatabase(stripeSchema, "stripe")
-  .withDependencies(({ config }): StripeFragmentDeps => {
-    const stripeClient = new Stripe(config.stripeSecretKey, config.stripeClientOptions ?? {});
-
-    return {
-      stripe: stripeClient,
-      log: config.logger ? config.logger : defaultLogger,
-    };
-  })
-  .providesService(({ deps, db, defineService }) => {
-    return defineService({
-      ...createStripeServices(deps, db),
-    });
-  });
-
-const asExternalSubscription = <T extends { id: { externalId: string }; status: string }>(
-  subscription: T,
-) => ({
-  ...subscription,
-  id: subscription.id.externalId,
-  status: subscription.status as Stripe.Subscription.Status,
-});
-
-function createStripeServices(
-  deps: StripeFragmentDeps,
-  db: AbstractQuery<typeof stripeSchema>,
-): StripeFragmentServices {
-  const services: StripeFragmentServices = {
-    getStripeClient(): Stripe {
-      return deps.stripe;
-    },
-    createSubscription: async (
-      data: Omit<
-        TableToInsertValues<typeof stripeSchema.tables.subscription>,
-        "id" | "createdAt" | "updatedAt"
-      >,
-    ) => {
-      return (await db.create("subscription", data)).externalId;
-    },
-    updateSubscription: async (
-      id: string,
-      data: Partial<Omit<TableToInsertValues<typeof stripeSchema.tables.subscription>, "id">>,
-    ) => {
-      await db.update("subscription", id, (b) => b.set({ ...data, updatedAt: new Date() }));
-    },
-
-    getSubscriptionByStripeId: async (stripeSubscriptionId: string) => {
-      const result = await db.findFirst("subscription", (b) =>
-        b.whereIndex("idx_stripe_subscription_id", (eb) =>
-          eb("stripeSubscriptionId", "=", stripeSubscriptionId),
-        ),
-      );
-      if (!result) {
-        return null;
-      }
-
-      return asExternalSubscription(result);
-    },
-    getSubscriptionsByStripeCustomerId: async (stripeCustomerId: string) => {
-      return (
-        await db.find("subscription", (b) =>
-          b.whereIndex("idx_stripe_customer_id", (eb) =>
-            eb("stripeCustomerId", "=", stripeCustomerId),
-          ),
-        )
-      ).map(asExternalSubscription);
-    },
-    getSubscriptionById: async (id: string) => {
-      const result = await db.findFirst("subscription", (b) =>
-        b.whereIndex("primary", (eb) => eb("id", "=", id)),
-      );
-      if (!result) {
-        return null;
-      }
-      return asExternalSubscription(result);
-    },
-    getSubscriptionsByReferenceId: async (referenceId: string) => {
-      const result = await db.find("subscription", (b) =>
-        b.whereIndex("idx_reference_id", (eb) => eb("referenceId", "=", referenceId)),
-      );
-      if (result.length == 0) {
-        return [];
-      }
-      return result.map(asExternalSubscription);
-    },
-
-    deleteSubscription: async (id: string) => {
-      await db.delete("subscription", id);
-    },
-
-    deleteSubscriptionsByReferenceId: async (referenceId: string) => {
-      const uow = db
-        .createUnitOfWork()
-        .find("subscription", (b) =>
-          b.whereIndex("idx_reference_id", (eb) => eb("referenceId", "=", referenceId)),
-        );
-
-      const [subscriptions] = await uow.executeRetrieve();
-      subscriptions.forEach((sub) => sub && uow.delete("subscription", sub.id));
-
-      return await uow.executeMutations();
-    },
-
-    getAllSubscriptions: async () => {
-      return (await db.find("subscription", (b) => b.whereIndex("primary"))).map(
-        asExternalSubscription,
-      );
-    },
-
-    /* Retrieve Stripe Subscription and create/update/delete internal entity */
-    syncStripeSubscriptions: async (referenceId: string, stripeCustomerId: string) => {
-      const stripeSubscriptions = await deps.stripe.subscriptions.list({
-        customer: stripeCustomerId,
-        status: "all",
-      });
-
-      if (stripeSubscriptions.data.length === 0) {
-        await services.deleteSubscriptionsByReferenceId(referenceId);
-        return { success: true };
-      }
-
-      const uow = db
-        .createUnitOfWork()
-        .find("subscription", (b) =>
-          b.whereIndex("idx_reference_id", (eb) => eb("referenceId", "=", referenceId)),
-        );
-
-      const [existingSubscriptions] = await uow.executeRetrieve();
-
-      // Mutation phase: process all Stripe subscriptions (including canceled)
-      for (const stripeSubscription of stripeSubscriptions.data) {
-        const existingSubscription = existingSubscriptions.find(
-          (sub) => sub.stripeSubscriptionId === stripeSubscription.id,
-        );
-
-        if (existingSubscription) {
-          // Update existing subscription with optimistic concurrency control
-          uow.update("subscription", existingSubscription.id, (b) =>
-            b
-              .set({
-                ...stripeSubscriptionToInternalSubscription(stripeSubscription),
-                updatedAt: new Date(),
-              })
-              .check(),
-          );
-        } else {
-          // Create new subscription
-          uow.create("subscription", {
-            ...stripeSubscriptionToInternalSubscription(stripeSubscription),
-            referenceId: referenceId ?? null,
-            updatedAt: new Date(),
-          });
-        }
-      }
-
-      // Execute all mutations and return result
-      return uow.executeMutations();
-    },
-  };
-  return services;
-}
+const routes = [
+  webhookRoutesFactory,
+  customersRoutesFactory,
+  subscriptionsRoutesFactory,
+  productsRoutesFactory,
+  pricesRoutesFactory,
+] as const;
 
 export function createStripeFragment(
   config: StripeFragmentConfig,
   fragnoConfig: FragnoPublicConfigWithDatabase,
 ) {
-  return createFragment(
-    stripeFragmentDefinition,
-    config,
-    [
-      webhookRoutesFactory,
-      customersRoutesFactory,
-      subscriptionsRoutesFactory,
-      productsRoutesFactory,
-      pricesRoutesFactory,
-    ],
-    fragnoConfig,
-  );
+  return instantiate(stripeFragmentDefinition)
+    .withConfig(config)
+    .withRoutes(routes)
+    .withOptions(fragnoConfig)
+    .build();
 }
 
 export function createStripeFragmentClients(fragnoConfig: FragnoPublicClientConfig = {}) {
-  const builder = createClientBuilder(stripeFragmentDefinition, fragnoConfig, [
-    webhookRoutesFactory,
-    customersRoutesFactory,
-    subscriptionsRoutesFactory,
-    productsRoutesFactory,
-    pricesRoutesFactory,
-  ]);
+  const builder = createClientBuilderNew(stripeFragmentDefinition, fragnoConfig, routes);
 
   return {
     // These hooks are for building internal administrative interfaces
@@ -235,5 +46,11 @@ export function createStripeFragmentClients(fragnoConfig: FragnoPublicClientConf
   };
 }
 
-export type { StripeFragmentConfig, StripeFragmentDeps, StripeFragmentServices } from "./types";
+export { stripeFragmentDefinition } from "./definition";
+export type {
+  StripeFragmentConfig,
+  StripeFragmentDeps,
+  StripeFragmentServices,
+  Logger,
+} from "./types";
 export type { FragnoRouteConfig } from "@fragno-dev/core/api";

--- a/packages/stripe/src/routes/customers.ts
+++ b/packages/stripe/src/routes/customers.ts
@@ -1,90 +1,91 @@
-import { defineRoute, defineRoutes } from "@fragno-dev/core";
 import { z } from "zod";
-import type { StripeFragmentConfig, StripeFragmentDeps, StripeFragmentServices } from "../types";
 import { CustomerResponseSchema } from "../models/customers";
 import { stripeToApiError } from "./errors";
+import { defineRoutesNew } from "@fragno-dev/core/api/route";
+import { stripeFragmentDefinition } from "../definition";
 
-export const customersRoutesFactory = defineRoutes<
-  StripeFragmentConfig,
-  StripeFragmentDeps,
-  StripeFragmentServices
->().create(({ deps, config }) => {
-  return [
-    defineRoute({
-      method: "GET",
-      path: "/admin/customers",
-      inputSchema: z.object({
-        limit: z
-          .number()
-          .int()
-          .positive()
-          .max(100)
-          .optional()
-          .default(50)
-          .describe("Number of customers to return (max 100)"),
-        startingAfter: z.string().optional().describe("Customer ID to start after for pagination"),
-      }),
-      outputSchema: z.object({
-        customers: z.array(CustomerResponseSchema),
-        hasMore: z.boolean().describe("Whether there are more customers to fetch"),
-      }),
-      handler: async ({ query }, { json, error }) => {
-        if (!config.enableAdminRoutes) {
-          return error({ message: "Unauthorized", code: "UNAUTHORIZED" }, 401);
-        }
+export const customersRoutesFactory = defineRoutesNew(stripeFragmentDefinition).create(
+  ({ deps, config, defineRoute }) => {
+    return [
+      defineRoute({
+        method: "GET",
+        path: "/admin/customers",
+        inputSchema: z.object({
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .max(100)
+            .optional()
+            .default(50)
+            .describe("Number of customers to return (max 100)"),
+          startingAfter: z
+            .string()
+            .optional()
+            .describe("Customer ID to start after for pagination"),
+        }),
+        outputSchema: z.object({
+          customers: z.array(CustomerResponseSchema),
+          hasMore: z.boolean().describe("Whether there are more customers to fetch"),
+        }),
+        handler: async ({ query }, { json, error }) => {
+          if (!config.enableAdminRoutes) {
+            return error({ message: "Unauthorized", code: "UNAUTHORIZED" }, 401);
+          }
 
-        const limit = Number(query.get("limit")) || undefined;
-        const startingAfter = query.get("startingAfter") || undefined;
+          const limit = Number(query.get("limit")) || undefined;
+          const startingAfter = query.get("startingAfter") || undefined;
 
-        const customers = await deps.stripe.customers.list({
-          limit,
-          starting_after: startingAfter,
-        });
-        return json({
-          customers: customers.data,
-          hasMore: customers.has_more,
-        });
-      },
-    }),
-    defineRoute({
-      method: "POST",
-      path: "/portal",
-      inputSchema: z.object({
-        returnUrl: z.url().describe("URL to redirect to after completing billing portal"),
-      }),
-      outputSchema: z.object({
-        url: z.url().describe("URL to redirect to after cancellation"),
-        redirect: z.boolean().describe("Whether to redirect to the URL"),
-      }),
-      errorCodes: ["NO_STRIPE_CUSTOMER_FOR_ENTITY"] as const,
-      handler: async (context, { json, error }) => {
-        const body = await context.input.valid();
-        const { stripeCustomerId } = await config.resolveEntityFromRequest(context);
-
-        if (!stripeCustomerId) {
-          return error(
-            {
-              message: "No stripe customer to create billing portal for",
-              code: "NO_STRIPE_CUSTOMER_FOR_ENTITY",
-            },
-            400,
-          );
-        }
-
-        try {
-          const portalSession = await deps.stripe.billingPortal.sessions.create({
-            customer: stripeCustomerId,
-            return_url: body.returnUrl,
+          const customers = await deps.stripe.customers.list({
+            limit,
+            starting_after: startingAfter,
           });
-
           return json({
-            url: portalSession.url,
-            redirect: true,
+            customers: customers.data,
+            hasMore: customers.has_more,
           });
-        } catch (err: unknown) {
-          throw stripeToApiError(err);
-        }
-      },
-    }),
-  ];
-});
+        },
+      }),
+      defineRoute({
+        method: "POST",
+        path: "/portal",
+        inputSchema: z.object({
+          returnUrl: z.url().describe("URL to redirect to after completing billing portal"),
+        }),
+        outputSchema: z.object({
+          url: z.url().describe("URL to redirect to after cancellation"),
+          redirect: z.boolean().describe("Whether to redirect to the URL"),
+        }),
+        errorCodes: ["NO_STRIPE_CUSTOMER_FOR_ENTITY"] as const,
+        handler: async (context, { json, error }) => {
+          const body = await context.input.valid();
+          const { stripeCustomerId } = await config.resolveEntityFromRequest(context);
+
+          if (!stripeCustomerId) {
+            return error(
+              {
+                message: "No stripe customer to create billing portal for",
+                code: "NO_STRIPE_CUSTOMER_FOR_ENTITY",
+              },
+              400,
+            );
+          }
+
+          try {
+            const portalSession = await deps.stripe.billingPortal.sessions.create({
+              customer: stripeCustomerId,
+              return_url: body.returnUrl,
+            });
+
+            return json({
+              url: portalSession.url,
+              redirect: true,
+            });
+          } catch (err: unknown) {
+            throw stripeToApiError(err);
+          }
+        },
+      }),
+    ];
+  },
+);

--- a/packages/stripe/src/routes/prices.ts
+++ b/packages/stripe/src/routes/prices.ts
@@ -1,52 +1,50 @@
-import { defineRoute, defineRoutes } from "@fragno-dev/core";
 import { z } from "zod";
-import type { StripeFragmentConfig, StripeFragmentDeps, StripeFragmentServices } from "../types";
 import { PriceResponseSchema } from "../models/prices";
+import { defineRoutesNew } from "@fragno-dev/core/api/route";
+import { stripeFragmentDefinition } from "../definition";
 
-export const pricesRoutesFactory = defineRoutes<
-  StripeFragmentConfig,
-  StripeFragmentDeps,
-  StripeFragmentServices
->().create(({ deps, config }) => {
-  return [
-    defineRoute({
-      method: "GET",
-      path: "/admin/products/:productId/prices",
-      inputSchema: z.object({
-        limit: z
-          .number()
-          .int()
-          .positive()
-          .max(100)
-          .optional()
-          .default(50)
-          .describe("Number of prices to return (max 100)"),
-        startingAfter: z.string().optional().describe("Price ID to start after for pagination"),
+export const pricesRoutesFactory = defineRoutesNew(stripeFragmentDefinition).create(
+  ({ deps, config, defineRoute }) => {
+    return [
+      defineRoute({
+        method: "GET",
+        path: "/admin/products/:productId/prices",
+        inputSchema: z.object({
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .max(100)
+            .optional()
+            .default(50)
+            .describe("Number of prices to return (max 100)"),
+          startingAfter: z.string().optional().describe("Price ID to start after for pagination"),
+        }),
+        outputSchema: z.object({
+          prices: z.array(PriceResponseSchema),
+          hasMore: z.boolean().describe("Whether there are more items to fetch"),
+        }),
+        handler: async ({ pathParams, query }, { json, error }) => {
+          if (!config.enableAdminRoutes) {
+            return error({ message: "Unauthorized", code: "UNAUTHORIZED" }, 401);
+          }
+
+          const { productId } = pathParams;
+          const limit = Number(query.get("limit")) || undefined;
+          const startingAfter = query.get("startingAfter") || undefined;
+
+          const prices = await deps.stripe.prices.list({
+            product: productId,
+            limit,
+            starting_after: startingAfter,
+          });
+
+          return json({
+            prices: prices.data,
+            hasMore: prices.has_more,
+          });
+        },
       }),
-      outputSchema: z.object({
-        prices: z.array(PriceResponseSchema),
-        hasMore: z.boolean().describe("Whether there are more items to fetch"),
-      }),
-      handler: async ({ pathParams, query }, { json, error }) => {
-        if (!config.enableAdminRoutes) {
-          return error({ message: "Unauthorized", code: "UNAUTHORIZED" }, 401);
-        }
-
-        const { productId } = pathParams;
-        const limit = Number(query.get("limit")) || undefined;
-        const startingAfter = query.get("startingAfter") || undefined;
-
-        const prices = await deps.stripe.prices.list({
-          product: productId,
-          limit,
-          starting_after: startingAfter,
-        });
-
-        return json({
-          prices: prices.data,
-          hasMore: prices.has_more,
-        });
-      },
-    }),
-  ];
-});
+    ];
+  },
+);

--- a/packages/stripe/src/routes/products.ts
+++ b/packages/stripe/src/routes/products.ts
@@ -1,50 +1,48 @@
-import { defineRoute, defineRoutes } from "@fragno-dev/core";
 import { z } from "zod";
-import type { StripeFragmentConfig, StripeFragmentDeps, StripeFragmentServices } from "../types";
 import { ProductResponseSchema } from "../models/products";
+import { defineRoutesNew } from "@fragno-dev/core/api/route";
+import { stripeFragmentDefinition } from "../definition";
 
-export const productsRoutesFactory = defineRoutes<
-  StripeFragmentConfig,
-  StripeFragmentDeps,
-  StripeFragmentServices
->().create(({ deps, config }) => {
-  return [
-    defineRoute({
-      method: "GET",
-      path: "/admin/products",
-      inputSchema: z.object({
-        limit: z
-          .number()
-          .int()
-          .positive()
-          .max(100)
-          .optional()
-          .default(50)
-          .describe("Number of products to return (max 100)"),
-        startingAfter: z.string().optional().describe("Product ID to start after for pagination"),
+export const productsRoutesFactory = defineRoutesNew(stripeFragmentDefinition).create(
+  ({ deps, config, defineRoute }) => {
+    return [
+      defineRoute({
+        method: "GET",
+        path: "/admin/products",
+        inputSchema: z.object({
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .max(100)
+            .optional()
+            .default(50)
+            .describe("Number of products to return (max 100)"),
+          startingAfter: z.string().optional().describe("Product ID to start after for pagination"),
+        }),
+        outputSchema: z.object({
+          products: z.array(ProductResponseSchema),
+          hasMore: z.boolean().describe("Whether there are more items to fetch"),
+        }),
+        handler: async ({ query }, { json, error }) => {
+          if (!config.enableAdminRoutes) {
+            return error({ message: "Unauthorized", code: "UNAUTHORIZED" }, 401);
+          }
+
+          const limit = Number(query.get("limit")) || undefined;
+          const startingAfter = query.get("startingAfter") || undefined;
+
+          const products = await deps.stripe.products.list({
+            limit,
+            starting_after: startingAfter,
+          });
+
+          return json({
+            products: products.data,
+            hasMore: products.has_more,
+          });
+        },
       }),
-      outputSchema: z.object({
-        products: z.array(ProductResponseSchema),
-        hasMore: z.boolean().describe("Whether there are more items to fetch"),
-      }),
-      handler: async ({ query }, { json, error }) => {
-        if (!config.enableAdminRoutes) {
-          return error({ message: "Unauthorized", code: "UNAUTHORIZED" }, 401);
-        }
-
-        const limit = Number(query.get("limit")) || undefined;
-        const startingAfter = query.get("startingAfter") || undefined;
-
-        const products = await deps.stripe.products.list({
-          limit,
-          starting_after: startingAfter,
-        });
-
-        return json({
-          products: products.data,
-          hasMore: products.has_more,
-        });
-      },
-    }),
-  ];
-});
+    ];
+  },
+);

--- a/packages/stripe/src/routes/subscriptions.ts
+++ b/packages/stripe/src/routes/subscriptions.ts
@@ -1,368 +1,366 @@
-import { defineRoute, defineRoutes } from "@fragno-dev/core";
 import { z } from "zod";
-import type { StripeFragmentConfig, StripeFragmentDeps, StripeFragmentServices } from "../types";
 import {
   SubscriptionReponseSchema,
   SubscriptionUpgradeRequestSchema,
   type SubscriptionResponse,
 } from "../models/subscriptions";
 import { stripeToApiError } from "./errors";
+import { defineRoutesNew } from "@fragno-dev/core/api/route";
+import { stripeFragmentDefinition } from "../definition";
 
-export const subscriptionsRoutesFactory = defineRoutes<
-  StripeFragmentConfig,
-  StripeFragmentDeps,
-  StripeFragmentServices
->().create(({ deps, services, config }) => {
-  return [
-    defineRoute({
-      method: "GET",
-      path: "/admin/subscriptions",
-      outputSchema: z.object({
-        subscriptions: z.array(SubscriptionReponseSchema),
+export const subscriptionsRoutesFactory = defineRoutesNew(stripeFragmentDefinition).create(
+  ({ deps, services, config, defineRoute }) => {
+    return [
+      defineRoute({
+        method: "GET",
+        path: "/admin/subscriptions",
+        outputSchema: z.object({
+          subscriptions: z.array(SubscriptionReponseSchema),
+        }),
+        handler: async (_, { json, error }) => {
+          if (!config.enableAdminRoutes) {
+            return error({ message: "Unauthorized", code: "UNAUTHORIZED" }, 401);
+          }
+
+          // TODO: Implement pagination
+          return json({
+            subscriptions: await services.getAllSubscriptions(),
+          });
+        },
       }),
-      handler: async (_, { json, error }) => {
-        if (!config.enableAdminRoutes) {
-          return error({ message: "Unauthorized", code: "UNAUTHORIZED" }, 401);
-        }
+      defineRoute({
+        method: "POST",
+        path: "/subscription/upgrade",
+        inputSchema: SubscriptionUpgradeRequestSchema,
+        outputSchema: z.object({
+          url: z.string(),
+          redirect: z.boolean(),
+          sessionId: z.string().optional(),
+        }),
+        errorCodes: [
+          "MISSING_CUSTOMER_INFO",
+          "SUBSCRIPTION_NOT_FOUND",
+          "CUSTOMER_SUBSCRIPTION_MISMATCH",
+          "UPGRADE_HAS_NO_EFFECT",
+          "SUBSCRIPTION_UPDATE_NOT_ALLOWED",
+          "SUBSCRIPTION_UPDATE_PROMO_CODE_NOT_ALLOWED",
+          "PROMOTION_CODE_CUSTOMER_NOT_FIRST_TIME",
+          "MULTIPLE_ACTIVE_SUBSCRIPTIONS",
+          "NO_ACTIVE_SUBSCRIPTIONS",
+        ] as const,
+        handler: async (context, { json, error }) => {
+          const body = await context.input.valid();
+          const entity = await config.resolveEntityFromRequest(context);
 
-        // TODO: Implement pagination
-        return json({
-          subscriptions: await services.getAllSubscriptions(),
-        });
-      },
-    }),
-    defineRoute({
-      method: "POST",
-      path: "/subscription/upgrade",
-      inputSchema: SubscriptionUpgradeRequestSchema,
-      outputSchema: z.object({
-        url: z.string(),
-        redirect: z.boolean(),
-        sessionId: z.string().optional(),
+          let customerId: string | undefined = entity.stripeCustomerId;
+          let existingSubscription: SubscriptionResponse | null = null;
+
+          // Step 1: Get active subscriptions
+          if (entity.stripeCustomerId) {
+            const existingSubscriptions = await services.getSubscriptionsByStripeCustomerId(
+              entity.stripeCustomerId,
+            );
+
+            // Cannot upgrade cancelled subscriptions
+            let activeSubscriptions = existingSubscriptions.filter((s) => s.status !== "canceled");
+
+            // A specific subscription has been specified
+            if (body.subscriptionId) {
+              activeSubscriptions = activeSubscriptions.filter((s) => s.id === body.subscriptionId);
+            }
+
+            if (activeSubscriptions.length > 1) {
+              return error(
+                {
+                  message:
+                    "Multiple active subscriptions found for customer, please specify which subscription to upgrade",
+                  code: "MULTIPLE_ACTIVE_SUBSCRIPTIONS",
+                },
+                400,
+              );
+            }
+            if (activeSubscriptions.length === 0) {
+              return error(
+                {
+                  message: "No active subscriptions found for customer",
+                  code: "NO_ACTIVE_SUBSCRIPTIONS",
+                },
+                400,
+              );
+            }
+            existingSubscription = activeSubscriptions[0];
+
+            if (
+              customerId &&
+              existingSubscription.stripeCustomerId &&
+              existingSubscription.stripeCustomerId !== customerId
+            ) {
+              return error(
+                {
+                  message:
+                    "Subsciption being updated does not belong to Stripe Customer that was provided",
+                  code: "CUSTOMER_SUBSCRIPTION_MISMATCH",
+                },
+                422,
+              );
+            }
+
+            customerId = existingSubscription.stripeCustomerId;
+          }
+
+          // Step 2: Get or Create customer if not found
+          if (!customerId) {
+            const existingLinkedCustomer = await deps.stripe.customers.search({
+              query: `metadata['referenceId']:'${entity.referenceId}'`,
+              limit: 1,
+            });
+
+            if (existingLinkedCustomer.data.length === 1) {
+              // Use existing customer
+              customerId = existingLinkedCustomer.data[0].id;
+            } else {
+              // Create new Stripe Customer
+
+              // Check if sufficient data is provided for this scenario
+              if (!entity.customerEmail || !entity.referenceId) {
+                return error({
+                  message:
+                    "New Stripe Customer must be created, but customerEmail or referenceID has not been provided",
+                  code: "MISSING_CUSTOMER_INFO",
+                });
+              }
+
+              const newCustomer = await deps.stripe.customers.create({
+                email: entity.customerEmail,
+                metadata: {
+                  referenceId: entity.referenceId,
+                  ...entity.stripeMetadata,
+                },
+              });
+              customerId = newCustomer.id;
+            }
+
+            // Communicate back to the user that a customer has been created/linked
+            try {
+              await config.onStripeCustomerCreated(customerId, entity.referenceId);
+            } catch (error) {
+              deps.log.error("onStripeCustomerCreated failed!", error);
+            }
+          }
+
+          // Step 3: Resolve promotion code to ID if provided
+          let promotionCodeId: string | undefined = undefined;
+          if (body.promotionCode) {
+            const promotionCodes = await deps.stripe.promotionCodes.list({
+              code: body.promotionCode,
+              active: true,
+              limit: 1,
+            });
+            if (promotionCodes.data.length > 0) {
+              promotionCodeId = promotionCodes.data[0].id;
+            }
+          }
+
+          // Step 4: If existing subscription is active, modify using billing portal
+          if (
+            existingSubscription?.status === "active" ||
+            existingSubscription?.status === "trialing"
+          ) {
+            const stripeSubscription = await deps.stripe.subscriptions.retrieve(
+              existingSubscription.stripeSubscriptionId,
+            );
+
+            try {
+              // when /upgrade is called on a subscription scheduled to cancel at the end of the billing period,
+              // it is still "active" but it's not possible to renew it using a billing portal.
+              if (existingSubscription.cancelAt != null) {
+                deps.log.info("un-cancelling subscription", stripeSubscription.id);
+
+                await deps.stripe.subscriptions.update(stripeSubscription.id, {
+                  cancel_at_period_end: false,
+                });
+
+                return json({
+                  url: body.returnUrl || body.successUrl,
+                  redirect: true,
+                });
+              }
+              // Portal session to confirm subscription changes
+              const portalSession = await deps.stripe.billingPortal.sessions.create({
+                customer: customerId,
+                return_url: body.returnUrl || body.successUrl,
+                flow_data: {
+                  type: "subscription_update_confirm",
+                  after_completion: {
+                    type: "redirect",
+                    redirect: {
+                      return_url: body.returnUrl || body.successUrl,
+                    },
+                  },
+                  subscription_update_confirm: {
+                    subscription: existingSubscription.stripeSubscriptionId,
+                    items: [
+                      {
+                        // We always create subscriptions with a single item
+                        id: stripeSubscription.items.data[0]?.id as string,
+                        quantity: body.quantity,
+                        price: body.priceId,
+                      },
+                    ],
+                    ...(promotionCodeId && {
+                      discounts: [{ promotion_code: promotionCodeId }],
+                    }),
+                  },
+                },
+              });
+              return json({
+                url: portalSession.url,
+                redirect: true,
+              });
+            } catch (error: unknown) {
+              throw stripeToApiError(error);
+            }
+          }
+
+          // Step 5: Create a Subscription
+          const checkoutSession = await deps.stripe.checkout.sessions.create({
+            customer: customerId,
+            success_url: body.successUrl,
+            cancel_url: body.cancelUrl,
+            line_items: [
+              {
+                price: body.priceId,
+                quantity: body.quantity,
+              },
+            ],
+            mode: "subscription",
+            metadata: {
+              referenceId: entity.referenceId,
+            },
+            ...(promotionCodeId && {
+              discounts: [{ promotion_code: promotionCodeId }],
+            }),
+          });
+
+          return json({
+            url: checkoutSession.url!,
+            redirect: true,
+            sessionId: checkoutSession.id,
+          });
+        },
       }),
-      errorCodes: [
-        "MISSING_CUSTOMER_INFO",
-        "SUBSCRIPTION_NOT_FOUND",
-        "CUSTOMER_SUBSCRIPTION_MISMATCH",
-        "UPGRADE_HAS_NO_EFFECT",
-        "SUBSCRIPTION_UPDATE_NOT_ALLOWED",
-        "SUBSCRIPTION_UPDATE_PROMO_CODE_NOT_ALLOWED",
-        "PROMOTION_CODE_CUSTOMER_NOT_FIRST_TIME",
-        "MULTIPLE_ACTIVE_SUBSCRIPTIONS",
-        "NO_ACTIVE_SUBSCRIPTIONS",
-      ] as const,
-      handler: async (context, { json, error }) => {
-        const body = await context.input.valid();
-        const entity = await config.resolveEntityFromRequest(context);
+      defineRoute({
+        method: "POST",
+        path: "/subscription/cancel",
+        inputSchema: z.object({
+          returnUrl: z.url().describe("URL to redirect to after cancellation is complete"),
+          subscriptionId: z
+            .string()
+            .optional()
+            .describe("Which subscription to cancel, if there are multiple active subscriptions"),
+        }),
+        outputSchema: z.object({
+          url: z.url().describe("URL to redirect to after cancellation"),
+          redirect: z.boolean().describe("Whether to redirect to the URL"),
+        }),
+        errorCodes: [
+          "SUBSCRIPTION_NOT_FOUND",
+          "NO_SUBSCRIPTION_TO_CANCEL",
+          "SUBSCRIPTION_ALREADY_CANCELED",
+          "NO_STRIPE_CUSTOMER_LINKED",
+          "MULTIPLE_SUBSCRIPTIONS_FOUND",
+        ] as const,
+        handler: async (context, { json, error }) => {
+          const body = await context.input.valid();
+          const { stripeCustomerId } = await config.resolveEntityFromRequest(context);
 
-        let customerId: string | undefined = entity.stripeCustomerId;
-        let existingSubscription: SubscriptionResponse | null = null;
+          if (!stripeCustomerId) {
+            return error(
+              { message: "No stripe customer linked to entity", code: "NO_STRIPE_CUSTOMER_LINKED" },
+              400,
+            );
+          }
 
-        // Step 1: Get active subscriptions
-        if (entity.stripeCustomerId) {
-          const existingSubscriptions = await services.getSubscriptionsByStripeCustomerId(
-            entity.stripeCustomerId,
-          );
+          let activeSubscriptions = (
+            await services.getSubscriptionsByStripeCustomerId(stripeCustomerId)
+          ).filter((s) => s.status === "active");
 
-          // Cannot upgrade cancelled subscriptions
-          let activeSubscriptions = existingSubscriptions.filter((s) => s.status !== "canceled");
-
-          // A specific subscription has been specified
+          // A specific active subscription was requested
           if (body.subscriptionId) {
             activeSubscriptions = activeSubscriptions.filter((s) => s.id === body.subscriptionId);
+          }
+
+          if (activeSubscriptions.length === 0) {
+            return error(
+              { message: "No active subscription to cancel", code: "NO_SUBSCRIPTION_TO_CANCEL" },
+              404,
+            );
           }
 
           if (activeSubscriptions.length > 1) {
             return error(
               {
-                message:
-                  "Multiple active subscriptions found for customer, please specify which subscription to upgrade",
-                code: "MULTIPLE_ACTIVE_SUBSCRIPTIONS",
+                message: "Multiple active subscriptions found",
+                code: "MULTIPLE_SUBSCRIPTIONS_FOUND",
               },
               400,
             );
           }
-          if (activeSubscriptions.length === 0) {
-            return error(
-              {
-                message: "No active subscriptions found for customer",
-                code: "NO_ACTIVE_SUBSCRIPTIONS",
-              },
-              400,
+
+          const activeSubscription = activeSubscriptions[0];
+
+          try {
+            // Get active subscriptions from Stripe for this customer
+            const stripeSubscription = await deps.stripe.subscriptions.retrieve(
+              activeSubscription.stripeSubscriptionId,
             );
-          }
-          existingSubscription = activeSubscriptions[0];
 
-          if (
-            customerId &&
-            existingSubscription.stripeCustomerId &&
-            existingSubscription.stripeCustomerId !== customerId
-          ) {
-            return error(
-              {
-                message:
-                  "Subsciption being updated does not belong to Stripe Customer that was provided",
-                code: "CUSTOMER_SUBSCRIPTION_MISMATCH",
-              },
-              422,
-            );
-          }
-
-          customerId = existingSubscription.stripeCustomerId;
-        }
-
-        // Step 2: Get or Create customer if not found
-        if (!customerId) {
-          const existingLinkedCustomer = await deps.stripe.customers.search({
-            query: `metadata['referenceId']:'${entity.referenceId}'`,
-            limit: 1,
-          });
-
-          if (existingLinkedCustomer.data.length === 1) {
-            // Use existing customer
-            customerId = existingLinkedCustomer.data[0].id;
-          } else {
-            // Create new Stripe Customer
-
-            // Check if sufficient data is provided for this scenario
-            if (!entity.customerEmail || !entity.referenceId) {
-              return error({
-                message:
-                  "New Stripe Customer must be created, but customerEmail or referenceID has not been provided",
-                code: "MISSING_CUSTOMER_INFO",
-              });
+            if (!stripeSubscription) {
+              return error(
+                {
+                  message: "Active subscription not found in Stripe",
+                  code: "SUBSCRIPTION_NOT_FOUND",
+                },
+                404,
+              );
             }
 
-            const newCustomer = await deps.stripe.customers.create({
-              email: entity.customerEmail,
-              metadata: {
-                referenceId: entity.referenceId,
-                ...entity.stripeMetadata,
-              },
-            });
-            customerId = newCustomer.id;
-          }
-
-          // Communicate back to the user that a customer has been created/linked
-          try {
-            await config.onStripeCustomerCreated(customerId, entity.referenceId);
-          } catch (error) {
-            deps.log.error("onStripeCustomerCreated failed!", error);
-          }
-        }
-
-        // Step 3: Resolve promotion code to ID if provided
-        let promotionCodeId: string | undefined = undefined;
-        if (body.promotionCode) {
-          const promotionCodes = await deps.stripe.promotionCodes.list({
-            code: body.promotionCode,
-            active: true,
-            limit: 1,
-          });
-          if (promotionCodes.data.length > 0) {
-            promotionCodeId = promotionCodes.data[0].id;
-          }
-        }
-
-        // Step 4: If existing subscription is active, modify using billing portal
-        if (
-          existingSubscription?.status === "active" ||
-          existingSubscription?.status === "trialing"
-        ) {
-          const stripeSubscription = await deps.stripe.subscriptions.retrieve(
-            existingSubscription.stripeSubscriptionId,
-          );
-
-          try {
-            // when /upgrade is called on a subscription scheduled to cancel at the end of the billing period,
-            // it is still "active" but it's not possible to renew it using a billing portal.
-            if (existingSubscription.cancelAt != null) {
-              deps.log.info("un-cancelling subscription", stripeSubscription.id);
-
-              await deps.stripe.subscriptions.update(stripeSubscription.id, {
-                cancel_at_period_end: false,
-              });
-
+            // Check if subscription is already set to cancel at period end
+            if (stripeSubscription.cancel_at_period_end) {
+              // Already scheduled for cancellation, just return success
               return json({
-                url: body.returnUrl || body.successUrl,
-                redirect: true,
+                url: "", // No redirect needed
+                redirect: false,
               });
             }
-            // Portal session to confirm subscription changes
+
+            // Create billing portal session for cancellation
             const portalSession = await deps.stripe.billingPortal.sessions.create({
-              customer: customerId,
-              return_url: body.returnUrl || body.successUrl,
+              customer: activeSubscription.stripeCustomerId!,
+              return_url: body.returnUrl,
               flow_data: {
-                type: "subscription_update_confirm",
+                type: "subscription_cancel",
+                subscription_cancel: {
+                  subscription: stripeSubscription.id,
+                },
                 after_completion: {
                   type: "redirect",
                   redirect: {
-                    return_url: body.returnUrl || body.successUrl,
+                    return_url: body.returnUrl,
                   },
-                },
-                subscription_update_confirm: {
-                  subscription: existingSubscription.stripeSubscriptionId,
-                  items: [
-                    {
-                      // We always create subscriptions with a single item
-                      id: stripeSubscription.items.data[0]?.id as string,
-                      quantity: body.quantity,
-                      price: body.priceId,
-                    },
-                  ],
-                  ...(promotionCodeId && {
-                    discounts: [{ promotion_code: promotionCodeId }],
-                  }),
                 },
               },
             });
+
             return json({
               url: portalSession.url,
               redirect: true,
             });
-          } catch (error: unknown) {
-            throw stripeToApiError(error);
+          } catch (err: unknown) {
+            throw stripeToApiError(err);
           }
-        }
-
-        // Step 5: Create a Subscription
-        const checkoutSession = await deps.stripe.checkout.sessions.create({
-          customer: customerId,
-          success_url: body.successUrl,
-          cancel_url: body.cancelUrl,
-          line_items: [
-            {
-              price: body.priceId,
-              quantity: body.quantity,
-            },
-          ],
-          mode: "subscription",
-          metadata: {
-            referenceId: entity.referenceId,
-          },
-          ...(promotionCodeId && {
-            discounts: [{ promotion_code: promotionCodeId }],
-          }),
-        });
-
-        return json({
-          url: checkoutSession.url!,
-          redirect: true,
-          sessionId: checkoutSession.id,
-        });
-      },
-    }),
-    defineRoute({
-      method: "POST",
-      path: "/subscription/cancel",
-      inputSchema: z.object({
-        returnUrl: z.url().describe("URL to redirect to after cancellation is complete"),
-        subscriptionId: z
-          .string()
-          .optional()
-          .describe("Which subscription to cancel, if there are multiple active subscriptions"),
+        },
       }),
-      outputSchema: z.object({
-        url: z.url().describe("URL to redirect to after cancellation"),
-        redirect: z.boolean().describe("Whether to redirect to the URL"),
-      }),
-      errorCodes: [
-        "SUBSCRIPTION_NOT_FOUND",
-        "NO_SUBSCRIPTION_TO_CANCEL",
-        "SUBSCRIPTION_ALREADY_CANCELED",
-        "NO_STRIPE_CUSTOMER_LINKED",
-        "MULTIPLE_SUBSCRIPTIONS_FOUND",
-      ] as const,
-      handler: async (context, { json, error }) => {
-        const body = await context.input.valid();
-        const { stripeCustomerId } = await config.resolveEntityFromRequest(context);
-
-        if (!stripeCustomerId) {
-          return error(
-            { message: "No stripe customer linked to entity", code: "NO_STRIPE_CUSTOMER_LINKED" },
-            400,
-          );
-        }
-
-        let activeSubscriptions = (
-          await services.getSubscriptionsByStripeCustomerId(stripeCustomerId)
-        ).filter((s) => s.status === "active");
-
-        // A specific active subscription was requested
-        if (body.subscriptionId) {
-          activeSubscriptions = activeSubscriptions.filter((s) => s.id === body.subscriptionId);
-        }
-
-        if (activeSubscriptions.length === 0) {
-          return error(
-            { message: "No active subscription to cancel", code: "NO_SUBSCRIPTION_TO_CANCEL" },
-            404,
-          );
-        }
-
-        if (activeSubscriptions.length > 1) {
-          return error(
-            {
-              message: "Multiple active subscriptions found",
-              code: "MULTIPLE_SUBSCRIPTIONS_FOUND",
-            },
-            400,
-          );
-        }
-
-        const activeSubscription = activeSubscriptions[0];
-
-        try {
-          // Get active subscriptions from Stripe for this customer
-          const stripeSubscription = await deps.stripe.subscriptions.retrieve(
-            activeSubscription.stripeSubscriptionId,
-          );
-
-          if (!stripeSubscription) {
-            return error(
-              {
-                message: "Active subscription not found in Stripe",
-                code: "SUBSCRIPTION_NOT_FOUND",
-              },
-              404,
-            );
-          }
-
-          // Check if subscription is already set to cancel at period end
-          if (stripeSubscription.cancel_at_period_end) {
-            // Already scheduled for cancellation, just return success
-            return json({
-              url: "", // No redirect needed
-              redirect: false,
-            });
-          }
-
-          // Create billing portal session for cancellation
-          const portalSession = await deps.stripe.billingPortal.sessions.create({
-            customer: activeSubscription.stripeCustomerId!,
-            return_url: body.returnUrl,
-            flow_data: {
-              type: "subscription_cancel",
-              subscription_cancel: {
-                subscription: stripeSubscription.id,
-              },
-              after_completion: {
-                type: "redirect",
-                redirect: {
-                  return_url: body.returnUrl,
-                },
-              },
-            },
-          });
-
-          return json({
-            url: portalSession.url,
-            redirect: true,
-          });
-        } catch (err: unknown) {
-          throw stripeToApiError(err);
-        }
-      },
-    }),
-  ];
-});
+    ];
+  },
+);

--- a/packages/stripe/src/routes/webhooks.ts
+++ b/packages/stripe/src/routes/webhooks.ts
@@ -1,88 +1,86 @@
-import { defineRoute, defineRoutes } from "@fragno-dev/core";
 import { z } from "zod";
 import Stripe from "stripe";
-import type { StripeFragmentConfig, StripeFragmentDeps, StripeFragmentServices } from "../types";
 import { eventToHandler, type SupportedStripeEvent } from "../webhook/handlers";
+import { defineRoutesNew } from "@fragno-dev/core/api/route";
+import { stripeFragmentDefinition } from "../definition";
 
-export const webhookRoutesFactory = defineRoutes<
-  StripeFragmentConfig,
-  StripeFragmentDeps,
-  StripeFragmentServices
->().create(({ config, deps, services }) => {
-  return [
-    defineRoute({
-      method: "POST",
-      path: "/webhook",
-      outputSchema: z.object({
-        success: z.boolean(),
-      }),
-      errorCodes: ["MISSING_SIGNATURE", "WEBHOOK_SIGNATURE_INVALID", "WEBHOOK_ERROR"] as const,
-      handler: async ({ headers, rawBody }, { json, error }) => {
-        // Get the signature
-        const signature = headers.get("stripe-signature");
+export const webhookRoutesFactory = defineRoutesNew(stripeFragmentDefinition).create(
+  ({ config, deps, services, defineRoute }) => {
+    return [
+      defineRoute({
+        method: "POST",
+        path: "/webhook",
+        outputSchema: z.object({
+          success: z.boolean(),
+        }),
+        errorCodes: ["MISSING_SIGNATURE", "WEBHOOK_SIGNATURE_INVALID", "WEBHOOK_ERROR"] as const,
+        handler: async ({ headers, rawBody }, { json, error }) => {
+          // Get the signature
+          const signature = headers.get("stripe-signature");
 
-        if (!signature) {
-          return error(
-            { message: "Missing stripe-signature header", code: "MISSING_SIGNATURE" },
-            400,
-          );
-        }
-
-        if (!rawBody) {
-          return error(
-            { message: "Missing request body for webhook verification", code: "WEBHOOK_ERROR" },
-            400,
-          );
-        }
-
-        // Verify the webhook signature
-        let event: Stripe.Event;
-        try {
-          // Support both Stripe v18 (constructEvent) and v19+ (constructEventAsync)
-          if (typeof deps.stripe.webhooks.constructEventAsync === "function") {
-            // Stripe v19+ - use async method
-            event = await deps.stripe.webhooks.constructEventAsync(
-              rawBody,
-              signature,
-              config.webhookSecret,
-            );
-          } else {
-            // Stripe v18 - use sync method
-            event = deps.stripe.webhooks.constructEvent(rawBody, signature, config.webhookSecret);
-          }
-        } catch (err) {
-          if (err instanceof Stripe.errors.StripeSignatureVerificationError) {
+          if (!signature) {
             return error(
-              {
-                message: `Webhook signature verification failed`,
-                code: "WEBHOOK_SIGNATURE_INVALID",
-              },
+              { message: "Missing stripe-signature header", code: "MISSING_SIGNATURE" },
               400,
             );
           }
-          throw err;
-        }
 
-        if (!event) {
-          return error({ message: "Failed to construct event", code: "WEBHOOK_ERROR" }, 400);
-        }
+          if (!rawBody) {
+            return error(
+              { message: "Missing request body for webhook verification", code: "WEBHOOK_ERROR" },
+              400,
+            );
+          }
 
-        if (config.onEvent) {
-          deps.log.info("Running user callback event");
-          await config.onEvent({ event, stripeClient: deps.stripe });
-        }
+          // Verify the webhook signature
+          let event: Stripe.Event;
+          try {
+            // Support both Stripe v18 (constructEvent) and v19+ (constructEventAsync)
+            if (typeof deps.stripe.webhooks.constructEventAsync === "function") {
+              // Stripe v19+ - use async method
+              event = await deps.stripe.webhooks.constructEventAsync(
+                rawBody,
+                signature,
+                config.webhookSecret,
+              );
+            } else {
+              // Stripe v18 - use sync method
+              event = deps.stripe.webhooks.constructEvent(rawBody, signature, config.webhookSecret);
+            }
+          } catch (err) {
+            if (err instanceof Stripe.errors.StripeSignatureVerificationError) {
+              return error(
+                {
+                  message: `Webhook signature verification failed`,
+                  code: "WEBHOOK_SIGNATURE_INVALID",
+                },
+                400,
+              );
+            }
+            throw err;
+          }
 
-        const eventHandler = eventToHandler[event.type as SupportedStripeEvent];
-        if (!eventHandler) {
-          deps.log.info(`Webhook event ${event.type}: ${event.id} ignored`);
+          if (!event) {
+            return error({ message: "Failed to construct event", code: "WEBHOOK_ERROR" }, 400);
+          }
+
+          if (config.onEvent) {
+            deps.log.info("Running user callback event");
+            await config.onEvent({ event, stripeClient: deps.stripe });
+          }
+
+          const eventHandler = eventToHandler[event.type as SupportedStripeEvent];
+          if (!eventHandler) {
+            deps.log.info(`Webhook event ${event.type}: ${event.id} ignored`);
+            return json({ success: true });
+          }
+
+          deps.log.info(`Executing event handler for ${event.type}: ${event.id}`);
+          await eventHandler({ event, services, deps, config });
+
           return json({ success: true });
-        }
-
-        deps.log.info(`Executing event handler for ${event.type}: ${event.id}`);
-        await eventHandler({ event, services, deps, config });
-
-        return json({ success: true });
-      },
-    }),
-  ];
-});
+        },
+      }),
+    ];
+  },
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates Stripe fragment to the new definition/instantiation, routing, and client builder APIs, extracting services to `definition.ts` and updating routes and tests accordingly.
> 
> - **Core/Structure**:
>   - Extracts `stripeFragmentDefinition` and services into `packages/stripe/src/definition.ts` using `defineFragment` + `withDatabase`.
>   - Replaces legacy fragment creation with `instantiate(...)` and updates client creation to `createClientBuilderNew`.
>   - Centralizes route list and re-exports types/definition from `index.ts`.
> - **Routes**:
>   - Migrates route factories (`customers`, `prices`, `products`, `subscriptions`, `webhooks`) to `defineRoutesNew(stripeFragmentDefinition)` while preserving handlers and schemas.
> - **Tests**:
>   - Updates tests to `buildDatabaseFragmentsTest()` and `instantiate(stripeFragmentDefinition)`; adjusts imports/mocks accordingly.
> - **Behavior**:
>   - Subscription service methods and webhook handling preserved; no functional changes intended beyond new APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b16a04ff71aab4895badbe7d54c31513a56d85fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->