### PR TITLE
fix(core): add `workerd` to export field in package.json

### DIFF
--- a/.changeset/flat-mugs-mix.md
+++ b/.changeset/flat-mugs-mix.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/core": patch
+---
+
+fix: set `workerd` package exports so Cloudflare Workers import the server bundle while server-side
+rendering instead of the browser bundle.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,8 +8,8 @@
     "dev": "react-router dev",
     "postinstall": "fumadocs-mdx",
     "preview": "pnpm run build && vite preview",
-    "types:check": "pnpm run types:generate && fumadocs-mdx && tsc --noEmit",
-    "types:generate": "wrangler types --env-interface CloudflareEnv && react-router typegen && prettier --write ./worker-configuration.d.ts",
+    "types:check": "tsc --noEmit",
+    "types:generate": "wrangler types --env-interface CloudflareEnv && react-router typegen && fumadocs-mdx",
     "db:fragno:generate": "fragno-cli db generate app/fragno/mailing-list.ts -o app/db/mailing-list-do.schema.ts",
     "db:mailing-list-do:generate": "drizzle-kit generate --config mailing-list-do.drizzle.config.ts"
   },

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -6,6 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import mdx from "fumadocs-mdx/vite";
 import devtoolsJson from "vite-plugin-devtools-json";
 import * as MdxConfig from "./source.config";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Plugin } from "vite";
 
 export default defineConfig(() => {
   return {
@@ -24,3 +27,40 @@ export default defineConfig(() => {
     },
   };
 });
+
+// oxlint-disable-next-line no-unused-vars
+function environmentInfoPlugin(): Plugin {
+  return {
+    name: "environment-info",
+    configResolved(config) {
+      const envInfo: Record<string, unknown> = {
+        root: config.root,
+        mode: config.mode,
+        command: config.command,
+        environments: {},
+      };
+
+      // Collect environment information
+      for (const [name, env] of Object.entries(config.environments)) {
+        (envInfo.environments as Record<string, unknown>)[name] = {
+          resolve: {
+            conditions: env.resolve.conditions,
+            externalConditions: env.resolve.externalConditions,
+            mainFields: env.resolve.mainFields,
+          },
+          build: {
+            outDir: env.build.outDir,
+            sourcemap: env.build.sourcemap,
+            minify: env.build.minify,
+            target: env.build.target,
+          },
+          consumer: env.consumer,
+        };
+      }
+
+      const outputPath = join(config.root, "vite-environments.json");
+      writeFileSync(outputPath, JSON.stringify(envInfo, null, 2), "utf-8");
+      console.log(`\nEnvironment info written to: ${outputPath}\n`);
+    },
+  };
+}

--- a/packages/fragno/package.json
+++ b/packages/fragno/package.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": {
       "development": "./src/mod.ts",
+      "workerd": "./dist/mod.js",
       "browser": "./dist/mod-client.js",
       "types": "./dist/mod.d.ts",
       "default": "./dist/mod.js"

--- a/packages/fragno/src/api/fragment-instantiator.ts
+++ b/packages/fragno/src/api/fragment-instantiator.ts
@@ -122,7 +122,8 @@ export class FragnoInstantiatedFragment<
   TRequestStorage = {},
   TOptions extends FragnoPublicConfig = FragnoPublicConfig,
   TLinkedFragments extends Record<string, AnyFragnoInstantiatedFragment> = {},
-> {
+> implements IFragnoInstantiatedFragment
+{
   readonly [instantiatedFragmentFakeSymbol] = instantiatedFragmentFakeSymbol;
 
   // Private fields
@@ -896,6 +897,101 @@ export function instantiateFragment<
 }
 
 /**
+ * Interface that defines the public API for a fragment instantiation builder.
+ * Used to ensure consistency between real implementations and stubs.
+ */
+interface IFragmentInstantiationBuilder {
+  /**
+   * Get the fragment definition
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get definition(): any;
+
+  /**
+   * Get the configured routes
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get routes(): any;
+
+  /**
+   * Get the configuration
+   */
+  get config(): unknown;
+
+  /**
+   * Get the options
+   */
+  get options(): unknown;
+
+  /**
+   * Set the configuration for the fragment
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withConfig(config: any): unknown;
+
+  /**
+   * Set the routes for the fragment
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withRoutes(routes: any): unknown;
+
+  /**
+   * Set the options for the fragment (e.g., mountRoute, databaseAdapter)
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withOptions(options: any): unknown;
+
+  /**
+   * Provide implementations for services that this fragment uses
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withServices(services: any): unknown;
+
+  /**
+   * Build and return the instantiated fragment
+   */
+  build(): IFragnoInstantiatedFragment;
+}
+
+/**
+ * Interface that defines the public API for an instantiated fragment.
+ * Used to ensure consistency between real implementations and stubs.
+ */
+interface IFragnoInstantiatedFragment {
+  readonly [instantiatedFragmentFakeSymbol]: typeof instantiatedFragmentFakeSymbol;
+
+  get name(): string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get routes(): any;
+  get services(): Record<string, unknown>;
+  get mountRoute(): string;
+  get $internal(): {
+    deps: unknown;
+    options: unknown;
+    linkedFragments: unknown;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withMiddleware(handler: any): this;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inContext<T>(callback: any): T;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inContext<T>(callback: any): Promise<T>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handlersFor(framework: FullstackFrameworks): any;
+
+  handler(req: Request): Promise<Response>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  callRoute(method: HTTPMethod, path: string, inputOptions?: any): Promise<any>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  callRouteRaw(method: HTTPMethod, path: string, inputOptions?: any): Promise<Response>;
+}
+
+/**
  * Fluent builder for instantiating fragments.
  * Provides a type-safe API for configuring and building fragment instances.
  */
@@ -912,7 +1008,8 @@ export class FragmentInstantiationBuilder<
   TRequestStorage,
   TRoutesOrFactories extends readonly AnyRouteOrFactory[],
   TLinkedFragments extends Record<string, AnyFragnoInstantiatedFragment>,
-> {
+> implements IFragmentInstantiationBuilder
+{
   #definition: FragmentDefinition<
     TConfig,
     TOptions,
@@ -1123,3 +1220,6 @@ export function instantiate<
 > {
   return new FragmentInstantiationBuilder(definition);
 }
+
+// Export interfaces for stub implementations
+export type { IFragmentInstantiationBuilder, IFragnoInstantiatedFragment };

--- a/packages/fragno/src/mod-client.ts
+++ b/packages/fragno/src/mod-client.ts
@@ -21,9 +21,19 @@ export type {
   BoundServices,
 } from "./api/fragment-instantiator";
 
+import type {
+  IFragmentInstantiationBuilder,
+  IFragnoInstantiatedFragment,
+} from "./api/fragment-instantiator";
+import { instantiatedFragmentFakeSymbol } from "./internal/symbols";
+
 // Stub implementation for defineFragment
 // This is stripped by unplugin-fragno in browser builds
 export function defineFragment(_name: string) {
+  const definitionStub = {
+    name: _name,
+  };
+
   const stub = {
     withDependencies: () => stub,
     providesBaseService: () => stub,
@@ -36,7 +46,7 @@ export function defineFragment(_name: string) {
     withThisContext: () => stub,
     withLinkedFragment: () => stub,
     extend: () => stub,
-    build: () => ({}),
+    build: () => definitionStub,
   };
   return stub;
 }
@@ -47,18 +57,41 @@ export { FragmentDefinitionBuilder } from "./api/fragment-definition-builder";
 // Stub implementation for instantiate
 // This is stripped by unplugin-fragno in browser builds
 export function instantiate(_definition: unknown) {
-  const stub = {
-    withConfig: () => stub,
-    withRoutes: () => stub,
-    withOptions: () => stub,
-    withServices: () => stub,
-    build: () => ({}),
+  const fragmentStub: IFragnoInstantiatedFragment = {
+    [instantiatedFragmentFakeSymbol]: instantiatedFragmentFakeSymbol,
+    name: "",
+    routes: [],
+    services: {},
+    mountRoute: "",
+    $internal: {
+      deps: {},
+      options: {},
+      linkedFragments: {},
+    },
+    withMiddleware: () => {
+      // throw new Error("withMiddleware is not supported in browser builds");
+      return fragmentStub;
+    },
+    inContext: <T>(callback: () => T) => callback(),
+    handlersFor: () => ({}),
+    handler: async () => new Response(),
+    callRoute: async () => ({ ok: true, data: undefined, error: undefined }),
+    callRouteRaw: async () => new Response(),
+  };
+
+  const builderStub: IFragmentInstantiationBuilder = {
+    withConfig: () => builderStub,
+    withRoutes: () => builderStub,
+    withOptions: () => builderStub,
+    withServices: () => builderStub,
+    build: () => fragmentStub,
     definition: {},
     routes: [],
     config: undefined,
     options: undefined,
   };
-  return stub;
+
+  return builderStub;
 }
 
 // ============================================================================


### PR DESCRIPTION
This fixes an issue where Cloudflare Workers would wrongfully load the browser bundle instead of the server bundle when server- side rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Workerd export mapping for improved Cloudflare Workers support.
  * Introduced public API interfaces for fragment instantiation and builders with enhanced type safety.

* **Bug Fixes**
  * Fixed Cloudflare Workers to import the server bundle during server-side rendering instead of the browser bundle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->