### PR TITLE
refactor(db): remove old transaction pattern in favor of builder

### DIFF
--- a/apps/docs/workers/mailing-list.do.ts
+++ b/apps/docs/workers/mailing-list.do.ts
@@ -32,10 +32,10 @@ export class MailingList extends DurableObject<CloudflareEnv> {
   }> {
     const fragment = this.#fragment;
     return this.#fragment.inContext(async function () {
-      const result = await this.handlerTx({
-        deps: () => [fragment.services.subscribe(email)],
-        success: ({ depsResult: [result] }) => result,
-      });
+      const result = await this.handlerTx()
+        .withServiceCalls(() => [fragment.services.subscribe(email)])
+        .transform(({ serviceResult: [result] }) => result)
+        .execute();
       return result;
     });
   }

--- a/example-fragments/otp-fragment/src/index.test.ts
+++ b/example-fragments/otp-fragment/src/index.test.ts
@@ -24,10 +24,10 @@ describe("OTP Fragment", () => {
       const otpService = fragments.otp.services.otp;
 
       const code = await testCtx.inContext(async function () {
-        const code = await this.handlerTx({
-          deps: () => [otpService.generateOTP("user-123")] as const,
-          success: ({ depsResult: [result] }) => result,
-        });
+        const code = await this.handlerTx()
+          .withServiceCalls(() => [otpService.generateOTP("user-123")] as const)
+          .transform(({ serviceResult: [result] }) => result)
+          .execute();
         return code;
       });
 
@@ -35,10 +35,10 @@ describe("OTP Fragment", () => {
 
       // Verify OTP in a separate UOW context with automatic phase execution
       const isValid = await testCtx.inContext(async function () {
-        const isValid = await this.handlerTx({
-          deps: () => [otpService.verifyOTP("user-123", code)] as const,
-          success: ({ depsResult: [result] }) => result,
-        });
+        const isValid = await this.handlerTx()
+          .withServiceCalls(() => [otpService.verifyOTP("user-123", code)] as const)
+          .transform(({ serviceResult: [result] }) => result)
+          .execute();
         return isValid;
       });
       expect(isValid).toBe(true);

--- a/packages/fragment-mailing-list/src/definition.ts
+++ b/packages/fragment-mailing-list/src/definition.ts
@@ -24,14 +24,14 @@ export const mailingListFragmentDefinition = defineFragment<MailingListConfig>("
   .providesBaseService(({ defineService }) => {
     return defineService({
       subscribe: function (email: string) {
-        return this.serviceTx(mailingListSchema, {
-          retrieve: (uow) => {
+        return this.serviceTx(mailingListSchema)
+          .retrieve((uow) => {
             // Check if already subscribed
             return uow.find("subscriber", (b) =>
               b.whereIndex("idx_subscriber_email", (eb) => eb("email", "=", email)),
             );
-          },
-          mutate: ({ uow, retrieveResult: [existing] }) => {
+          })
+          .mutate(({ uow, retrieveResult: [existing] }) => {
             if (existing.length > 0) {
               const subscriber = existing[0];
               return {
@@ -53,8 +53,8 @@ export const mailingListFragmentDefinition = defineFragment<MailingListConfig>("
               subscribedAt,
               alreadySubscribed: false,
             };
-          },
-        });
+          })
+          .build();
       },
       getSubscribers: function ({
         search,
@@ -73,8 +73,8 @@ export const mailingListFragmentDefinition = defineFragment<MailingListConfig>("
         const effectiveSortOrder = cursor ? cursor.orderDirection : sortOrder;
         const effectivePageSize = cursor ? cursor.pageSize : pageSize;
 
-        return this.serviceTx(mailingListSchema, {
-          retrieve: (uow) => {
+        return this.serviceTx(mailingListSchema)
+          .retrieve((uow) => {
             return uow.findWithCursor("subscriber", (b) => {
               // When searching, we must filter by email and can only use the email index
               if (search) {
@@ -96,8 +96,8 @@ export const mailingListFragmentDefinition = defineFragment<MailingListConfig>("
               // Add cursor for pagination continuation
               return cursor ? query.after(cursor) : query;
             });
-          },
-          mutate: ({ retrieveResult: [subscribers] }) => {
+          })
+          .mutate(({ retrieveResult: [subscribers] }) => {
             return {
               subscribers: subscribers.items.map((subscriber) => ({
                 id: subscriber.id.toString(),
@@ -107,8 +107,8 @@ export const mailingListFragmentDefinition = defineFragment<MailingListConfig>("
               cursor: subscribers.cursor,
               hasNextPage: subscribers.hasNextPage,
             };
-          },
-        });
+          })
+          .build();
       },
     });
   })

--- a/packages/fragment-mailing-list/src/routes.ts
+++ b/packages/fragment-mailing-list/src/routes.ts
@@ -65,8 +65,8 @@ export const mailingListRoutesFactory = defineRoutes(mailingListFragmentDefiniti
           const params = parseQueryParams(query);
           const cursor = parseCursor(params.cursor);
 
-          const result = await this.handlerTx({
-            deps: () => [
+          const result = await this.handlerTx()
+            .withServiceCalls(() => [
               services.getSubscribers({
                 search: params.search,
                 sortBy: params.sortBy,
@@ -74,9 +74,9 @@ export const mailingListRoutesFactory = defineRoutes(mailingListFragmentDefiniti
                 pageSize: params.pageSize,
                 cursor,
               }),
-            ],
-            success: ({ depsResult: [result] }) => result,
-          });
+            ])
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
 
           return json({
             subscribers: result.subscribers,
@@ -102,10 +102,10 @@ export const mailingListRoutesFactory = defineRoutes(mailingListFragmentDefiniti
         handler: async function ({ input }, { json }) {
           const { email } = await input.valid();
 
-          const result = await this.handlerTx({
-            deps: () => [services.subscribe(email)],
-            success: ({ depsResult: [result] }) => result,
-          });
+          const result = await this.handlerTx()
+            .withServiceCalls(() => [services.subscribe(email)])
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
 
           return json(result);
         },

--- a/packages/fragno-db/src/adapters/generic-sql/test/generic-drizzle-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/test/generic-drizzle-adapter-sqlite3.test.ts
@@ -3,8 +3,8 @@ import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 import { column, idColumn, referenceColumn, schema, type FragnoId } from "../../../schema/create";
 import {
   Cursor,
-  executeTx,
-  createServiceTx,
+  createServiceTxBuilder,
+  createHandlerTxBuilder,
   ExponentialBackoffRetryPolicy,
   type DatabaseAdapter,
 } from "../../../mod";
@@ -794,7 +794,7 @@ describe("GenericSQLAdapter with DrizzleAdapter better-sqlite3", () => {
     expect(emptyPage.cursor).toBeUndefined();
   });
 
-  it("should support executeTx with retry logic", async () => {
+  it("should support handlerTx with retry logic", async () => {
     const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
 
     // Create a test user
@@ -808,49 +808,41 @@ describe("GenericSQLAdapter with DrizzleAdapter better-sqlite3", () => {
       .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")))
       .executeRetrieve();
 
-    // Use executeTx to increment age with optimistic locking
+    // Use handlerTx to increment age with optimistic locking
     let currentUow: ReturnType<typeof queryEngine.createUnitOfWork> | null = null;
 
     // Service that retrieves user by ID
     const getUserById = (userId: typeof user.id) => {
-      return createServiceTx(
-        testSchema,
-        {
-          retrieve: (uow) =>
-            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
-          retrieveSuccess: ([users]) => users[0] ?? null,
-        },
-        currentUow!,
-      );
+      return createServiceTxBuilder(testSchema, currentUow!)
+        .retrieve((uow) =>
+          uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+        )
+        .transformRetrieve(([users]) => users[0] ?? null)
+        .build();
     };
 
-    const result = await executeTx(
-      {
-        deps: () => [getUserById(user.id)],
-        mutate: ({ forSchema, depsIntermediateResult: [foundUser] }) => {
-          if (!foundUser) {
-            throw new Error("User not found");
-          }
-          const newAge = foundUser.age! + 1;
-          forSchema(testSchema).update("users", foundUser.id, (b) =>
-            b.set({ age: newAge }).check(),
-          );
-          return { previousAge: foundUser.age, newAge };
-        },
-        success: ({ mutateResult }) => {
-          // Verify the age was incremented correctly
-          expect(mutateResult.newAge).toBe(mutateResult.previousAge! + 1);
-          return mutateResult;
-        },
+    const result = await createHandlerTxBuilder({
+      createUnitOfWork: () => {
+        currentUow = queryEngine.createUnitOfWork("execute-uow-update");
+        return currentUow;
       },
-      {
-        createUnitOfWork: () => {
-          currentUow = queryEngine.createUnitOfWork("execute-uow-update");
-          return currentUow;
-        },
-        retryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 3, initialDelayMs: 1 }),
-      },
-    );
+      retryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 3, initialDelayMs: 1 }),
+    })
+      .withServiceCalls(() => [getUserById(user.id)])
+      .mutate(({ forSchema, serviceIntermediateResult: [foundUser] }) => {
+        if (!foundUser) {
+          throw new Error("User not found");
+        }
+        const newAge = foundUser.age! + 1;
+        forSchema(testSchema).update("users", foundUser.id, (b) => b.set({ age: newAge }).check());
+        return { previousAge: foundUser.age, newAge };
+      })
+      .transform(({ mutateResult }) => {
+        // Verify the age was incremented correctly
+        expect(mutateResult.newAge).toBe(mutateResult.previousAge! + 1);
+        return mutateResult;
+      })
+      .execute();
 
     // Verify the operation succeeded
     expect(result).toEqual({

--- a/packages/fragno-db/src/mod.ts
+++ b/packages/fragno-db/src/mod.ts
@@ -101,8 +101,6 @@ export {
 } from "./query/unit-of-work/retry-policy";
 
 export {
-  executeTx,
-  createServiceTx,
   ConcurrencyConflictError,
   // Builder pattern exports
   ServiceTxBuilder,

--- a/packages/fragno-db/src/query/unit-of-work/tx-builder.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/tx-builder.test.ts
@@ -232,8 +232,8 @@ describe("ServiceTxBuilder type inference", () => {
       type MutateParam = Parameters<Builder["mutate"]>[0];
       type MutateCtx = Parameters<MutateParam>[0];
 
-      // serviceResult should be a tuple with the retrieve success results
-      expectTypeOf<MutateCtx["serviceResult"]>().toEqualTypeOf<
+      // serviceIntermediateResult should be a tuple with the retrieve success results
+      expectTypeOf<MutateCtx["serviceIntermediateResult"]>().toEqualTypeOf<
         readonly [{ userId: string }, number]
       >();
     });
@@ -248,7 +248,7 @@ describe("ServiceTxBuilder type inference", () => {
       expectTypeOf<Extracted>().toEqualTypeOf<readonly [{ userId: string }, undefined]>();
     });
 
-    it("provides serviceResult in transform with final results", () => {
+    it("provides serviceIntermediateResult in transform with final results", () => {
       type ServiceCall = TxResult<{ finalData: string }, { retrieveData: string }>;
       type ServiceCalls = readonly [ServiceCall];
 
@@ -287,7 +287,7 @@ describe("ServiceTxBuilder type inference", () => {
 
       expectTypeOf<Ctx["uow"]>().toExtend<TypedUnitOfWork<TestSchema, [], unknown, {}>>();
       expectTypeOf<Ctx["retrieveResult"]>().toEqualTypeOf<string>();
-      expectTypeOf<Ctx["serviceResult"]>().toEqualTypeOf<readonly []>();
+      expectTypeOf<Ctx["serviceIntermediateResult"]>().toEqualTypeOf<readonly []>();
     });
 
     it("BuilderTransformContextWithMutate has mutateResult defined", () => {
@@ -300,7 +300,7 @@ describe("ServiceTxBuilder type inference", () => {
 
       expectTypeOf<Ctx["retrieveResult"]>().toEqualTypeOf<string>();
       expectTypeOf<Ctx["mutateResult"]>().toEqualTypeOf<{ id: string }>();
-      expectTypeOf<Ctx["serviceResult"]>().toEqualTypeOf<readonly []>();
+      expectTypeOf<Ctx["serviceIntermediateResult"]>().toEqualTypeOf<readonly []>();
       expectTypeOf<Ctx["serviceIntermediateResult"]>().toEqualTypeOf<readonly []>();
     });
 
@@ -309,7 +309,7 @@ describe("ServiceTxBuilder type inference", () => {
 
       expectTypeOf<Ctx["retrieveResult"]>().toEqualTypeOf<string>();
       expectTypeOf<Ctx["mutateResult"]>().toEqualTypeOf<undefined>();
-      expectTypeOf<Ctx["serviceResult"]>().toEqualTypeOf<readonly []>();
+      expectTypeOf<Ctx["serviceIntermediateResult"]>().toEqualTypeOf<readonly []>();
       expectTypeOf<Ctx["serviceIntermediateResult"]>().toEqualTypeOf<readonly []>();
     });
   });
@@ -473,7 +473,7 @@ describe("HandlerTxBuilder type inference", () => {
       expectTypeOf<Ctx["forSchema"]>().toBeFunction();
       // Check length property to verify empty tuple without array method comparison issues
       expectTypeOf<Ctx["retrieveResult"]["length"]>().toEqualTypeOf<0>();
-      expectTypeOf<Ctx["serviceResult"]["length"]>().toEqualTypeOf<0>();
+      expectTypeOf<Ctx["serviceIntermediateResult"]["length"]>().toEqualTypeOf<0>();
     });
 
     it("retrieve context in HandlerTxBuilder has correct type", () => {
@@ -529,7 +529,7 @@ describe("HandlerTxBuilder type inference", () => {
   });
 
   describe("withServiceCalls + mutate flow", () => {
-    it("serviceResult is available in mutate", () => {
+    it("serviceIntermediateResult is available in mutate", () => {
       type ServiceCall = TxResult<number, { user: { id: string } }>;
 
       type Builder = HandlerTxBuilder<
@@ -548,7 +548,7 @@ describe("HandlerTxBuilder type inference", () => {
       type MutateParam = Parameters<Builder["mutate"]>[0];
       type MutateCtx = Parameters<MutateParam>[0];
 
-      expectTypeOf<MutateCtx["serviceResult"]>().toEqualTypeOf<
+      expectTypeOf<MutateCtx["serviceIntermediateResult"]>().toEqualTypeOf<
         readonly [{ user: { id: string } }]
       >();
     });
@@ -807,7 +807,9 @@ describe("ServiceTxBuilder method parameter types", () => {
       type MutateCallback = Parameters<BuilderWithServices["mutate"]>[0];
       type MutateCtx = Parameters<MutateCallback>[0];
 
-      expectTypeOf<MutateCtx["serviceResult"]>().toEqualTypeOf<readonly [{ data: number[] }]>();
+      expectTypeOf<MutateCtx["serviceIntermediateResult"]>().toEqualTypeOf<
+        readonly [{ data: number[] }]
+      >();
     });
   });
 
@@ -854,7 +856,7 @@ describe("ServiceTxBuilder method parameter types", () => {
       expectTypeOf<TransformCtx["mutateResult"]>().toEqualTypeOf<undefined>();
     });
 
-    it("has serviceResult with final results and serviceResult with retrieve results", () => {
+    it("has serviceResult with final results and serviceIntermediateResult with retrieve results", () => {
       type BuilderWithServices = ServiceTxBuilder<
         TestSchema,
         readonly [TxResult<{ finalValue: number }, { retrieveValue: string }>],
@@ -969,7 +971,7 @@ describe("HandlerTxBuilder method parameter types", () => {
       type MutateCallback = Parameters<BuilderWithServices["mutate"]>[0];
       type MutateCtx = Parameters<MutateCallback>[0];
 
-      expectTypeOf<MutateCtx["serviceResult"]>().toEqualTypeOf<
+      expectTypeOf<MutateCtx["serviceIntermediateResult"]>().toEqualTypeOf<
         readonly [{ user: { id: string } }]
       >();
     });


### PR DESCRIPTION
Remove public `executeTx` and `createServiceTx` functions in favor of the builder pattern API. The builder pattern is now the only way to create and execute transactions.

As part of this refactor, rename API terminology for clarity:
- `deps` → `serviceCalls` in builder pattern
- `depsResult` → `serviceResult` (final results)
- `depsIntermediateResult` → `serviceIntermediateResult` (intermediate results)

The old functions are now internal implementation details. All transaction execution now goes through `handlerTx()` or `createServiceTxBuilder()` builders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Transaction and service-call flows migrated to a unified fluent/builder-style API across modules to improve consistency and maintainability.
  * Internal naming and test plumbing updated to match the new builder pattern.

This release contains internal improvements only; no user-facing behavior or public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->