### PR TITLE
feat(db): add durable hooks system for database fragments

### DIFF
--- a/.changeset/durable-hooks.md
+++ b/.changeset/durable-hooks.md
@@ -1,0 +1,7 @@
+---
+"@fragno-dev/db": minor
+---
+
+Add durable hooks system for database fragments. Hooks are automatically persisted and retried on
+failure, allowing fragment authors to define side effects that execute after successful transaction
+commits.

--- a/packages/fragno-db/src/adapters/drizzle/drizzle-adapter-pglite.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/drizzle-adapter-pglite.test.ts
@@ -6,7 +6,7 @@ import { column, idColumn, referenceColumn, schema } from "../../schema/create";
 import { Cursor } from "../../query/cursor";
 import { PGLiteDriverConfig } from "../generic-sql/driver-config";
 import type { CompiledQuery } from "../../sql-driver/sql-driver";
-import { settingsSchema } from "../../fragments/internal-fragment";
+import { internalSchema } from "../../fragments/internal-fragment";
 
 describe("DrizzleAdapter PGLite", () => {
   let pgliteDatabase: PGlite;
@@ -105,7 +105,7 @@ describe("DrizzleAdapter PGLite", () => {
 
     // Create settings table first (needed for version tracking)
     {
-      const migrations = adapter.prepareMigrations(settingsSchema, "");
+      const migrations = adapter.prepareMigrations(internalSchema, "");
       await migrations.executeWithDriver(adapter.driver, 0);
     }
 

--- a/packages/fragno-db/src/adapters/drizzle/drizzle-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/drizzle-adapter-sqlite3.test.ts
@@ -7,7 +7,7 @@ import { Cursor } from "../../query/cursor";
 import { executeUnitOfWork } from "../../query/unit-of-work/execute-unit-of-work";
 import { ExponentialBackoffRetryPolicy } from "../../query/unit-of-work/retry-policy";
 import { BetterSQLite3DriverConfig } from "../generic-sql/driver-config";
-import { settingsSchema } from "../../fragments/internal-fragment";
+import { internalSchema } from "../../fragments/internal-fragment";
 
 describe("DrizzleAdapter SQLite", () => {
   const testSchema = schema((s) => {
@@ -108,7 +108,7 @@ describe("DrizzleAdapter SQLite", () => {
 
     // Create settings table first (needed for version tracking)
     {
-      const migrations = adapter.prepareMigrations(settingsSchema, "");
+      const migrations = adapter.prepareMigrations(internalSchema, "");
       await migrations.executeWithDriver(adapter.driver, 0);
     }
 

--- a/packages/fragno-db/src/adapters/drizzle/generate.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/generate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { column, idColumn, referenceColumn, schema } from "../../schema/create";
 import { generateSchema } from "./generate";
-import { settingsSchema } from "../../fragments/internal-fragment";
+import { internalSchema } from "../../fragments/internal-fragment";
 
 describe("generateSchema", () => {
   const testSchema = schema((s) => {
@@ -1072,7 +1072,7 @@ describe("generateSchema", () => {
       // This test verifies generateSchema works correctly with already-deduplicated inputs
       const generated = generateSchema(
         [
-          { namespace: "", schema: settingsSchema }, // Internal fragment (namespace: "")
+          { namespace: "", schema: internalSchema }, // Internal fragment (namespace: "")
           { namespace: "fragment1", schema: fragment1Schema },
           { namespace: "fragment2", schema: fragment2Schema },
         ],

--- a/packages/fragno-db/src/adapters/drizzle/migrate-drizzle.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/migrate-drizzle.test.ts
@@ -158,6 +158,23 @@ describe("generateSchema and migrate", () => {
       	"_version" integer DEFAULT 0 NOT NULL
       );
 
+      CREATE TABLE "fragno_hooks" (
+      	"id" varchar(30) NOT NULL,
+      	"namespace" text NOT NULL,
+      	"hookName" text NOT NULL,
+      	"payload" json NOT NULL,
+      	"status" text NOT NULL,
+      	"attempts" integer DEFAULT 0 NOT NULL,
+      	"maxAttempts" integer DEFAULT 5 NOT NULL,
+      	"lastAttemptAt" timestamp,
+      	"nextRetryAt" timestamp,
+      	"error" text,
+      	"createdAt" timestamp DEFAULT now() NOT NULL,
+      	"nonce" text NOT NULL,
+      	"_internalId" bigserial PRIMARY KEY NOT NULL,
+      	"_version" integer DEFAULT 0 NOT NULL
+      );
+
       CREATE TABLE "users" (
       	"id" varchar(30) NOT NULL,
       	"name" text NOT NULL,
@@ -231,6 +248,8 @@ describe("generateSchema and migrate", () => {
       ALTER TABLE "postTags" ADD CONSTRAINT "postTags_posts_post_fk" FOREIGN KEY ("postId") REFERENCES "public"."posts"("_internalId") ON DELETE no action ON UPDATE no action;
       ALTER TABLE "postTags" ADD CONSTRAINT "postTags_tags_tag_fk" FOREIGN KEY ("tagId") REFERENCES "public"."tags"("_internalId") ON DELETE no action ON UPDATE no action;
       CREATE UNIQUE INDEX "unique_key" ON "fragno_db_settings" USING btree ("key");
+      CREATE INDEX "idx_namespace_status_retry" ON "fragno_hooks" USING btree ("namespace","status","nextRetryAt");
+      CREATE INDEX "idx_nonce" ON "fragno_hooks" USING btree ("nonce");
       CREATE UNIQUE INDEX "idx_users_email" ON "users" USING btree ("email");
       CREATE INDEX "idx_users_name" ON "users" USING btree ("name");
       CREATE INDEX "idx_users_active" ON "users" USING btree ("isActive");

--- a/packages/fragno-db/src/adapters/drizzle/test-utils.ts
+++ b/packages/fragno-db/src/adapters/drizzle/test-utils.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile, rm, access } from "node:fs/promises";
 import { join } from "node:path";
 import { generateSchema, type SupportedProvider } from "./generate";
 import type { Schema } from "../../schema/create";
-import { settingsSchema } from "../../fragments/internal-fragment";
+import { internalSchema } from "../../fragments/internal-fragment";
 
 /**
  * Writes a Fragno schema to a temporary TypeScript file and dynamically imports it.
@@ -42,10 +42,10 @@ export async function writeAndLoadSchema(
   // Always include settings schema first (as done in generation-engine.ts), then the test schema
   // De-duplicate: if the test schema IS the settings schema, don't add it twice
   const fragments: Array<{ namespace: string; schema: Schema }> = [
-    { namespace: "", schema: settingsSchema },
+    { namespace: "", schema: internalSchema },
   ];
 
-  if (schema !== settingsSchema) {
+  if (schema !== internalSchema) {
     fragments.push({ namespace: namespace ?? "", schema });
   }
 

--- a/packages/fragno-db/src/adapters/generic-sql/generic-sql-adapter.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/generic-sql-adapter.test.ts
@@ -3,7 +3,7 @@ import { assert, describe, expect, it } from "vitest";
 import { SQLocalDriverConfig } from "./driver-config";
 import { GenericSQLAdapter } from "./generic-sql-adapter";
 import { column, idColumn, schema } from "../../schema/create";
-import { settingsSchema } from "../../fragments/internal-fragment";
+import { internalSchema } from "../../fragments/internal-fragment";
 
 describe("GenericSQLAdapter", () => {
   const testSchema = schema((s) => {
@@ -23,7 +23,7 @@ describe("GenericSQLAdapter", () => {
     const adapter = new GenericSQLAdapter({ dialect, driverConfig });
 
     // Create settings table first (needed for version tracking)
-    const settingsMigrations = adapter.prepareMigrations(settingsSchema, "");
+    const settingsMigrations = adapter.prepareMigrations(internalSchema, "");
     await settingsMigrations.executeWithDriver(adapter.driver, 0);
 
     // Now run the actual test schema migrations (use a different namespace)

--- a/packages/fragno-db/src/adapters/generic-sql/test/generic-drizzle-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/test/generic-drizzle-adapter-sqlite3.test.ts
@@ -11,7 +11,7 @@ import { SqliteDialect } from "kysely";
 import { SqlDriverAdapter } from "../../../sql-driver/sql-driver-adapter";
 import { BetterSQLite3DriverConfig } from "../driver-config";
 import { GenericSQLAdapter } from "../generic-sql-adapter";
-import { settingsSchema } from "../../../fragments/internal-fragment";
+import { internalSchema } from "../../../fragments/internal-fragment";
 
 describe("GenericSQLAdapter with DrizzleAdapter better-sqlite3", () => {
   const testSchema = schema((s) => {
@@ -107,7 +107,7 @@ describe("GenericSQLAdapter with DrizzleAdapter better-sqlite3", () => {
     const genericAdapter = new GenericSQLAdapter({ dialect, driverConfig });
 
     {
-      const migrations = genericAdapter.prepareMigrations(settingsSchema, "");
+      const migrations = genericAdapter.prepareMigrations(internalSchema, "");
       await migrations.executeWithDriver(sqlAdapter, 0);
     }
 

--- a/packages/fragno-db/src/adapters/kysely/kysely-adapter-pglite.test.ts
+++ b/packages/fragno-db/src/adapters/kysely/kysely-adapter-pglite.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../schema/create";
 import { Cursor } from "../../query/cursor";
 import { PGLiteDriverConfig } from "../generic-sql/driver-config";
-import { settingsSchema } from "../../fragments/internal-fragment";
+import { internalSchema } from "../../fragments/internal-fragment";
 
 describe("KyselyAdapter PGLite", () => {
   const testSchema = schema((s) => {
@@ -112,7 +112,7 @@ describe("KyselyAdapter PGLite", () => {
     expect(schemaVersion).toBeUndefined();
 
     {
-      const migrations = adapter.prepareMigrations(settingsSchema, "");
+      const migrations = adapter.prepareMigrations(internalSchema, "");
       await migrations.executeWithDriver(adapter.driver, 0);
     }
 

--- a/packages/fragno-db/src/fragments/internal-fragment.test.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.test.ts
@@ -2,10 +2,12 @@ import SQLite from "better-sqlite3";
 import { SqliteDialect } from "kysely";
 import { beforeAll, describe, expect, it } from "vitest";
 import { instantiate } from "@fragno-dev/core";
-import { internalFragmentDef, settingsSchema, SETTINGS_NAMESPACE } from "./internal-fragment";
+import { internalFragmentDef, internalSchema, SETTINGS_NAMESPACE } from "./internal-fragment";
 import type { FragnoPublicConfigWithDatabase } from "../db-fragment-definition-builder";
 import { DrizzleAdapter } from "../adapters/drizzle/drizzle-adapter";
 import { BetterSQLite3DriverConfig } from "../adapters/generic-sql/driver-config";
+import { ExponentialBackoffRetryPolicy, NoRetryPolicy } from "../query/unit-of-work/retry-policy";
+import type { FragnoId } from "../schema/create";
 
 describe("Internal Fragment", () => {
   let sqliteDatabase: SQLite.Database;
@@ -29,7 +31,7 @@ describe("Internal Fragment", () => {
     });
 
     {
-      const migrations = adapter.prepareMigrations(settingsSchema, "");
+      const migrations = adapter.prepareMigrations(internalSchema, "");
       await migrations.executeWithDriver(adapter.driver, 0);
     }
 
@@ -142,5 +144,406 @@ describe("Internal Fragment", () => {
     });
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe("Hook Service", () => {
+  let sqliteDatabase: SQLite.Database;
+  let adapter: DrizzleAdapter;
+  let fragment: ReturnType<typeof instantiateFragment>;
+
+  function instantiateFragment(options: FragnoPublicConfigWithDatabase) {
+    return instantiate(internalFragmentDef).withConfig({}).withOptions(options).build();
+  }
+
+  beforeAll(async () => {
+    sqliteDatabase = new SQLite(":memory:");
+
+    const dialect = new SqliteDialect({
+      database: sqliteDatabase,
+    });
+
+    adapter = new DrizzleAdapter({
+      dialect,
+      driverConfig: new BetterSQLite3DriverConfig(),
+    });
+
+    {
+      const migrations = adapter.prepareMigrations(internalSchema, "");
+      await migrations.executeWithDriver(adapter.driver, 0);
+    }
+
+    const options: FragnoPublicConfigWithDatabase = {
+      databaseAdapter: adapter,
+    };
+
+    fragment = instantiateFragment(options);
+
+    return async () => {
+      await adapter.close();
+    };
+  }, 12000);
+
+  it("should create a hook event and retrieve it by namespace", async () => {
+    const nonce = "test-nonce-1";
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeMutate }) => {
+        const uow = forSchema(internalSchema);
+        uow.create("fragno_hooks", {
+          namespace: "test-namespace",
+          hookName: "onTest",
+          payload: { test: "data" },
+          status: "pending",
+          attempts: 0,
+          maxAttempts: 5,
+          lastAttemptAt: null,
+          nextRetryAt: null,
+          error: null,
+          nonce,
+        });
+        uow.create("fragno_hooks", {
+          namespace: "test-namespace",
+          hookName: "onTest",
+          payload: { test: "already-completed-data" },
+          status: "completed",
+          attempts: 0,
+          maxAttempts: 5,
+          lastAttemptAt: null,
+          nextRetryAt: null,
+          error: null,
+          nonce,
+        });
+        await executeMutate();
+      });
+    });
+
+    const events = await fragment.inContext(async function () {
+      return await this.uow(async ({ executeRetrieve }) => {
+        const eventsPromise = fragment.services.hookService.getPendingHookEvents("test-namespace");
+        await executeRetrieve();
+        return await eventsPromise;
+      });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      hookName: "onTest",
+      payload: { test: "data" },
+      attempts: 0,
+      maxAttempts: 5,
+      nonce,
+    });
+  });
+
+  it("should mark a hook event as completed", async () => {
+    const nonce = "test-nonce-2";
+    let eventId: FragnoId;
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeMutate }) => {
+        const uow = forSchema(internalSchema);
+        eventId = uow.create("fragno_hooks", {
+          namespace: "test-namespace",
+          hookName: "onComplete",
+          payload: { test: "data" },
+          status: "pending",
+          attempts: 0,
+          maxAttempts: 5,
+          lastAttemptAt: null,
+          nextRetryAt: null,
+          error: null,
+          nonce,
+        });
+        await executeMutate();
+      });
+    });
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ executeMutate }) => {
+        fragment.services.hookService.markHookCompleted(eventId);
+        await executeMutate();
+      });
+    });
+
+    const result = await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeRetrieve }) => {
+        const uow = forSchema(internalSchema);
+        const findUow = uow.find("fragno_hooks", (b) =>
+          b.whereIndex("primary", (eb) => eb("id", "=", eventId)),
+        );
+        await executeRetrieve();
+        const [events] = await findUow.retrievalPhase;
+        return events?.[0];
+      });
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("completed");
+    expect(result?.lastAttemptAt).toBeInstanceOf(Date);
+  });
+
+  it("should mark a hook event as processing", async () => {
+    const nonce = "test-nonce-3";
+    let eventId: FragnoId;
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeMutate }) => {
+        const uow = forSchema(internalSchema);
+        eventId = uow.create("fragno_hooks", {
+          namespace: "test-namespace",
+          hookName: "onProcess",
+          payload: { test: "data" },
+          status: "pending",
+          attempts: 0,
+          maxAttempts: 5,
+          lastAttemptAt: null,
+          nextRetryAt: null,
+          error: null,
+          nonce,
+        });
+        await executeMutate();
+      });
+    });
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ executeMutate }) => {
+        fragment.services.hookService.markHookProcessing(eventId);
+        await executeMutate();
+      });
+    });
+
+    const result = await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeRetrieve }) => {
+        const uow = forSchema(internalSchema);
+        const findUow = uow.find("fragno_hooks", (b) =>
+          b.whereIndex("primary", (eb) => eb("id", "=", eventId)),
+        );
+        await executeRetrieve();
+        const [events] = await findUow.retrievalPhase;
+        return events?.[0];
+      });
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("processing");
+    expect(result?.lastAttemptAt).toBeInstanceOf(Date);
+  });
+
+  it("should mark a hook event as failed with retry scheduled", async () => {
+    const nonce = "test-nonce-4";
+    let eventId: FragnoId;
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeMutate }) => {
+        const uow = forSchema(internalSchema);
+        eventId = uow.create("fragno_hooks", {
+          namespace: "test-namespace",
+          hookName: "onFail",
+          payload: { test: "data" },
+          status: "pending",
+          attempts: 0,
+          maxAttempts: 5,
+          lastAttemptAt: null,
+          nextRetryAt: null,
+          error: null,
+          nonce,
+        });
+        await executeMutate();
+      });
+    });
+
+    const retryPolicy = new ExponentialBackoffRetryPolicy({ maxRetries: 3 });
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ executeMutate }) => {
+        fragment.services.hookService.markHookFailed(eventId, "Test error", 0, retryPolicy);
+        await executeMutate();
+      });
+    });
+
+    const result = await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeRetrieve }) => {
+        const uow = forSchema(internalSchema);
+        const findUow = uow.find("fragno_hooks", (b) =>
+          b.whereIndex("primary", (eb) => eb("id", "=", eventId)),
+        );
+        await executeRetrieve();
+        const [events] = await findUow.retrievalPhase;
+        return events?.[0];
+      });
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("pending");
+    expect(result?.attempts).toBe(1);
+    expect(result?.error).toBe("Test error");
+    expect(result?.nextRetryAt).toBeInstanceOf(Date);
+    expect(result?.lastAttemptAt).toBeInstanceOf(Date);
+  });
+
+  it("should mark a hook event as permanently failed when max attempts reached", async () => {
+    const nonce = "test-nonce-5";
+    let eventId: FragnoId;
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeMutate }) => {
+        const uow = forSchema(internalSchema);
+        eventId = uow.create("fragno_hooks", {
+          namespace: "test-namespace",
+          hookName: "onMaxFail",
+          payload: { test: "data" },
+          status: "pending",
+          attempts: 0,
+          maxAttempts: 1,
+          lastAttemptAt: null,
+          nextRetryAt: null,
+          error: null,
+          nonce,
+        });
+        await executeMutate();
+      });
+    });
+
+    const retryPolicy = new NoRetryPolicy();
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ executeMutate }) => {
+        fragment.services.hookService.markHookFailed(
+          eventId,
+          "Max attempts reached",
+          0,
+          retryPolicy,
+        );
+        await executeMutate();
+      });
+    });
+
+    const result = await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeRetrieve }) => {
+        const uow = forSchema(internalSchema);
+        const findUow = uow.find("fragno_hooks", (b) =>
+          b.whereIndex("primary", (eb) => eb("id", "=", eventId)),
+        );
+        await executeRetrieve();
+        const [events] = await findUow.retrievalPhase;
+        return events?.[0];
+      });
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("failed");
+    expect(result?.attempts).toBe(1);
+    expect(result?.error).toBe("Max attempts reached");
+  });
+
+  it("should retrieve stale events ready for retry", async () => {
+    const nonce = "test-nonce-6";
+    let eventId: FragnoId;
+
+    const pastTime = new Date(Date.now() - 10000);
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeMutate }) => {
+        const uow = forSchema(internalSchema);
+        eventId = uow.create("fragno_hooks", {
+          namespace: "test-namespace",
+          hookName: "onStale",
+          payload: { test: "stale" },
+          status: "pending",
+          attempts: 1,
+          maxAttempts: 5,
+          lastAttemptAt: pastTime,
+          nextRetryAt: pastTime,
+          error: "Previous error",
+          nonce,
+        });
+        await executeMutate();
+      });
+    });
+
+    const events = await fragment.inContext(async function () {
+      return await this.uow(async ({ executeRetrieve }) => {
+        const eventsPromise = fragment.services.hookService.getPendingHookEvents("test-namespace");
+        await executeRetrieve();
+        return await eventsPromise;
+      });
+    });
+
+    const staleEvent = events.find((e) => e.id.externalId === eventId.externalId);
+    expect(staleEvent).toBeDefined();
+    expect(staleEvent?.hookName).toBe("onStale");
+    expect(staleEvent?.attempts).toBe(1);
+  });
+
+  it("should not retrieve events from different namespace", async () => {
+    const nonce = "test-nonce-7";
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeMutate }) => {
+        const uow = forSchema(internalSchema);
+        uow.create("fragno_hooks", {
+          namespace: "other-namespace",
+          hookName: "onOther",
+          payload: { test: "other" },
+          status: "pending",
+          attempts: 0,
+          maxAttempts: 5,
+          lastAttemptAt: null,
+          nextRetryAt: null,
+          error: null,
+          nonce,
+        });
+        await executeMutate();
+      });
+    });
+
+    const events = await fragment.inContext(async function () {
+      return await this.uow(async ({ executeRetrieve }) => {
+        const eventsPromise = fragment.services.hookService.getPendingHookEvents("test-namespace");
+        await executeRetrieve();
+        return await eventsPromise;
+      });
+    });
+
+    const otherEvent = events.find((e) => e.hookName === "onOther");
+    expect(otherEvent).toBeUndefined();
+  });
+
+  it("should not retrieve events not yet ready for retry", async () => {
+    const nonce = "test-nonce-8";
+    let eventId: FragnoId;
+
+    const futureTime = new Date(Date.now() + 60000);
+
+    await fragment.inContext(async function () {
+      return await this.uow(async ({ forSchema, executeMutate }) => {
+        const uow = forSchema(internalSchema);
+        eventId = uow.create("fragno_hooks", {
+          namespace: "test-namespace",
+          hookName: "onFuture",
+          payload: { test: "future" },
+          status: "pending",
+          attempts: 1,
+          maxAttempts: 5,
+          lastAttemptAt: new Date(),
+          nextRetryAt: futureTime,
+          error: "Previous error",
+          nonce,
+        });
+        await executeMutate();
+      });
+    });
+
+    const events = await fragment.inContext(async function () {
+      return await this.uow(async ({ executeRetrieve }) => {
+        const eventsPromise = fragment.services.hookService.getPendingHookEvents("test-namespace");
+        await executeRetrieve();
+        return await eventsPromise;
+      });
+    });
+
+    const futureEvent = events.find((e) => e.id.externalId === eventId.externalId);
+    expect(futureEvent).toBeUndefined();
   });
 });

--- a/packages/fragno-db/src/fragments/internal-fragment.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.ts
@@ -10,21 +10,42 @@ import {
 } from "../db-fragment-definition-builder";
 import type { FragnoId } from "../schema/create";
 import { schema, idColumn, column } from "../schema/create";
+import type { RetryPolicy } from "../query/unit-of-work/retry-policy";
 
 // Constants for Fragno's internal settings table
 export const SETTINGS_TABLE_NAME = "fragno_db_settings" as const;
 // FIXME: In some places we simply use empty string "" as namespace, which is not correct.
 export const SETTINGS_NAMESPACE = "fragno-db-settings" as const;
 
-// Settings schema for storing Fragno's internal key-value settings
-export const settingsSchema = schema((s) => {
-  return s.addTable(SETTINGS_TABLE_NAME, (t) => {
-    return t
-      .addColumn("id", idColumn())
-      .addColumn("key", column("string"))
-      .addColumn("value", column("string"))
-      .createIndex("unique_key", ["key"], { unique: true });
-  });
+export const internalSchema = schema((s) => {
+  return s
+    .addTable(SETTINGS_TABLE_NAME, (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("key", column("string"))
+        .addColumn("value", column("string"))
+        .createIndex("unique_key", ["key"], { unique: true });
+    })
+    .addTable("fragno_hooks", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("namespace", column("string"))
+        .addColumn("hookName", column("string"))
+        .addColumn("payload", column("json"))
+        .addColumn("status", column("string")) // "pending" | "processing" | "completed" | "failed"
+        .addColumn("attempts", column("integer").defaultTo(0))
+        .addColumn("maxAttempts", column("integer").defaultTo(5))
+        .addColumn("lastAttemptAt", column("timestamp").nullable())
+        .addColumn("nextRetryAt", column("timestamp").nullable())
+        .addColumn("error", column("string").nullable())
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .addColumn("nonce", column("string"))
+        .createIndex("idx_namespace_status_retry", ["namespace", "status", "nextRetryAt"])
+        .createIndex("idx_nonce", ["nonce"]);
+    });
 });
 
 // This uses DatabaseFragmentDefinitionBuilder directly
@@ -33,16 +54,16 @@ export const internalFragmentDef = new DatabaseFragmentDefinitionBuilder(
   new FragmentDefinitionBuilder<
     {},
     FragnoPublicConfigWithDatabase,
-    ImplicitDatabaseDependencies<typeof settingsSchema>,
+    ImplicitDatabaseDependencies<typeof internalSchema>,
     {},
     {},
     {},
     {},
-    DatabaseServiceContext,
+    DatabaseServiceContext<{}>,
     DatabaseHandlerContext,
     DatabaseRequestStorage
   >("$fragno-internal-fragment"),
-  settingsSchema,
+  internalSchema,
   "", // intentionally blank namespace so there is no prefix
 )
   .providesService("settingsService", ({ defineService }) => {
@@ -52,7 +73,7 @@ export const internalFragmentDef = new DatabaseFragmentDefinitionBuilder(
         key: string,
       ): Promise<{ id: FragnoId; key: string; value: string } | undefined> {
         const fullKey = `${namespace}.${key}`;
-        const uow = this.uow(settingsSchema).find(SETTINGS_TABLE_NAME, (b) =>
+        const uow = this.uow(internalSchema).find(SETTINGS_TABLE_NAME, (b) =>
           b.whereIndex("unique_key", (eb) => eb("key", "=", fullKey)),
         );
         const [results] = await uow.retrievalPhase;
@@ -61,7 +82,7 @@ export const internalFragmentDef = new DatabaseFragmentDefinitionBuilder(
 
       async set(namespace: string, key: string, value: string) {
         const fullKey = `${namespace}.${key}`;
-        const uow = this.uow(settingsSchema);
+        const uow = this.uow(internalSchema);
 
         // First, find if the key already exists
         const findUow = uow.find(SETTINGS_TABLE_NAME, (b) =>
@@ -83,9 +104,117 @@ export const internalFragmentDef = new DatabaseFragmentDefinitionBuilder(
       },
 
       async delete(id: FragnoId) {
-        const uow = this.uow(settingsSchema);
+        const uow = this.uow(internalSchema);
         uow.delete(SETTINGS_TABLE_NAME, id);
         await uow.mutationPhase;
+      },
+    });
+  })
+  .providesService("hookService", ({ defineService }) => {
+    // TODO(Wilco): re-implement this better
+    return defineService({
+      /**
+       * Get pending hook events for processing.
+       * Returns all pending events for the given namespace that are ready to be processed.
+       */
+      async getPendingHookEvents(namespace: string): Promise<
+        {
+          id: FragnoId;
+          hookName: string;
+          payload: unknown;
+          attempts: number;
+          maxAttempts: number;
+          nonce: string;
+        }[]
+      > {
+        const uow = this.uow(internalSchema).find("fragno_hooks", (b) =>
+          b.whereIndex("idx_namespace_status_retry", (eb) =>
+            eb.and(eb("namespace", "=", namespace), eb("status", "=", "pending")),
+          ),
+        );
+
+        const [events] = await uow.retrievalPhase;
+
+        // Filter for pending status and events ready for retry
+        const now = new Date();
+        const ready = events.filter((event) => {
+          // FIXME(Wilco): this should be handled by the database query, but there seems to be an issue.
+          if (!event.nextRetryAt) {
+            return true; // Newly created events (nextRetryAt = null) are ready
+          }
+          return event.nextRetryAt <= now; // Only include if retry time has passed
+        });
+
+        return ready.map((event) => ({
+          id: event.id,
+          hookName: event.hookName,
+          payload: event.payload,
+          attempts: event.attempts,
+          maxAttempts: event.maxAttempts,
+          nonce: event.nonce,
+        }));
+      },
+
+      /**
+       * Mark a hook event as completed.
+       */
+      markHookCompleted(eventId: FragnoId): void {
+        const uow = this.uow(internalSchema);
+        uow.update("fragno_hooks", eventId, (b) =>
+          b.set({ status: "completed", lastAttemptAt: new Date() }).check(),
+        );
+      },
+
+      /**
+       * Mark a hook event as failed and schedule next retry.
+       */
+      markHookFailed(
+        eventId: FragnoId,
+        error: string,
+        attempts: number,
+        retryPolicy: RetryPolicy,
+      ): void {
+        const uow = this.uow(internalSchema);
+
+        const newAttempts = attempts + 1;
+        const shouldRetry = retryPolicy.shouldRetry(newAttempts - 1);
+
+        if (shouldRetry) {
+          const delayMs = retryPolicy.getDelayMs(newAttempts - 1);
+          const nextRetryAt = new Date(Date.now() + delayMs);
+          uow.update("fragno_hooks", eventId, (b) =>
+            b
+              .set({
+                status: "pending",
+                attempts: newAttempts,
+                lastAttemptAt: new Date(),
+                nextRetryAt,
+                error,
+              })
+              .check(),
+          );
+        } else {
+          uow.update("fragno_hooks", eventId, (b) =>
+            b
+              .set({
+                status: "failed",
+                attempts: newAttempts,
+                lastAttemptAt: new Date(),
+                error,
+              })
+              .check(),
+          );
+        }
+      },
+
+      /**
+       * Mark a hook event as processing (to prevent concurrent execution).
+       */
+      markHookProcessing(eventId: FragnoId): void {
+        const uow = this.uow(internalSchema);
+        uow.update("fragno_hooks", eventId, (b) =>
+          b.set({ status: "processing", lastAttemptAt: new Date() }).check(),
+        );
       },
     });
   })

--- a/packages/fragno-db/src/hooks/hooks.test.ts
+++ b/packages/fragno-db/src/hooks/hooks.test.ts
@@ -1,0 +1,575 @@
+import SQLite from "better-sqlite3";
+import { SqliteDialect } from "kysely";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { instantiate } from "@fragno-dev/core";
+import { prepareHookMutations, processHooks, type HooksMap, type HookContext } from "./hooks";
+import { internalFragmentDef, internalSchema } from "../fragments/internal-fragment";
+import type { FragnoPublicConfigWithDatabase } from "../db-fragment-definition-builder";
+import { DrizzleAdapter } from "../adapters/drizzle/drizzle-adapter";
+import { BetterSQLite3DriverConfig } from "../adapters/generic-sql/driver-config";
+import { ExponentialBackoffRetryPolicy, NoRetryPolicy } from "../query/unit-of-work/retry-policy";
+import type { FragnoId } from "../schema/create";
+
+describe("Hook System", () => {
+  let sqliteDatabase: SQLite.Database;
+  let adapter: DrizzleAdapter;
+  let internalFragment: ReturnType<typeof instantiateFragment>;
+
+  function instantiateFragment(options: FragnoPublicConfigWithDatabase) {
+    return instantiate(internalFragmentDef).withConfig({}).withOptions(options).build();
+  }
+
+  beforeAll(async () => {
+    sqliteDatabase = new SQLite(":memory:");
+
+    const dialect = new SqliteDialect({
+      database: sqliteDatabase,
+    });
+
+    adapter = new DrizzleAdapter({
+      dialect,
+      driverConfig: new BetterSQLite3DriverConfig(),
+    });
+
+    {
+      const migrations = adapter.prepareMigrations(internalSchema, "");
+      await migrations.executeWithDriver(adapter.driver, 0);
+    }
+
+    const options: FragnoPublicConfigWithDatabase = {
+      databaseAdapter: adapter,
+    };
+
+    internalFragment = instantiateFragment(options);
+
+    return async () => {
+      await adapter.close();
+    };
+  }, 12000);
+
+  describe("prepareHookMutations", () => {
+    it("should create hook records for triggered hooks", async () => {
+      const namespace = "test-namespace";
+      const hooks: HooksMap = {
+        onTest: vi.fn(),
+      };
+
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema, hooks);
+
+          // Trigger a hook
+          uow.triggerHook("onTest", { data: "test" });
+
+          // Prepare hook mutations
+          prepareHookMutations(uow, {
+            hooks,
+            namespace,
+            internalFragment,
+            defaultRetryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 5 }),
+          });
+
+          await executeMutate();
+        });
+      });
+
+      // Verify hook was created
+      const events = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ executeRetrieve }) => {
+          const result = internalFragment.services.hookService.getPendingHookEvents(namespace);
+          await executeRetrieve();
+          return result;
+        });
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        hookName: "onTest",
+        payload: { data: "test" },
+        attempts: 0,
+        maxAttempts: 5,
+      });
+    });
+
+    it("should set maxAttempts to 1 when retry policy does not retry", async () => {
+      const namespace = "test-no-retry";
+      const hooks: HooksMap = {
+        onNoRetry: vi.fn(),
+      };
+
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema, hooks);
+
+          uow.triggerHook("onNoRetry", { data: "test" });
+
+          prepareHookMutations(uow, {
+            hooks,
+            namespace,
+            internalFragment,
+            defaultRetryPolicy: new NoRetryPolicy(),
+          });
+
+          await executeMutate();
+        });
+      });
+
+      const events = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ executeRetrieve }) => {
+          const result = internalFragment.services.hookService.getPendingHookEvents(namespace);
+          await executeRetrieve();
+          return result;
+        });
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.maxAttempts).toBe(1);
+    });
+
+    it("should use custom retry policy from trigger options", async () => {
+      const namespace = "test-custom-retry";
+      const hooks: HooksMap = {
+        onCustomRetry: vi.fn(),
+      };
+
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema, hooks);
+
+          uow.triggerHook(
+            "onCustomRetry",
+            { data: "test" },
+            {
+              retryPolicy: new NoRetryPolicy(),
+            },
+          );
+
+          prepareHookMutations(uow, {
+            hooks,
+            namespace,
+            internalFragment,
+            defaultRetryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 10 }),
+          });
+
+          await executeMutate();
+        });
+      });
+
+      const events = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ executeRetrieve }) => {
+          const result = internalFragment.services.hookService.getPendingHookEvents(namespace);
+          await executeRetrieve();
+          return result;
+        });
+      });
+
+      expect(events[0]?.maxAttempts).toBe(1);
+    });
+  });
+
+  describe("processHooks", () => {
+    it("should execute hooks and mark them as completed", async () => {
+      const namespace = "test-success";
+      const hookFn = vi.fn();
+      const hooks: HooksMap = {
+        onSuccess: hookFn,
+      };
+
+      let eventId: FragnoId;
+
+      // Create a pending hook event
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema);
+          eventId = uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onSuccess",
+            payload: { email: "test@example.com" },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 5,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "test-nonce",
+          });
+          await executeMutate();
+        });
+      });
+
+      // Process hooks
+      await processHooks({
+        hooks,
+        namespace,
+        internalFragment,
+        defaultRetryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 3 }),
+      });
+
+      // Verify hook was called
+      expect(hookFn).toHaveBeenCalledOnce();
+      expect(hookFn).toHaveBeenCalledWith({ email: "test@example.com" });
+
+      // Verify hook context (this)
+      const hookContext = hookFn.mock.contexts[0] as HookContext;
+      expect(hookContext.nonce).toBe("test-nonce");
+
+      // Verify event was marked as completed
+      const result = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ forSchema, executeRetrieve }) => {
+          const uow = forSchema(internalSchema);
+          const findUow = uow.find("fragno_hooks", (b) =>
+            b.whereIndex("primary", (eb) => eb("id", "=", eventId)),
+          );
+          await executeRetrieve();
+          const [events] = await findUow.retrievalPhase;
+          return events?.[0];
+        });
+      });
+
+      expect(result?.status).toBe("completed");
+      expect(result?.lastAttemptAt).toBeInstanceOf(Date);
+    });
+
+    it("should mark failed hooks for retry", async () => {
+      const namespace = "test-failure";
+      const hookFn = vi.fn().mockRejectedValue(new Error("Hook failed"));
+      const hooks: HooksMap = {
+        onFailure: hookFn,
+      };
+
+      let eventId: FragnoId;
+
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema);
+          eventId = uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onFailure",
+            payload: { data: "test" },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 5,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "test-nonce",
+          });
+          await executeMutate();
+        });
+      });
+
+      await processHooks({
+        hooks,
+        namespace,
+        internalFragment,
+        defaultRetryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 3 }),
+      });
+
+      expect(hookFn).toHaveBeenCalledOnce();
+
+      const result = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ forSchema, executeRetrieve }) => {
+          const uow = forSchema(internalSchema);
+          const findUow = uow.find("fragno_hooks", (b) =>
+            b.whereIndex("primary", (eb) => eb("id", "=", eventId)),
+          );
+          await executeRetrieve();
+          const [events] = await findUow.retrievalPhase;
+          return events?.[0];
+        });
+      });
+
+      expect(result?.status).toBe("pending");
+      expect(result?.attempts).toBe(1);
+      expect(result?.error).toBe("Hook failed");
+      expect(result?.nextRetryAt).toBeInstanceOf(Date);
+    });
+
+    it("should mark failed hooks as permanently failed when max retries exceeded", async () => {
+      const namespace = "test-max-retries";
+      const hookFn = vi.fn().mockRejectedValue(new Error("Permanent failure"));
+      const hooks: HooksMap = {
+        onMaxRetries: hookFn,
+      };
+
+      let eventId: FragnoId;
+
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema);
+          eventId = uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onMaxRetries",
+            payload: { data: "test" },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 1,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "test-nonce",
+          });
+          await executeMutate();
+        });
+      });
+
+      await processHooks({
+        hooks,
+        namespace,
+        internalFragment,
+        defaultRetryPolicy: new NoRetryPolicy(),
+      });
+
+      const result = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ forSchema, executeRetrieve }) => {
+          const uow = forSchema(internalSchema);
+          const findUow = uow.find("fragno_hooks", (b) =>
+            b.whereIndex("primary", (eb) => eb("id", "=", eventId)),
+          );
+          await executeRetrieve();
+          const [events] = await findUow.retrievalPhase;
+          return events?.[0];
+        });
+      });
+
+      expect(result?.status).toBe("failed");
+      expect(result?.attempts).toBe(1);
+      expect(result?.error).toBe("Permanent failure");
+    });
+
+    it("should handle missing hooks gracefully", async () => {
+      const namespace = "test-missing-hook";
+      const hooks: HooksMap = {
+        onExisting: vi.fn(),
+      };
+
+      let eventId: FragnoId;
+
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema);
+          eventId = uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onMissing",
+            payload: { data: "test" },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 1,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "test-nonce",
+          });
+          await executeMutate();
+        });
+      });
+
+      await processHooks({
+        hooks,
+        namespace,
+        internalFragment,
+        defaultRetryPolicy: new NoRetryPolicy(),
+      });
+
+      const result = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ forSchema, executeRetrieve }) => {
+          const uow = forSchema(internalSchema);
+          const findUow = uow.find("fragno_hooks", (b) =>
+            b.whereIndex("primary", (eb) => eb("id", "=", eventId)),
+          );
+          await executeRetrieve();
+          const [events] = await findUow.retrievalPhase;
+          return events?.[0];
+        });
+      });
+
+      expect(result?.status).toBe("failed");
+      expect(result?.error).toBe("Hook 'onMissing' not found in hooks map");
+    });
+
+    it("should process multiple hooks in parallel", async () => {
+      const namespace = "test-parallel";
+      const hook1 = vi.fn();
+      const hook2 = vi.fn();
+      const hook3 = vi.fn();
+      const hooks: HooksMap = {
+        onHook1: hook1,
+        onHook2: hook2,
+        onHook3: hook3,
+      };
+
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema);
+          uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onHook1",
+            payload: { id: 1 },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 5,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "nonce-1",
+          });
+          uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onHook2",
+            payload: { id: 2 },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 5,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "nonce-2",
+          });
+          uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onHook3",
+            payload: { id: 3 },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 5,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "nonce-3",
+          });
+          await executeMutate();
+        });
+      });
+
+      await processHooks({
+        hooks,
+        namespace,
+        internalFragment,
+        defaultRetryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 3 }),
+      });
+
+      expect(hook1).toHaveBeenCalledWith({ id: 1 });
+      expect(hook2).toHaveBeenCalledWith({ id: 2 });
+      expect(hook3).toHaveBeenCalledWith({ id: 3 });
+
+      // Verify all were marked as completed
+      const events = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ forSchema, executeRetrieve }) => {
+          const uow = forSchema(internalSchema);
+          const findUow = uow.find("fragno_hooks", (b) =>
+            b.whereIndex("idx_namespace_status_retry", (eb) => eb("namespace", "=", namespace)),
+          );
+          await executeRetrieve();
+          const [results] = await findUow.retrievalPhase;
+          return results;
+        });
+      });
+
+      const completed = events.filter((e) => e.status === "completed");
+      expect(completed).toHaveLength(3);
+    });
+
+    it("should continue processing other hooks when one fails", async () => {
+      const namespace = "test-partial-failure";
+      const hook1 = vi.fn();
+      const hook2 = vi.fn().mockRejectedValue(new Error("Hook 2 failed"));
+      const hook3 = vi.fn();
+      const hooks: HooksMap = {
+        onHook1: hook1,
+        onHook2: hook2,
+        onHook3: hook3,
+      };
+
+      await internalFragment.inContext(async function () {
+        await this.uow(async ({ forSchema, executeMutate }) => {
+          const uow = forSchema(internalSchema);
+          uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onHook1",
+            payload: { id: 1 },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 5,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "nonce-1",
+          });
+          uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onHook2",
+            payload: { id: 2 },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 5,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "nonce-2",
+          });
+          uow.create("fragno_hooks", {
+            namespace,
+            hookName: "onHook3",
+            payload: { id: 3 },
+            status: "pending",
+            attempts: 0,
+            maxAttempts: 5,
+            lastAttemptAt: null,
+            nextRetryAt: null,
+            error: null,
+            nonce: "nonce-3",
+          });
+          await executeMutate();
+        });
+      });
+
+      await processHooks({
+        hooks,
+        namespace,
+        internalFragment,
+        defaultRetryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 3 }),
+      });
+
+      expect(hook1).toHaveBeenCalledOnce();
+      expect(hook2).toHaveBeenCalledOnce();
+      expect(hook3).toHaveBeenCalledOnce();
+
+      // Verify hook1 and hook3 were completed, hook2 was marked for retry
+      const events = await internalFragment.inContext(async function () {
+        return await this.uow(async ({ forSchema, executeRetrieve }) => {
+          const uow = forSchema(internalSchema);
+          const findUow = uow.find("fragno_hooks", (b) =>
+            b.whereIndex("idx_namespace_status_retry", (eb) => eb("namespace", "=", namespace)),
+          );
+          await executeRetrieve();
+          const [results] = await findUow.retrievalPhase;
+          return results;
+        });
+      });
+
+      const completed = events.filter((e) => e.status === "completed");
+      const pending = events.filter((e) => e.status === "pending" && e.attempts === 1);
+
+      expect(completed).toHaveLength(2);
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.error).toBe("Hook 2 failed");
+    });
+
+    it("should do nothing when no pending events exist", async () => {
+      const namespace = "test-no-events";
+      const hookFn = vi.fn();
+      const hooks: HooksMap = {
+        onTest: hookFn,
+      };
+
+      await processHooks({
+        hooks,
+        namespace,
+        internalFragment,
+        defaultRetryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 3 }),
+      });
+
+      expect(hookFn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/fragno-db/src/hooks/hooks.ts
+++ b/packages/fragno-db/src/hooks/hooks.ts
@@ -1,0 +1,179 @@
+import type { RetryPolicy } from "../query/unit-of-work/retry-policy";
+import { ExponentialBackoffRetryPolicy } from "../query/unit-of-work/retry-policy";
+import type { IUnitOfWork } from "../query/unit-of-work/unit-of-work";
+import type { InternalFragmentInstance } from "../fragments/internal-fragment";
+
+/**
+ * Context available in hook functions via `this`.
+ * Contains the nonce for idempotency and database access.
+ */
+export interface HookContext {
+  /**
+   * Unique nonce for this transaction.
+   * Use this for idempotency checks in your hook implementation.
+   */
+  nonce: string;
+}
+
+/**
+ * A hook function signature.
+ * Hooks receive a typed payload and access context via `this`.
+ */
+export type HookFn<TPayload = unknown> = (payload: TPayload) => void | Promise<void>;
+
+/**
+ * Map of hook names to hook functions.
+ * Used for type-safe hook definitions and triggering.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type HooksMap = Record<string, HookFn<any>>;
+
+/**
+ * Extract the payload type from a hook function.
+ */
+export type HookPayload<T> = T extends HookFn<infer P> ? P : never;
+
+/**
+ * Options for triggering a hook.
+ */
+export interface TriggerHookOptions {
+  /**
+   * Optional retry policy override for this specific hook trigger.
+   * If not provided, uses the default retry policy.
+   */
+  retryPolicy?: RetryPolicy;
+}
+
+/**
+ * Internal representation of a triggered hook.
+ * Stored in the Unit of Work before execution.
+ */
+export interface TriggeredHook {
+  hookName: string;
+  payload: unknown;
+  options?: TriggerHookOptions;
+}
+
+/**
+ * Configuration for hook processing.
+ */
+export interface HookProcessorConfig {
+  hooks: HooksMap;
+  namespace: string;
+  internalFragment: InternalFragmentInstance;
+  defaultRetryPolicy?: RetryPolicy;
+}
+
+/**
+ * Add hook events as mutation operations to the UOW.
+ * This should be called before executeMutations() so hook records are created
+ * in the same transaction as the user's mutations.
+ */
+export function prepareHookMutations(uow: IUnitOfWork, config: HookProcessorConfig): void {
+  const { namespace, internalFragment, defaultRetryPolicy } = config;
+  const retryPolicy = defaultRetryPolicy ?? new ExponentialBackoffRetryPolicy({ maxRetries: 5 });
+
+  const triggeredHooks = uow.getTriggeredHooks();
+
+  if (triggeredHooks.length === 0) {
+    return;
+  }
+
+  const internalSchema = internalFragment.$internal.deps.schema;
+  const internalUow = uow.forSchema(internalSchema);
+
+  for (const hook of triggeredHooks) {
+    const hookRetryPolicy = hook.options?.retryPolicy ?? retryPolicy;
+    const maxAttempts = hookRetryPolicy.shouldRetry(4) ? 5 : 1;
+    internalUow.create("fragno_hooks", {
+      namespace,
+      hookName: hook.hookName,
+      payload: hook.payload,
+      status: "pending",
+      attempts: 0,
+      maxAttempts,
+      lastAttemptAt: null,
+      nextRetryAt: null,
+      error: null,
+      nonce: uow.nonce,
+    });
+  }
+}
+
+/**
+ * Process pending hook events after the transaction has committed.
+ * This should be called in the onSuccess callback after executeMutations().
+ */
+export async function processHooks(config: HookProcessorConfig): Promise<void> {
+  const { hooks, namespace, internalFragment, defaultRetryPolicy } = config;
+  const retryPolicy = defaultRetryPolicy ?? new ExponentialBackoffRetryPolicy({ maxRetries: 5 });
+
+  await internalFragment.inContext(async function () {
+    return await this.uow(async ({ executeRetrieve, executeMutate }) => {
+      const pendingEventsPromise =
+        internalFragment.services.hookService.getPendingHookEvents(namespace);
+      await executeRetrieve();
+
+      const pendingEvents = await pendingEventsPromise;
+
+      if (pendingEvents.length === 0) {
+        return;
+      }
+
+      const processedEvents = await Promise.allSettled(
+        pendingEvents.map(async (event) => {
+          const hookFn = hooks[event.hookName];
+          if (!hookFn) {
+            return {
+              eventId: event.id,
+              status: "failed" as const,
+              error: `Hook '${event.hookName}' not found in hooks map`,
+              attempts: event.attempts,
+              maxAttempts: event.maxAttempts,
+            };
+          }
+
+          try {
+            const hookContext: HookContext = { nonce: event.nonce };
+            await hookFn.call(hookContext, event.payload);
+            return {
+              eventId: event.id,
+              status: "completed" as const,
+            };
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return {
+              eventId: event.id,
+              status: "failed" as const,
+              error: errorMessage,
+              attempts: event.attempts,
+              maxAttempts: event.maxAttempts,
+            };
+          }
+        }),
+      );
+
+      for (const processedEvent of processedEvents) {
+        if (processedEvent.status === "rejected") {
+          continue;
+        }
+
+        const { eventId, status } = processedEvent.value;
+
+        if (status === "completed") {
+          internalFragment.services.hookService.markHookCompleted(eventId);
+        } else if (status === "failed") {
+          const { error, attempts } = processedEvent.value;
+          internalFragment.services.hookService.markHookFailed(
+            eventId,
+            error,
+            attempts,
+            retryPolicy,
+          );
+        }
+      }
+
+      await executeMutate();
+    });
+  });
+}

--- a/packages/fragno-db/src/migration-engine/generation-engine.test.ts
+++ b/packages/fragno-db/src/migration-engine/generation-engine.test.ts
@@ -64,7 +64,7 @@ describe("generateMigrationsOrSchema - kysely", () => {
 
     expect(results).toHaveLength(2); // Settings + test-db
     expect(results[0].namespace).toBe(""); // Empty namespace for settings table
-    expect(results[0].path).toBe("20251024_001_f000_t001_fragno_db_settings.sql");
+    expect(results[0].path).toMatch(/^20251024_001_f000_t00\d_fragno_db_settings.sql$/);
     expect(results[0].schema).toContain("create table");
     expect(results[0].schema).toContain("fragno_db_settings");
 
@@ -115,7 +115,7 @@ describe("generateMigrationsOrSchema - kysely", () => {
 
     expect(results).toHaveLength(4); // Settings + 3 databases
     expect(results[0].namespace).toBe(""); // Empty namespace for settings table
-    expect(results[0].path).toBe("20251024_001_f000_t001_fragno_db_settings.sql");
+    expect(results[0].path).toMatch(/^20251024_001_f000_t00\d_fragno_db_settings.sql$/);
 
     expect(results[1].namespace).toBe("apple-db");
     expect(results[1].path).toBe("20251024_002_f000_t001_apple-db.sql");

--- a/packages/fragno-db/src/migration-engine/generation-engine.ts
+++ b/packages/fragno-db/src/migration-engine/generation-engine.ts
@@ -6,7 +6,7 @@ import {
 } from "../adapters/adapters";
 import {
   internalFragmentDef,
-  settingsSchema,
+  internalSchema,
   SETTINGS_NAMESPACE,
   getSchemaVersionFromDatabase,
 } from "../fragments/internal-fragment";
@@ -66,7 +66,7 @@ export async function generateMigrationsOrSchema<
 
     // Include internal fragment first with empty namespace (settings table has no prefix)
     fragmentsMap.set("", {
-      schema: settingsSchema,
+      schema: internalSchema,
       namespace: "",
     });
 
@@ -121,8 +121,8 @@ export async function generateMigrationsOrSchema<
   const generatedFiles: GenerationInternalResult[] = [];
 
   // Use empty namespace for settings (SETTINGS_NAMESPACE is for prefixing keys, not the database namespace)
-  const settingsPreparedMigrations = adapter.prepareMigrations(settingsSchema, "");
-  const settingsTargetVersion = settingsSchema.version;
+  const settingsPreparedMigrations = adapter.prepareMigrations(internalSchema, "");
+  const settingsTargetVersion = internalSchema.version;
 
   // Generate settings table migration
   const settingsSql = settingsPreparedMigrations.getSQL(
@@ -243,8 +243,8 @@ export async function executeMigrations<const TDatabases extends FragnoDatabase<
   );
 
   // Use empty namespace for settings (SETTINGS_NAMESPACE is for prefixing keys, not the database namespace)
-  const settingsPreparedMigrations = adapter.prepareMigrations(settingsSchema, "");
-  const settingsTargetVersion = settingsSchema.version;
+  const settingsPreparedMigrations = adapter.prepareMigrations(internalSchema, "");
+  const settingsTargetVersion = internalSchema.version;
 
   if (settingsSourceVersion < settingsTargetVersion) {
     const compiledMigration = settingsPreparedMigrations.compile(

--- a/packages/fragno-db/src/mod.ts
+++ b/packages/fragno-db/src/mod.ts
@@ -112,6 +112,8 @@ export type { BoundServices } from "@fragno-dev/core";
 export { internalFragmentDef } from "./fragments/internal-fragment";
 export type { InternalFragmentInstance } from "./fragments/internal-fragment";
 
+export type { HookContext, HooksMap, HookFn, HookPayload, TriggerHookOptions } from "./hooks/hooks";
+
 export type AnyFragnoInstantiatedDatabaseFragment = FragnoInstantiatedFragment<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   any,

--- a/packages/fragno-db/src/with-database.ts
+++ b/packages/fragno-db/src/with-database.ts
@@ -14,6 +14,7 @@ import {
   type DatabaseRequestStorage,
 } from "./db-fragment-definition-builder";
 import { internalFragmentDef, type InternalFragmentInstance } from "./fragments/internal-fragment";
+import type { HooksMap } from "./hooks/hooks";
 
 /**
  * Helper to add database support to a fragment builder.
@@ -69,7 +70,8 @@ export function withDatabase<TSchema extends AnySchema>(
   TServices,
   TServiceDeps,
   TPrivateServices,
-  DatabaseServiceContext,
+  HooksMap,
+  DatabaseServiceContext<HooksMap>,
   DatabaseHandlerContext,
   TLinkedFragments & { _fragno_internal: InternalFragmentInstance }
 > {
@@ -125,7 +127,8 @@ export function withDatabase<TSchema extends AnySchema>(
       TServices,
       TServiceDeps,
       TPrivateServices,
-      DatabaseServiceContext,
+      {}, // Start with empty hooks, provideHooks() will update this
+      DatabaseServiceContext<{}>,
       DatabaseHandlerContext,
       TLinkedFragments & { _fragno_internal: InternalFragmentInstance }
     >(
@@ -137,7 +140,7 @@ export function withDatabase<TSchema extends AnySchema>(
         TServices,
         TServiceDeps,
         TPrivateServices,
-        DatabaseServiceContext,
+        DatabaseServiceContext<{}>,
         DatabaseHandlerContext,
         DatabaseRequestStorage,
         TLinkedFragments & { _fragno_internal: InternalFragmentInstance }

--- a/packages/fragno/src/api/fragment-instantiator.ts
+++ b/packages/fragno/src/api/fragment-instantiator.ts
@@ -512,7 +512,6 @@ export class FragnoInstantiatedFragment<
           ? new URLSearchParams(query)
           : new URLSearchParams();
 
-    // Convert headers to Headers if needed
     const requestHeaders =
       headers instanceof Headers ? headers : headers ? new Headers(headers) : new Headers();
 


### PR DESCRIPTION
Add support for durable hooks that are automatically persisted and retried on failure. Hooks are triggered during transactions and executed after successful commits, with automatic retry logic.

- Add provideHooks() method to DatabaseFragmentDefinitionBuilder
- Add hooks table to internal schema for persistence
- Add hookService to internal fragment for event management
- Rename settingsSchema to internalSchema for clarity
- Update UnitOfWork to support hook triggering
- Export hook types from mod.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a durable hooks system for database fragments that automatically persists hook invocations and retries on failure with configurable retry policies.
  * Fragment authors can now define hooks to execute side effects after successful transaction commits, with built-in support for idempotency and retry logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->