### PR TITLE
docs(docs,db): add transactions and durable hooks documentation

### DIFF
--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/durable-hooks.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/durable-hooks.mdx
@@ -1,0 +1,86 @@
+---
+title: Durable Hooks
+description: Persist side effects in the same transaction and run them after commit with retries
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Durable hooks solve a common problem:
+
+> What if your database transaction commits, but your side effect (email, webhook, API call) fails?
+
+With durable hooks, you **register a hook trigger during the transaction**. The trigger is persisted
+in the database as part of the same commit, and then the hook is executed **after the commit**. If
+execution fails, it’s retried with an exponential backoff policy.
+
+## Defining hooks
+
+Hooks are defined on the fragment definition:
+
+<Callout title="Use defineHook() + function syntax" type="warn">
+  Hook implementations must be created via `defineHook(...)` and written with `function (...) { ... }`
+  (or `async function (...) { ... }`) so the hook `this` context is available and typed. Arrow
+  functions (`() => {}`) don’t have their own `this`, so you won’t be able to access `this.nonce`.
+</Callout>
+
+```typescript
+export const fragmentDef = defineFragment<Config>("my-fragment")
+  .extend(withDatabase(mySchema))
+  .provideHooks(({ defineHook, config }) => ({
+    onSubscribe: defineHook(async function (payload: { email: string }) {
+      // Hook functions run outside the transaction, after commit.
+      // `this.nonce` is a unique idempotency key for this transaction.
+      await config.onSubscribe?.({ nonce: this.nonce, email: payload.email });
+    }),
+  }))
+  .build();
+```
+
+### Hook context (`this`)
+
+Hook functions receive a `this` context that includes:
+
+- `nonce`: a unique nonce for the originating transaction (use for idempotency)
+
+## Triggering hooks from services
+
+Within a service method, trigger a hook using the restricted UOW:
+
+```typescript
+subscribe: async function (email: string) {
+  const uow = this.uow(mySchema);
+
+  uow.create("subscriber", { email, subscribedAt: new Date() });
+
+  // Register side effect to run after commit (and retry on failure)
+  uow.triggerHook("onSubscribe", { email });
+
+  // Wait for the handler to commit
+  await uow.mutationPhase;
+};
+```
+
+The key point is that **the hook trigger is part of your transaction**: if the transaction rolls
+back, the hook trigger is not recorded, so the side effect won’t run.
+
+## Running the transaction in a route handler
+
+Hooks are recorded when the handler runs `executeMutate()`:
+
+```typescript
+await this.uow(async ({ executeMutate }) => {
+  const resultPromise = services.subscribe(email);
+  await executeMutate();
+  return resultPromise;
+});
+```
+
+## Retry behavior
+
+If a hook execution fails, it will be retried with an exponential backoff policy. This makes hooks
+safe for “at least once” delivery, as long as your hook implementation is **idempotent**.
+
+Use the `nonce` to make idempotency easy:
+
+- store processed nonces in your external system
+- or pass the nonce as an idempotency key to third-party APIs that support it

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/meta.json
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Database Integration",
-  "pages": ["overview", "defining-schemas", "querying"]
+  "pages": ["overview", "defining-schemas", "querying", "transactions", "durable-hooks"],
+  "defaultOpen": true
 }

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/overview.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/overview.mdx
@@ -15,7 +15,10 @@ their existing database connection.
 - **Type-Safe ORM**: Full TypeScript type inference for queries
 - **User-Owned Database**: Fragment users provide their database adapter
 - **ORM Agnostic**: Works with Kysely or Drizzle
+- **Transactional**: All database operations support ACID transactions
 - **Automatic Migrations**: Schema versioning and migration generation
+- **Durable Hooks** (outbox pattern): Trigger durable hooks when database operations are performed,
+  allowing the user to take action after a successful commit.
 - **Namespaced Tables**: Prevents conflicts with user tables
 
 <Callout title="Optional Feature" type="info">
@@ -45,18 +48,22 @@ export interface CommentFragmentConfig {
 
 const commentFragmentDef = defineFragment<CommentFragmentConfig>("comment-fragment")
   .extend(withDatabase(commentSchema))
-  .providesBaseService(({ db }) => {
-    return {
-      createComment: async (data) => {
-        const id = await db.create("comment", data);
+  .providesBaseService(({ defineService }) => {
+    return defineService({
+      createComment: async function (data) {
+        const uow = this.uow(commentSchema);
+        const id = uow.create("comment", data);
+        await uow.mutationPhase;
         return { id: id.toJSON(), ...data };
       },
-      getComments: async (postId: string) => {
-        return db.find("comment", (b) =>
+      getComments: async function (postId: string) {
+        const uow = this.uow(commentSchema).find("comment", (b) =>
           b.whereIndex("idx_post", (eb) => eb("postId", "=", postId)),
         );
+        const [comments] = await uow.retrievalPhase;
+        return comments;
       },
-    };
+    });
   })
   .build();
 
@@ -78,6 +85,39 @@ export function createCommentFragment(
   `DatabaseAdapter` in the options.
 </Callout>
 
+## Querying using transactions
+
+In Fragno DB, database operations are always executed through a **Unit of Work (UOW)** transaction
+pattern. Services enqueue reads/writes on a UOW, and the route handler executes them as a single
+transaction.
+
+This design is important because it:
+
+- **Makes composition easy**: a handler can combine multiple service calls (even across multiple
+  Fragments) and commit them together
+- **Amortises database round-trips**: work can be batched into fewer DB interactions for significant
+  speed-ups for most applications
+- **Doesn't block the database**: interactive transactions can block the database with locks, in the
+  UOW pattern this cannot happen.
+- **Enables Durable Hooks**: hooks are recorded in the same transaction and run after commit
+  ([Durable Hooks](/docs/fragno/for-library-authors/database-integration/durable-hooks))
+
+## `this` context in services vs handlers
+
+- **Services** get `this.uow(schema)`: a restricted UOW used to schedule operations and await
+  `retrievalPhase` / `mutationPhase`.
+- **Handlers** get `this.uow(callback, options)`: controls the transaction boundary and executes the
+  phases (including retries on optimistic conflicts).
+
+See [Transactions](/docs/fragno/for-library-authors/database-integration/transactions) for the full
+pattern and examples.
+
+<Callout title="Why defineService()?" type="info">
+  `defineService()` is required to correctly bind and type the service `this` context. It ensures
+  `this.uow(...)` is available at runtime, and TypeScript understands the `this` type inside service
+  methods (when using `function () {}` syntax).
+</Callout>
+
 ## Next Steps
 
 - Learn about
@@ -85,6 +125,9 @@ export function createCommentFragment(
   the append-only log approach
 - Explore the [Querying](/docs/fragno/for-library-authors/database-integration/querying) API for
   CRUD operations
+- Learn how to structure
+  [Transactions](/docs/fragno/for-library-authors/database-integration/transactions) and side
+  effects with [Durable Hooks](/docs/fragno/for-library-authors/database-integration/durable-hooks)
 - See the
   [example-fragments/fragno-db-library](https://github.com/rejot-dev/fragno/tree/main/example-fragments/fragno-db-library)
   for a complete example

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/querying.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/querying.mdx
@@ -5,70 +5,87 @@ description: Using the DB to query and manipulate data
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-The `db` object provides a type-safe query interface for all CRUD operations. All methods are fully
-typed based on your schema.
+Fragno DB queries are type-safe and based on your schema. The recommended way to query is via the
+**Unit of Work (UOW)** helpers on the `this` context, so reads/writes can be **composed** and
+**batched** into a single transaction.
 
-## Accessing the DB
+## Querying with `this.uow(...)`
 
-The `db` is available in both `withDependencies()` and `providesService()`:
+There are two places you’ll use UOWs:
+
+- **Services**: `this.uow(schema)` gives a **restricted UOW** that can schedule operations and await
+  `retrievalPhase` / `mutationPhase`.
+- **Route handlers**: `this.uow(callback, options)` controls execution and runs `executeRetrieve()`
+  / `executeMutate()` (with retries on optimistic conflicts).
+
+See [Transactions](/docs/fragno/for-library-authors/database-integration/transactions) for the full
+pattern.
+
+<Callout title="Use function syntax in services" type="warn">
+  Service methods should be defined with `defineService({ ... })` and use `function (...) { ... }`
+  syntax so `this.uow(...)` is available and typed. Arrow functions (`() => {}`) don’t have their
+  own `this`.
+</Callout>
+
+## Finding Records
+
+### Index-Based Queries
+
+All `find(...)` and `findFirst(...)` queries must specify an index using `whereIndex()`. This
+ensures optimal performance and predictable query patterns.
 
 ```typescript
-const fragmentDef = defineFragment("my-fragment")
-  .extend(withDatabase(mySchema))
-  .withDependencies(({ db }) => {
-    // Use in dependencies
-  })
-  .providesBaseService(({ db, deps }) => {
-    // Use in services
-    return {
-      createComment: async (data) => {
-        return db.create("comment", data);
-      },
-    };
-  });
-```
-
-## Index-Based Queries
-
-All queries in Fragno DB must specify an index using `whereIndex()`. This ensures optimal
-performance and predictable query patterns.
-
-```typescript
-// Query using the primary index (ID)
-const users = await db.find("users", (b) =>
-  b.whereIndex("primary", (eb) => eb("id", "=", "user123")),
-);
-
-// Query using a custom index
-const users = await db.find("users", (b) =>
+const uow = this.uow(mySchema).find("users", (b) =>
   b.whereIndex("idx_email", (eb) => eb("email", "=", "user@example.com")),
 );
+const [users] = await uow.retrievalPhase;
 ```
 
 <Callout title="Why Index-Based Queries?" type="info">
   Requiring indexes for all queries ensures consistent performance and prevents slow table scans.
 </Callout>
 
-## Finding Records
-
 ### Basic Queries
 
+Find all users (table scan using the primary index):
+
 ```typescript
-// Find all users (using primary index)
-const users = await db.find("users", (b) => b.whereIndex("primary"));
+const uow = this.uow(mySchema).find("users", (b) => b.whereIndex("primary"));
+const [users] = await uow.retrievalPhase;
+```
 
-// Find with filtering
-const activeUsers = await db.find("users", (b) =>
-  b.whereIndex("idx_status", (eb) => eb("status", "=", "active")),
+Select specific columns:
+
+```typescript
+const uow = this.uow(mySchema).find("users", (b) => b.whereIndex("primary").select(["id", "name"]));
+const [userNames] = await uow.retrievalPhase;
+```
+
+Count records:
+
+```typescript
+const uow = this.uow(mySchema).find("users", (b) => b.whereIndex("primary").selectCount());
+const [userCount] = await uow.retrievalPhase;
+```
+
+Use `find(...)` when you want **an array of results**:
+
+```typescript
+const uow = this.uow(mySchema).find("users", (b) =>
+  b.whereIndex("idx_email", (eb) => eb("email", "contains", "@example.com")),
 );
+const [users] = await uow.retrievalPhase;
+// users is User[]
+```
 
-// Select specific columns
-const userNames = await db.find("users", (b) => b.whereIndex("primary").select(["id", "name"]));
-// Returns: Array<{ id: FragnoId; name: string }>
+Use `findFirst(...)` when you want **a single row (or null)**:
 
-// Count records
-const userCount = await db.find("users", (b) => b.whereIndex("primary").selectCount());
-// Returns: number
+```typescript
+const uow = this.uow(mySchema).findFirst("users", (b) =>
+  b.whereIndex("idx_email", (eb) => eb("email", "=", "user@example.com")),
+);
+const [user] = await uow.retrievalPhase;
+// user is User | null
 ```
 
 ### Cursor-Based Pagination
@@ -77,53 +94,18 @@ Use cursor-based pagination for efficient paging through large result sets. Frag
 `findWithCursor()` which automatically generates cursors from query results:
 
 ```typescript
-// Fetch first page with automatic cursor generation
-const firstPage = await db.findWithCursor("users", (b) =>
-  b.whereIndex("idx_name").orderByIndex("idx_name", "asc").pageSize(10),
-);
-// Returns: { items: User[], cursor?: Cursor }
-
-// Fetch next page using the returned cursor (simplified - cursor contains all metadata!)
-if (firstPage.cursor) {
-  const nextPage = await db.findWithCursor("users", (b) => b.after(firstPage.cursor));
-}
-
-// Or be explicit with parameters (they must match the cursor):
-if (firstPage.cursor) {
-  const nextPage = await db.findWithCursor("users", (b) =>
-    b.whereIndex("idx_name").after(firstPage.cursor).orderByIndex("idx_name", "asc").pageSize(10),
-  );
-}
-
-// Access the results
-firstPage.items.forEach((user) => {
-  console.log(user.name);
-});
-
-// Send cursor to client (encode to opaque string)
-const cursorForClient = firstPage.cursor?.encode();
-```
-
-**Manual Cursor Creation** (advanced):
-
-If you need more control, you can manually create cursors:
-
-```typescript
-import { Cursor } from "@fragno-dev/db";
-
-// Fetch page with regular find()
-const users = await db.find("users", (b) =>
+const uow = this.uow(mySchema).findWithCursor("users", (b) =>
   b.whereIndex("idx_name").orderByIndex("idx_name", "asc").pageSize(10),
 );
 
-// Manually create cursor from last item
-const lastItem = users[users.length - 1];
-const cursor = new Cursor({
-  indexName: "idx_name",
-  orderDirection: "asc",
-  pageSize: 10,
-  indexValues: { name: lastItem.name },
-});
+const [firstPage] = await uow.retrievalPhase;
+
+// firstPage.items
+// firstPage.cursor?.encode()
+
+// Fetch next page
+const uow2 = this.uow(mySchema).findWithCursor("users", (b) => b.after(firstPage.cursor));
+const [nextPage] = await uow2.retrievalPhase;
 ```
 
 <Callout title="When to Use findWithCursor()" type="info">
@@ -136,12 +118,10 @@ const cursor = new Cursor({
 Sort results using indexes:
 
 ```typescript
-// Order by an index
-const users = await db.find("users", (b) =>
-  b
-    .whereIndex("idx_created", (eb) => eb("status", "=", "active"))
-    .orderByIndex("idx_created", "desc"),
+const uow = this.uow(mySchema).find("users", (b) =>
+  b.whereIndex("idx_created").orderByIndex("idx_created", "desc"),
 );
+const [users] = await uow.retrievalPhase;
 ```
 
 ### Joins
@@ -149,188 +129,78 @@ const users = await db.find("users", (b) =>
 Load related data using joins:
 
 ```typescript
-// Join a single relation
-const postsWithAuthor = await db.find("posts", (b) =>
+const uow = this.uow(mySchema).find("posts", (b) =>
   b.whereIndex("primary").join((j) => j.author()),
 );
-
-// Access joined data
-postsWithAuthor.forEach((post) => {
-  console.log(post.title);
-  console.log(post.author?.name); // Typed as User | null
-});
-
-// Join with filtering and selection
-const posts = await db.find("posts", (b) =>
-  b
-    .whereIndex("primary")
-    .join((j) =>
-      j.author((authorBuilder) =>
-        authorBuilder
-          .whereIndex("idx_status", (eb) => eb("status", "=", "active"))
-          .select(["name"]),
-      ),
-    ),
-);
-
-// Nested joins
-const commentsWithPostAndAuthor = await db.find("comments", (b) =>
-  b
-    .whereIndex("primary")
-    .join((j) => j.post((postBuilder) => postBuilder.join((j2) => j2.author()))),
-);
+const [postsWithAuthor] = await uow.retrievalPhase;
 ```
+
+Note: We currently only support simple left joins.
 
 ## Creating Records
 
 ```typescript
-// Create single record
-const userId = await db.create("users", {
+const uow = this.uow(mySchema);
+
+// Schedule create
+const userId = uow.create("users", {
   name: "Alice",
   email: "alice@example.com",
   age: 25,
 });
-// Returns: FragnoId
 
-// Create multiple records
-const userIds = await db.createMany("users", [
-  { name: "Bob", email: "bob@example.com" },
-  { name: "Carol", email: "carol@example.com" },
-]);
-// Returns: FragnoId[]
+// Wait until the handler commits (or call executeMutate() if you're in a handler)
+await uow.mutationPhase;
 
 // Columns with defaultTo$() are auto-populated
-await db.create("posts", {
+uow.create("posts", {
   title: "My Post",
   content: "Content here",
   userId: userId.toString(),
   // createdAt auto-generated via defaultTo$("now")
 });
+await uow.mutationPhase;
 ```
 
 ## Updating Records
 
 ```typescript
 // Update by ID
-await db.update("users", userId, (b) => b.set({ name: "Alice Updated", age: 26 }));
+const uow = this.uow(mySchema);
+uow.update("users", userId, (b) => b.set({ name: "Alice Updated", age: 26 }));
+await uow.mutationPhase;
 ```
 
 ## Deleting Records
 
 ```typescript
 // Delete by ID
-await db.delete("users", userId);
+const uow = this.uow(mySchema);
+uow.delete("users", userId);
+await uow.mutationPhase;
 ```
 
-## Transactions (Unit of Work)
+## Transactions
 
-Unit of Work provides atomic transactions with a two-phase approach and optimistic concurrency
-control.
+For atomic operations, batching, and the recommended “routes execute, services enqueue” pattern, see
+[Transactions](/docs/fragno/for-library-authors/database-integration/transactions).
 
-### Two-Phase Transactions with Version Checking
+## Alternative: using `db` from dependencies (no multi-operation transactions)
 
-Fragno DB automatically tracks row versions in a hidden `_version` column. The two-phase pattern
-enables safe concurrent updates:
+You can access the `db` object directly inside the `withDependencies()` callback. Operations execute
+immediately as individual queries. This can be convenient for simple tasks, but you lose the key
+benefits of the UOW pattern:
 
-```typescript
-const uow = db.createUnitOfWork();
+- **No multi-operation atomicity** across several reads/writes (no single transaction boundary).
+- **No optimistic concurrency control** via `.check()` (and no automatic retries).
+- **No durable hooks integration**, because hooks are recorded during the UOW mutation phase.
 
-// Phase 1: Retrieval - fetch data with version info
-uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
-uow.find("accounts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
-
-// Execute retrieval phase
-const [users, accounts] = await uow.executeRetrieve();
-
-// Phase 2: Mutation - modify data with version checks
-const user = users[0];
-const account = accounts[0];
-
-// Use .check() for optimistic locking
-uow.update("users", user.id, (b) => b.set({ lastLogin: new Date() }).check());
-uow.update("accounts", account.id, (b) => b.set({ balance: account.balance + 100 }).check());
-
-// Execute mutations atomically
-const { success } = await uow.executeMutations();
-if (!success) {
-  // Version conflict - another transaction modified the data
-  // Retry the entire transaction
-  console.error("Concurrent modification detected");
-}
-```
-
-**How `.check()` works:**
-
-- Only succeeds if the row's `_version` hasn't changed since retrieval
-- Prevents lost updates in concurrent scenarios
-- Requires a `FragnoId` with version info (not a plain string)
-- Returns `success: false` if any version check fails
-
-<Callout title="Version Checking Requires FragnoId" type="warn">
-  `.check()` only works with `FragnoId` objects from query results. String IDs don't contain version
-  information and will throw an error.
-</Callout>
-
-### Getting Created IDs
-
-```typescript
-const uow = db.createUnitOfWork();
-
-uow.create("users", { name: "Alice", email: "alice@example.com" });
-uow.create("users", { name: "Bob", email: "bob@example.com" });
-
-await uow.executeMutations();
-
-// Get IDs of created records
-const createdIds = uow.getCreatedIds();
-console.log(createdIds[0].toString()); // First user's ID
-console.log(createdIds[1].toString()); // Second user's ID
-```
-
-## Wrapping in Services
-
-DB operations won't be available in services (and thus to the user) by default. You can wrap these
-operations in functions as part of the services object. You're also free to expose the `db` object
-directly to the user if you want to, but make sure to think about encapsulation and security before
-you do.
-
-```typescript
-.providesService(({ db }) => {
-  return {
-    createComment: async (data: { content: string; userId: string; postId: string }) => {
-      // Validation
-      if (data.content.length < 10) {
-        throw new Error("Comment too short");
-      }
-
-      // Create with business logic
-      const id = await db.create("comment", {
-        content: data.content,
-        userId: data.userId,
-        postId: data.postId,
-      });
-
-      return { id: id.toString(), ...data };
-    },
-
-    getCommentsByPost: async (postId: string, limit = 20) => {
-      return db.find("comment", (b) =>
-        b
-          .whereIndex("idx_post", (eb) => eb("postId", "=", postId))
-          .orderByIndex("idx_created", "desc")
-          .pageSize(limit),
-      );
-    },
-  };
-})
-```
+Keep `db` usage for cases where you don’t need transactional composition.
 
 ## Next Steps
 
-- Learn about
-  [Defining Schemas](/docs/fragno/for-library-authors/database-integration/defining-schemas)
 - See
   [Dependencies and Services](/docs/fragno/for-library-authors/features/dependencies-and-services)
-  for using DB in context
+  for using the DB in context
 - Check the
   [example-fragments/fragno-db-library](https://github.com/rejot-dev/fragno/tree/main/example-fragments/fragno-db-library)

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/transactions.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/transactions.mdx
@@ -1,0 +1,248 @@
+---
+title: Transactions
+description: Use the Unit of Work (UOW) helpers to batch reads/writes and keep handlers atomic
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+In the Fragno database layer, transactions are built around a **two-phase Unit of Work (UOW)**
+pattern:
+
+- **Retrieval phase**: schedule reads, then execute them together
+- **Mutation phase**: schedule writes, then execute them atomically
+
+The important architectural rule is:
+
+- **Route handlers control transaction execution**
+- **Services only enqueue database operations and wait for execution**
+
+This lets you call **multiple service methods inside one transaction**, and the DB work will be
+batched.
+
+## Route handlers: control the transaction boundary
+
+In route handlers (or any “handler context”), you get a helper `this.uow(...)` that:
+
+- creates a UOW for the request
+- lets you explicitly run `executeRetrieve()` and `executeMutate()`
+- **automatically retries** the whole callback on optimistic concurrency conflicts
+- **awaits promises** in the returned object (one level deep)
+
+Example pattern (from the mailing-list fragment):
+
+```typescript
+const result = await this.uow(async ({ executeRetrieve }) => {
+  const resultPromise = services.getSubscribers({
+    search,
+    sortBy,
+    sortOrder,
+    pageSize,
+    cursor,
+  });
+
+  // Executes all reads scheduled by services
+  await executeRetrieve();
+
+  // Return the promise; Fragno awaits it for you (one level deep)
+  return resultPromise;
+});
+```
+
+### Reads vs writes
+
+- **Read-only work**: call `executeRetrieve()`
+- **Write work (create/update/delete)**: call `executeMutate()`
+  - If you didn’t call `executeRetrieve()` yet, `executeMutate()` will run it first.
+
+## Services: enqueue work on a restricted UOW
+
+In services, you typically **don’t start transactions**. Instead you get a restricted UOW via
+`this.uow(schema)`:
+
+- **Important**: Services should be defined via `defineService(...)` and use `function` syntax (not
+  arrow functions) so `this` is correctly bound and typed.
+
+<Callout title="Use defineService() + function syntax" type="warn">
+  To use `this.uow(...)` in services, define your service methods via `defineService({ ... })` and
+  write them with `function (...) { ... }` (or `async function (...) { ... }`). Arrow functions
+  (`() => {}`) don’t have their own `this`, so `this.uow` won’t be available/typed.
+</Callout>
+
+- you can call things like `find(...)`, `findWithCursor(...)`, `create(...)`, `update(...)`, etc.
+- you can `await uow.retrievalPhase` / `await uow.mutationPhase`
+- you **cannot** commit/execute phases yourself (that stays in the handler)
+
+Example pattern (mailing-list `subscribe()`):
+
+```typescript
+subscribe: async function (email: string) {
+  const uow = this.uow(mailingListSchema).find("subscriber", (b) =>
+    b.whereIndex("idx_subscriber_email", (eb) => eb("email", "=", email)),
+  );
+
+  const [existing] = await uow.retrievalPhase;
+  if (existing.length > 0) {
+    return { alreadySubscribed: true };
+  }
+
+  uow.create("subscriber", { email, subscribedAt: new Date() });
+
+  // Wait for the handler to run executeMutate()
+  await uow.mutationPhase;
+
+  return { alreadySubscribed: false };
+};
+```
+
+### Why this design?
+
+Because services can’t “own” the transaction, you can safely do:
+
+- call multiple service methods
+- execute retrieval once
+- execute mutation once
+
+…and the underlying DB operations are batched and committed atomically by the handler.
+
+## Optimistic concurrency with `.check()`
+
+Fragno DB supports **optimistic concurrency control** using a hidden `_version` column. When you
+read a row through the ORM/UOW, its `id` is a `FragnoId` that also carries version information.
+
+Calling `.check()` on a mutation tells Fragno:
+
+> “Only apply this update/delete if the row’s version is still the one I read.”
+
+If the row was modified by another transaction in between, the mutation phase will fail and the
+handler-level `this.uow(...)` will retry the whole callback (up to the retry policy).
+
+### `update(...).check()` / `delete(...).check()`
+
+You can enable version checking on updates and deletes:
+
+```typescript
+updateUser: async function (userId: FragnoId) {
+  const uow = this.uow(mySchema);
+  uow.update("users", userId, (b) => b.set({ name: "New name" }).check());
+  await uow.mutationPhase;
+}
+```
+
+### Standalone `uow.check(table, id)`
+
+Sometimes you want to assert that a record hasn’t changed _without_ updating it (e.g. guard related
+rows before writing):
+
+```typescript
+transfer: async function (from: FragnoId, to: FragnoId) {
+  const uow = this.uow(mySchema);
+  uow.check("accounts", from);
+  uow.check("accounts", to);
+  uow.create("transfers", { fromAccountId: from.toString(), toAccountId: to.toString() });
+  await uow.mutationPhase;
+}
+```
+
+### Important: `.check()` requires a `FragnoId`, not a string
+
+`.check()` **throws** if you try to use it with a plain string ID, because a string doesn’t contain
+version information:
+
+- ✅ `uow.update("users", user.id, (b) => b.set(...).check())` (where `user.id` came from a query)
+- ❌ `uow.update("users", "user-123", (b) => b.set(...).check())`
+
+You _can_ update/delete using a string ID **without** `.check()` (no version guard), but that means
+last-write-wins.
+
+### End-to-end example: handler controls execution, service performs the transfer
+
+This is the same “two-phase + `.check()`” flow as the classic UOW example, but structured in the
+recommended way:
+
+- **Route handler**: owns the transaction boundary and phase execution
+- **Service**: enqueues reads/writes and uses `.check()` for optimistic locking
+
+```typescript
+import { ExponentialBackoffRetryPolicy } from "@fragno-dev/db";
+
+// Route handler (handler context) - controls transaction execution
+defineRoute({
+  method: "POST",
+  path: "/transfer",
+  handler: async function ({ input }, { json }) {
+    const { fromAccountId, toAccountId, amount } = await input.valid();
+
+    const result = await this.uow(
+      async ({ executeMutate }) => {
+        const resultPromise = services.transferBetweenAccounts({
+          fromAccountId,
+          toAccountId,
+          amount,
+        });
+
+        // Executes retrieval automatically (if needed), then executes writes atomically.
+        await executeMutate();
+
+        return resultPromise;
+      },
+      {
+        // Custom retry policy for optimistic concurrency conflicts
+        retryPolicy: new ExponentialBackoffRetryPolicy({
+          maxRetries: 5,
+          initialDelayMs: 10,
+          maxDelayMs: 250,
+        }),
+      },
+    );
+
+    return json(result);
+  },
+});
+
+defineService({
+  transferBetweenAccounts: async function (args: {
+    fromAccountId: string;
+    toAccountId: string;
+    amount: number;
+  }) {
+    const { fromAccountId, toAccountId, amount } = args;
+
+    // Phase 1: schedule retrievals
+    const uow = this.uow(mySchema)
+      .findFirst("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", fromAccountId)))
+      .findFirst("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", toAccountId)));
+
+    // Wait until the handler runs executeMutate() (it runs retrieval first if needed)
+    const [from, to] = await uow.retrievalPhase;
+
+    if (!from || !to) {
+      return { ok: false };
+    }
+
+    if (from.balance < amount) {
+      return { ok: false };
+    }
+
+    // Phase 2: schedule mutations (with version checks)
+    uow.update("accounts", from.id, (b) => b.set({ balance: from.balance - amount }).check());
+    uow.update("accounts", to.id, (b) => b.set({ balance: to.balance + amount }).check());
+
+    // Wait until the handler commits the transaction
+    // On optimistic conflicts, the handler automatically retries the whole transaction.
+    await uow.mutationPhase;
+
+    return { ok: true };
+  },
+});
+```
+
+## Retries and side effects
+
+`this.uow(...)` automatically retries the whole callback on optimistic concurrency conflicts.
+
+That means you should **avoid side effects** (sending emails, webhooks, etc.) inside the UOW
+callback or service code that runs during the transaction.
+
+Use [Durable Hooks](/docs/fragno/for-library-authors/database-integration/durable-hooks) for that:
+they record the side effect request in the same transaction and execute it **after commit**, with
+retries.

--- a/apps/docs/content/docs/fragno/for-library-authors/features/dependencies-and-services.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/features/dependencies-and-services.mdx
@@ -48,7 +48,7 @@ const myFragmentDefinition = defineFragment<MyFragmentConfig>("my-fragment")
       }),
     };
   })
-  .providesService(({ config, deps }) => {
+  .providesBaseService(({ config, deps }) => {
     return {
       summarizeText: (text: string) => {
         const result = deps.aiWrapper.summarizeText(text);
@@ -61,43 +61,38 @@ const myFragmentDefinition = defineFragment<MyFragmentConfig>("my-fragment")
 
 ## Using `defineRoutes` to work with Dependencies and Services
 
-The `defineRoute` function has a companion, `defineRoutes` (note the plural), which is a factory
-function that can be used to define multiple routes that have access to the dependencies and
-services.
+Use `defineRoutes(fragmentDefinition)` to define routes that have access to your Fragment's config,
+dependencies, and services.
 
-The dependencies and services are scoped to the `defineRoutes` call. This means that we don't need
-global types for the dependencies and services, and can define them locally instead.
+Because `defineRoutes` is typed from the fragment definition, you usually don't need to define
+separate `Deps`/`Services` types just to get good inference in your route handlers.
 
 Another benefit of this approach is that we can define routes in a single TypeScript file (like the
 `post-todos.ts` file in the previous section). This makes the codebase easier to understand and
 maintain.
 
-We define two types per `defineRoutes` call: one for the dependencies and one for the services.
-These types are passed to the call as generic parameters.
-
 ```typescript title="routes/post-todos.ts"
-import { defineRoute, defineRoutes } from "@fragno-dev/core";
-import type { Todo } from "../index";
-import type { MyOpenAIWrapper } from "../lib/my-openai-wrapper";
+import { defineRoutes } from "@fragno-dev/core";
+import { z } from "zod";
+import { myFragmentDefinition } from "../definition";
 
-type AddTodoRouteDeps = {
-  aiWrapper: MyOpenAIWrapper;
-};
+export const routes = defineRoutes(myFragmentDefinition).create(
+  ({ config, deps, services, defineRoute }) => [
+    defineRoute({
+      method: "POST",
+      path: "/summarize",
+      inputSchema: z.object({ text: z.string() }),
+      handler: async ({ input }, { json }) => {
+        const { text } = await input.valid();
 
-type AddTodoRouteServices = {
-  summarizeText: (text: string) => { summary: string; tokensUsed: number };
-};
+        // deps + services are fully typed here based on myFragmentDefinition
+        const result = deps.aiWrapper.summarizeText(text);
+        config.onTextSummarized?.(text, result.summary, result.tokensUsed);
 
-export const addTodoRoute = defineRoutes<AddTodoRouteDeps, AddTodoRouteServices>().create(
-  ({ config, deps, services }) => {
-    const { aiWrapper } = deps;
-    const { summarizeText } = services;
-
-    return [
-      /* Calls to `defineRoute` that use internal methods on `aiWrapper` or public methods such
-         as `summarizeText` from the services. */
-    ];
-  },
+        return json(result);
+      },
+    }),
+  ],
 );
 ```
 
@@ -171,7 +166,7 @@ interface IEmailService {
 // A Fragment that requires email functionality
 export const notificationFragment = defineFragment<{}>("notification-fragment")
   .usesService<"email", IEmailService>("email")
-  .providesService(({ deps }) => ({
+  .providesBaseService(({ deps }) => ({
     sendWelcomeNotification: async (userId: string) => {
       // Use the required email service
       await deps.email.sendEmail(
@@ -210,6 +205,17 @@ const fragment = defineFragment<{}>("app-fragment").usesService<"logger", ILogge
 const instance = instantiate(fragment).withConfig({}).build();
 // instance.services.logger will be undefined
 ```
+
+## Service types
+
+Fragments support three kinds of services:
+
+- **Base services**: Defined with `providesBaseService(...)`. These methods are exposed directly on
+  `instance.services`.
+- **Named services**: Defined with `providesService("name", ...)`. These are grouped under
+  `instance.services.name` (useful for composition and organization).
+- **Private services**: Defined with `providesPrivateService("name", ...)`. These are not exposed to
+  users, but can be used when constructing other services via the `privateServices` context.
 
 ## Database Integration
 

--- a/apps/docs/content/docs/fragno/for-library-authors/features/route-definition.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/features/route-definition.mdx
@@ -12,16 +12,28 @@ type-safe way to define HTTP routes with validation, error handling, and automat
 ## Basic Route Structure
 
 ```typescript
-import { defineRoute } from "@fragno-dev/core";
+import { defineFragment, defineRoutes } from "@fragno-dev/core";
 
-const route = defineRoute({
-  method: "GET",
-  path: "/users",
-  handler: async ({ query }, { json }) => {
-    return json({ users: [] });
-  },
-});
+const fragmentDefinition = defineFragment("my-fragment").build();
+
+export const routes = defineRoutes(fragmentDefinition).create(({ defineRoute }) => [
+  defineRoute({
+    method: "GET",
+    path: "/users",
+    handler: async ({ query }, { json }) => {
+      return json({ users: [] });
+    },
+  }),
+]);
 ```
+
+You can either pass the runtime definition for type inference: `defineRoutes(fragmentDefinition)`,
+or you can use the generic overload: `defineRoutes<typeof fragmentDefinition>()`. The latter is
+useful if importing the runtime value would result in circular dependencies.
+
+The `defineRoutes` factory pattern can be used to split route definitions into multiple files. The
+`.withRoutes` method can be used to combine them into a single array when instantiating the
+server-side Fragment.
 
 ## Path Configuration
 
@@ -51,36 +63,42 @@ Use `:name` for single-segment parameters and `**:name` for wildcard parameters 
 entire remainder of the path.
 
 ```typescript
-// Single parameter
-defineRoute({
-  method: "GET",
-  path: "/users/:id",
-  handler: async ({ pathParams }, { json }) => {
-    // pathParams is typed as { id: string }
-    return json({ userId: pathParams.id });
-  },
-});
+import { defineFragment, defineRoutes } from "@fragno-dev/core";
 
-// Multiple parameters
-defineRoute({
-  method: "GET",
-  path: "/organizations/:orgId/users/:userId",
-  handler: async ({ pathParams }, { json }) => {
-    // pathParams is typed as { orgId: string; userId: string }
-    return json({ orgId: pathParams.orgId, userId: pathParams.userId });
-  },
-});
+const fragmentDefinition = defineFragment("my-fragment").build();
 
-// Wildcard parameter
-defineRoute({
-  method: "GET",
-  path: "/files/**:filepath",
-  handler: async ({ pathParams }, { json }) => {
-    // pathParams is typed as { filepath: string }
-    // Captures entire remainder: "/files/docs/readme.txt" -> filepath = "docs/readme.txt"
-    return json({ file: pathParams.filepath });
-  },
-});
+export const routes = defineRoutes(fragmentDefinition).create(({ defineRoute }) => [
+  // Single parameter
+  defineRoute({
+    method: "GET",
+    path: "/users/:id",
+    handler: async ({ pathParams }, { json }) => {
+      // pathParams is typed as { id: string }
+      return json({ userId: pathParams.id });
+    },
+  }),
+
+  // Multiple parameters
+  defineRoute({
+    method: "GET",
+    path: "/organizations/:orgId/users/:userId",
+    handler: async ({ pathParams }, { json }) => {
+      // pathParams is typed as { orgId: string; userId: string }
+      return json({ orgId: pathParams.orgId, userId: pathParams.userId });
+    },
+  }),
+
+  // Wildcard parameter
+  defineRoute({
+    method: "GET",
+    path: "/files/**:filepath",
+    handler: async ({ pathParams }, { json }) => {
+      // pathParams is typed as { filepath: string }
+      // Captures entire remainder: "/files/docs/readme.txt" -> filepath = "docs/readme.txt"
+      return json({ file: pathParams.filepath });
+    },
+  }),
+]);
 ```
 
 ## Input Schema
@@ -89,24 +107,29 @@ Define input validation using any [Standard Schema](https://standardschema.dev/)
 such as Zod:
 
 ```typescript
+import { defineFragment, defineRoutes } from "@fragno-dev/core";
 import { z } from "zod";
 
-defineRoute({
-  method: "POST",
-  path: "/users",
-  inputSchema: z.object({
-    name: z.string().min(1),
-    email: z.string().email(),
-    age: z.number().optional(),
-  }),
-  handler: async ({ input }, { json }) => {
-    // input.valid() returns the validated data
-    const userData = await input.valid();
-    // userData is typed as { name: string; email: string; age?: number }
+const fragmentDefinition = defineFragment("my-fragment").build();
 
-    return json({ id: "123", ...userData });
-  },
-});
+export const routes = defineRoutes(fragmentDefinition).create(({ defineRoute }) => [
+  defineRoute({
+    method: "POST",
+    path: "/users",
+    inputSchema: z.object({
+      name: z.string().min(1),
+      email: z.string().email(),
+      age: z.number().optional(),
+    }),
+    handler: async ({ input }, { json }) => {
+      // input.valid() returns the validated data
+      const userData = await input.valid();
+      // userData is typed as { name: string; email: string; age?: number }
+
+      return json({ id: "123", ...userData });
+    },
+  }),
+]);
 ```
 
 The input context provides:
@@ -121,6 +144,11 @@ The input context provides:
 Define the expected response structure for type safety and documentation:
 
 ```typescript
+import { defineFragment, defineRoutes } from "@fragno-dev/core";
+import { z } from "zod";
+
+const fragmentDefinition = defineFragment("my-fragment").build();
+
 const UserSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -128,16 +156,18 @@ const UserSchema = z.object({
   createdAt: z.string(),
 });
 
-defineRoute({
-  method: "GET",
-  path: "/users/:id",
-  outputSchema: UserSchema,
-  handler: async ({ pathParams }, { json }) => {
-    const user = await getUserById(pathParams.id);
-    // TypeScript ensures the return value matches UserSchema
-    return json(user);
-  },
-});
+export const routes = defineRoutes(fragmentDefinition).create(({ defineRoute }) => [
+  defineRoute({
+    method: "GET",
+    path: "/users/:id",
+    outputSchema: UserSchema,
+    handler: async ({ pathParams }, { json }) => {
+      const user = await getUserById(pathParams.id);
+      // TypeScript ensures the return value matches UserSchema
+      return json(user);
+    },
+  }),
+]);
 ```
 
 <Callout type="info" title="Output Schema when Streaming">
@@ -152,24 +182,31 @@ forward-compatibility reasons. Error codes are expected to be strings, as updati
 introduce new error codes.
 
 ```typescript
-defineRoute({
-  method: "POST",
-  path: "/users",
-  inputSchema: z.object({ email: z.string().email() }),
-  errorCodes: ["USER_EXISTS", "VALIDATION_ERROR"],
-  handler: async ({ input }, { json, error }) => {
-    const { email } = await input.valid();
+import { defineFragment, defineRoutes } from "@fragno-dev/core";
+import { z } from "zod";
 
-    if (await userExists(email)) {
-      return error(
-        { message: "User already exists", code: "USER_EXISTS" },
-        409, // HTTP status code
-      );
-    }
+const fragmentDefinition = defineFragment("my-fragment").build();
 
-    return json({ id: "123", email });
-  },
-});
+export const routes = defineRoutes(fragmentDefinition).create(({ defineRoute }) => [
+  defineRoute({
+    method: "POST",
+    path: "/users",
+    inputSchema: z.object({ email: z.string().email() }),
+    errorCodes: ["USER_EXISTS", "VALIDATION_ERROR"],
+    handler: async ({ input }, { json, error }) => {
+      const { email } = await input.valid();
+
+      if (await userExists(email)) {
+        return error(
+          { message: "User already exists", code: "USER_EXISTS" },
+          409, // HTTP status code
+        );
+      }
+
+      return json({ id: "123", email });
+    },
+  }),
+]);
 ```
 
 Error responses are returned to the client as:
@@ -187,20 +224,26 @@ Like error codes, query parameters are just a hint. The `query` object is a web-
 `URLSearchParams` object.
 
 ```typescript
-defineRoute({
-  method: "GET",
-  path: "/users",
-  queryParameters: ["page", "limit", "sort"],
-  handler: async ({ query }, { json }) => {
-    const page = query.get("page") || "1";
-    const limit = query.get("limit") || "10";
-    const sort = query.get("sort");
+import { defineFragment, defineRoutes } from "@fragno-dev/core";
 
-    // Access any query parameter via query.get()
-    const users = await getUsers({ page, limit, sort });
-    return json(users);
-  },
-});
+const fragmentDefinition = defineFragment("my-fragment").build();
+
+export const routes = defineRoutes(fragmentDefinition).create(({ defineRoute }) => [
+  defineRoute({
+    method: "GET",
+    path: "/users",
+    queryParameters: ["page", "limit", "sort"],
+    handler: async ({ query }, { json }) => {
+      const page = query.get("page") || "1";
+      const limit = query.get("limit") || "10";
+      const sort = query.get("sort");
+
+      // Access any query parameter via query.get()
+      const users = await getUsers({ page, limit, sort });
+      return json(users);
+    },
+  }),
+]);
 ```
 
 ## Handler Callback

--- a/apps/docs/content/docs/fragno/for-library-authors/getting-started.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/getting-started.mdx
@@ -50,16 +50,28 @@ or add it to an existing package:
 npm install @fragno-dev/core
 ```
 
+Usually, it makes more sense to create a completely new package. If you want to extend an existing
+package using new functionality, your best bet is to create a new package that imports/extends the
+existing package.
+
 ## Creating Your First Fragment
 
 Let's build a simple todos fragment that demonstrates the core concepts.
 
 ### Step 1: Define Your Fragment
 
-```typescript title="src/index.ts"
-import { defineFragment, defineRoute, instantiate } from "@fragno-dev/core";
-import { createClientBuilder } from "@fragno-dev/core/client";
+```typescript title="src/definition.ts"
+import { defineFragment } from "@fragno-dev/core";
 import { z } from "zod";
+
+export const TodoSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  done: z.boolean(),
+  createdAt: z.string(),
+});
+
+export type Todo = z.infer<typeof TodoSchema>;
 
 // Any configuration the users of your Fragment will need to provide
 export interface TodosConfig {
@@ -67,16 +79,7 @@ export interface TodosConfig {
   onTodoCreated?: (todo: Todo & { textSummary?: string }) => void;
 }
 
-export type Todo = z.infer<typeof TodoSchema>;
-
-const TodoSchema = z.object({
-  id: z.string(),
-  text: z.string(),
-  done: z.boolean(),
-  createdAt: z.string(),
-});
-
-const todosDefinition = defineFragment<TodosConfig>("todos-fragment").build();
+export const todosDefinition = defineFragment<TodosConfig>("todos-fragment").build();
 ```
 
 ### Step 2: Add Dependencies and Services (Optional)
@@ -85,11 +88,11 @@ Dependencies are private to the library/fragment and are not included in the cli
 be used in the server-side route handlers. Dependencies can be defined using the `withDependencies`
 method, which has access to the config object.
 
-```typescript title="src/index.ts"
+```typescript title="src/definition.ts"
 import { defineFragment } from "@fragno-dev/core";
 import { MyOpenAIWrapper } from "./lib/my-openai-wrapper";
 
-const todosDefinition = defineFragment<TodosConfig>("todos-fragment")
+export const todosDefinition = defineFragment<TodosConfig>("todos-fragment")
   .withDependencies(({ config }) => {
     return {
       aiWrapper: new MyOpenAIWrapper({
@@ -111,10 +114,11 @@ We'll skip over services for now, but you can read more about them in the
 
 ### Step 3: Define Routes
 
-A basic route can be defined using the `defineRoute` function. Options are: `method`, `path`,
-`inputSchema`, `outputSchema`, `handler`, `errorCodes`, and `queryParameters`. See our
-[Route Definition](/docs/fragno/for-library-authors/features/route-definition) page for additional
-details.
+Routes are typically defined using `defineRoutes(todosDefinition)`, which gives you access to a
+typed route factory context (config, deps, services) and a `defineRoute` helper. Route options are:
+`method`, `path`, `inputSchema`, `outputSchema`, `handler`, `errorCodes`, and `queryParameters`. See
+our [Route Definition](/docs/fragno/for-library-authors/features/route-definition) page for
+additional details.
 
 The first argument passed to the handler is the input context object, which has an `input` field
 with a `valid` method that can be used to validate the input. It also contains other fields related
@@ -125,79 +129,75 @@ method fields: `json`, `jsonStream`, `empty`, and `error`. These methods can be 
 response.
 
 ```typescript title="routes/get-todos.ts"
-import { defineRoute } from "@fragno-dev/core";
+import { defineRoutes } from "@fragno-dev/core";
+import { z } from "zod";
+import { TodoSchema, todosDefinition, type Todo } from "../definition";
 
-export const getTodosRoute = defineRoute({
-  method: "GET",
-  path: "/todos",
-  outputSchema: z.array(TodoSchema),
-  handler: async ({ query }, { json }) => {
-    return json([
-      {
-        id: "1",
-        text: "Learn Fragno",
-        done: query.get("done") === "true",
-        createdAt: new Date().toISOString(),
-      },
-    ]);
-  },
-});
+export const getTodosRoute = defineRoutes(todosDefinition).create(({ defineRoute }) => [
+  defineRoute({
+    method: "GET",
+    path: "/todos",
+    outputSchema: z.array(TodoSchema),
+    handler: async ({ query }, { json }) => {
+      return json([
+        {
+          id: "1",
+          text: "Learn Fragno",
+          done: query.get("done") === "true",
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+    },
+  }),
+]);
 ```
 
-The `defineRoute` function does _not_ have access to the dependencies or services. These are
-available in the route factory context object that can be accessed by using `defineRoutes` (note the
-plural).
-
 ```typescript title="routes/post-todos.ts"
-import { defineRoute, defineRoutes } from "@fragno-dev/core";
-import type { Todo } from "../index";
-import type { MyOpenAIWrapper } from "../lib/my-openai-wrapper";
+import { defineRoutes } from "@fragno-dev/core";
+import { z } from "zod";
+import { TodoSchema, todosDefinition, type Todo } from "../definition";
 
-// Dependencies and services can be defined on a per-route level, since they might be a subset of
-// all dependencies/services.
-type AddTodoRouteDeps = {
-  aiWrapper: MyOpenAIWrapper;
-};
+export const addTodoRoute = defineRoutes(todosDefinition).create(
+  ({ config, deps, defineRoute }) => {
+    const { aiWrapper } = deps;
 
-export const addTodoRoute = defineRoutes<AddTodoRouteDeps, {}>().create(({ config, deps }) => {
-  const { aiWrapper } = deps;
+    return [
+      defineRoute({
+        method: "POST",
+        path: "/todos",
+        inputSchema: z.object({ text: z.string() }),
+        outputSchema: TodoSchema,
+        queryParameters: ["summarize"],
+        errorCodes: ["SUMMARY_ERROR"],
+        handler: async ({ input, query }, { json, error }) => {
+          const { text } = await input.valid();
 
-  return [
-    defineRoute({
-      method: "POST",
-      path: "/todos",
-      inputSchema: z.object({ text: z.string() }),
-      outputSchema: TodoSchema,
-      queryParameters: ["summarize"],
-      errorCodes: ["SUMMARY_ERROR"],
-      handler: async ({ input, query }, { json, error }) => {
-        const { text } = await input.valid();
+          const todo = {
+            id: crypto.randomUUID(),
+            text,
+            done: false,
+            createdAt: new Date().toISOString(),
+          } satisfies Todo;
 
-        const todo = {
-          id: crypto.randomUUID(),
-          text,
-          done: false,
-          createdAt: new Date().toISOString(),
-        } satisfies Todo;
+          let textSummary: string | undefined;
+          try {
+            textSummary = query.get("summarize") ? await aiWrapper.summarizeText(text) : undefined;
+          } catch {
+            return error({ message: "Summary error", code: "SUMMARY_ERROR" }, 503);
+          }
 
-        let textSummary: string | undefined;
-        try {
-          textSummary = query.get("summarize") ? await aiWrapper.summarizeText(text) : undefined;
-        } catch {
-          return error({ message: "Summary error", code: "SUMMARY_ERROR" }, 503);
-        }
+          // Call the user's callback if provided
+          config?.onTodoCreated?.({
+            ...todo,
+            textSummary,
+          });
 
-        // Call the user's callback if provided
-        config?.onTodoCreated?.({
-          ...todo,
-          textSummary,
-        });
-
-        return json(todo);
-      },
-    }),
-  ];
-});
+          return json(todo);
+        },
+      }),
+    ];
+  },
+);
 ```
 
 ### Step 4: Create the Server-Side Fragment
@@ -207,6 +207,7 @@ instance. We use the `instantiate` builder pattern to configure the fragment wit
 routes, and options.
 
 ```typescript title="src/index.ts"
+import { todosDefinition, type TodosConfig } from "./definition";
 import { getTodosRoute } from "./routes/get-todos";
 import { addTodoRoute } from "./routes/post-todos";
 
@@ -230,6 +231,7 @@ we simply create hooks for the two routes we defined. Library authors must expor
 each of the supported frameworks.
 
 ```typescript title="src/fragment.ts"
+import { todosDefinition } from "./definition";
 import { getTodosRoute } from "./routes/get-todos";
 import { addTodoRoute } from "./routes/post-todos";
 
@@ -273,6 +275,17 @@ export function createTodosClient(config: FragnoPublicClientConfig = {}) {
 import { createTodosClients } from "../fragment";
 
 import { useFragno } from "@fragno-dev/core/svelte";
+import type { FragnoPublicClientConfig } from "@fragno-dev/core/client";
+
+export function createTodosClient(config: FragnoPublicClientConfig = {}) {
+  return useFragno(createTodosClients(config));
+}
+```
+
+```typescript title="src/client/solid.ts" tab="Solid JS"
+import { createTodosClients } from "../fragment";
+
+import { useFragno } from "@fragno-dev/core/solid";
 import type { FragnoPublicClientConfig } from "@fragno-dev/core/client";
 
 export function createTodosClient(config: FragnoPublicClientConfig = {}) {

--- a/apps/docs/content/docs/fragno/for-users/client-frameworks/meta.json
+++ b/apps/docs/content/docs/fragno/for-users/client-frameworks/meta.json
@@ -1,4 +1,3 @@
 {
-  "pages": ["react", "vue", "svelte", "solid-js", "vanilla-js"],
-  "defaultOpen": true
+  "pages": ["react", "vue", "svelte", "solid-js", "vanilla-js"]
 }

--- a/apps/docs/content/docs/fragno/meta.json
+++ b/apps/docs/content/docs/fragno/meta.json
@@ -9,9 +9,9 @@
     "user-quick-start",
     "---Reference---",
     "...reference",
-    "---For Users---",
-    "...for-users",
     "---For Library Authors---",
-    "...for-library-authors"
+    "...for-library-authors",
+    "---For Users---",
+    "...for-users"
   ]
 }

--- a/apps/docs/content/docs/fragno/reference/frameworks.mdx
+++ b/apps/docs/content/docs/fragno/reference/frameworks.mdx
@@ -18,7 +18,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 <Callout type="info" title="Something missing?">
   If your favorite framework is missing, let us know by opening an [issue on
-  Github!](https://github.com/rejot-dev/fragno/issues/)
+  GitHub!](https://github.com/rejot-dev/fragno/issues/)
 </Callout>
 
 ## Server-side
@@ -47,6 +47,16 @@ import { Callout } from "fumadocs-ui/components/callout";
 | Drizzle | ✅      |
 | Prisma  | ❌      |
 
-Prisma is not supported yet, but we are working on it. Follow
+Prisma is not currently supported. Follow
 [this issue](https://github.com/rejot-dev/fragno/issues/64) to get updates, and let us know if you'd
 like to see it supported.
+
+### Kysely Dialects
+
+Fragno's data layer executes queries using the Kysely query builder. This is true even when using
+the Drizzle adapter, which is exclusively used to generate schema files to integrate directly with
+the user's existing Drizzle schema.
+
+Kysely's dialect interface is relatively easy to implement, and there are already many first- and
+third-party dialects available. You can find a list of supported dialects
+[here](https://kysely.dev/docs/dialects).

--- a/apps/docs/content/docs/fragno/reference/glossary.mdx
+++ b/apps/docs/content/docs/fragno/reference/glossary.mdx
@@ -4,13 +4,17 @@ description: Overview of terms used in the Fragno docs
 icon: NotebookTabs
 ---
 
-| Term               | Definition                                                                                                                                                      |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Adapters**       | Framework-specific integration helpers that convert Fragno's standard handlers to work with specific frameworks                                                 |
-| **Code Splitting** | Automatic separation of client and server code during build time, removing server-side dependencies from client bundles                                         |
-| **Dependencies**   | Private server-side objects (like database connections, API clients) available to route handlers but not included in client bundles                             |
-| **Fragment**       | A full-stack library built with Fragno that contains both server-side API logic and client-side integration code                                                |
-| **Hooks**          | React-style functions for reading data from GET routes, created via `createHook`                                                                                |
-| **Mutators**       | Client-side functions for modifying data through POST/PUT/DELETE routes, created via `createMutator`                                                            |
-| **Services**       | Public server-side functions exposed to Fragment users for use in custom handlers or background tasks                                                           |
-| **Unplugin**       | A unified plugin system that supports Vite, Rollup, webpack, and other build tools, used by fragment authors throught the `@fragno-dev/unplugin-fragno` package |
+| Term                               | Definition                                                                                                                                                      | Area     |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **Dependencies**                   | Private server-side objects (like database connections, API clients) available to route handlers but not included in client bundles                             | Core     |
+| **Fragment**                       | A full-stack library built with Fragno that contains both server-side API logic and client-side integration code                                                | Core     |
+| **Services**                       | Public server-side functions exposed to Fragment users for use in custom handlers or background tasks                                                           | Core     |
+| **Hooks**                          | React-style functions for reading data from GET routes, created via `createHook`                                                                                | Client   |
+| **Mutators**                       | Client-side functions for modifying data through POST/PUT/DELETE routes, created via `createMutator`                                                            | Client   |
+| **Adapters**                       | Framework-specific integration helpers that convert Fragno's standard handlers to work with specific frameworks                                                 | Server   |
+| **Durable Hooks**                  | Side effects registered during a database transaction that are persisted and executed after commit, with automatic retries on failure                           | Database |
+| **FragnoId**                       | A type that carries both ID and version information, used for optimistic concurrency control in database operations                                             | Database |
+| **Optimistic Concurrency Control** | A concurrency control method that uses version checking to detect conflicts, automatically retrying transactions when conflicts occur                           | Database |
+| **Unit of Work (UOW)**             | A two-phase transaction pattern where services enqueue reads/writes and route handlers execute them atomically, enabling composition and batching               | Database |
+| **Code Splitting**                 | Automatic separation of client and server code during build time, removing server-side dependencies from client bundles                                         | Build    |
+| **Unplugin**                       | A unified plugin system that supports Vite, Rollup, webpack, and other build tools, used by fragment authors throught the `@fragno-dev/unplugin-fragno` package | Build    |

--- a/packages/fragno-db/src/fragments/internal-fragment.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.ts
@@ -111,7 +111,6 @@ export const internalFragmentDef = new DatabaseFragmentDefinitionBuilder(
     });
   })
   .providesService("hookService", ({ defineService }) => {
-    // TODO(Wilco): re-implement this better
     return defineService({
       /**
        * Get pending hook events for processing.


### PR DESCRIPTION
- Add dedicated pages for transactions (UOW pattern) and durable hooks
- Update database integration overview with transaction and hook info
- Refactor querying docs to reference new transactions page
- Update examples to use defineRoutes and providesBaseService patterns
- Remove TODO comment in internal-fragment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New Durable Hooks guide and a Transactions (Unit of Work) guide; extensive updates to database integration, querying, routing, services, getting-started, glossary, and framework docs.
  * Minor copy fixes and navigation metadata updates (added/removed default-open flags, reordering pages).

* **API Changes**
  * Examples and guidance updated to use fragment-based route definitions and the providesBaseService service pattern.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->