### PR TITLE
test(db): update tests to use new transaction builder API

### DIFF
--- a/packages/fragno-db/src/adapters/drizzle/drizzle-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/drizzle-adapter-sqlite3.test.ts
@@ -826,7 +826,7 @@ describe("DrizzleAdapter SQLite", () => {
     const result = await executeTx(
       {
         deps: () => [getUserById(user.id)],
-        mutate: ({ forSchema, depsRetrieveResult: [foundUser] }) => {
+        mutate: ({ forSchema, depsIntermediateResult: [foundUser] }) => {
           if (!foundUser) {
             throw new Error("User not found");
           }

--- a/packages/fragno-db/src/adapters/generic-sql/test/generic-drizzle-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/test/generic-drizzle-adapter-sqlite3.test.ts
@@ -827,7 +827,7 @@ describe("GenericSQLAdapter with DrizzleAdapter better-sqlite3", () => {
     const result = await executeTx(
       {
         deps: () => [getUserById(user.id)],
-        mutate: ({ forSchema, depsRetrieveResult: [foundUser] }) => {
+        mutate: ({ forSchema, depsIntermediateResult: [foundUser] }) => {
           if (!foundUser) {
             throw new Error("User not found");
           }

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
@@ -263,13 +263,9 @@ export type MutationResult =
  * Executor interface for Unit of Work operations
  */
 export interface UOWExecutor<TOutput, TRawResult = unknown> {
-  /**
-   * Execute the retrieval phase - all queries run in a single transaction for snapshot isolation
-   */
   executeRetrievalPhase(retrievalBatch: TOutput[]): Promise<TRawResult[]>;
 
   /**
-   * Execute the mutation phase - all queries run in a transaction with version checks
    * Returns success status indicating if mutations completed without conflicts,
    * and internal IDs for create operations (null if database doesn't support RETURNING)
    */


### PR DESCRIPTION
- Rename depsRetrieveResult → serviceIntermediateResult in transform contexts
- Rename retrieveSuccess → transformRetrieve callback in builder APIs
- Rename success → transform callback in builder APIs
- Rename nonce → idempotencyKey in handler contexts
- Rename attemptCount → currentAttempt in handler contexts
- Rename serviceRetrieveResult → serviceResult in mutate contexts
- Update type inference to use toExtend instead of deprecated toMatchTypeOf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fluent builder API for constructing and executing transactions with chainable configuration.

* **Refactor**
  * Renamed context and result fields for clarity: nonce → idempotencyKey, depsRetrieveResult → depsIntermediateResult, serviceRetrieveResult → serviceResult/serviceIntermediateResult.
  * Public API evolved to builder-style transaction constructors (new builder exports added; older procedural factories removed).

* **Tests & Docs**
  * Tests, examples and JSDoc/comments updated to reflect new naming and builder-based flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->