### PR TITLE
Wilco/nonce to idempotency key

### DIFF
--- a/.changeset/rename-nonce-to-idempotency-key.md
+++ b/.changeset/rename-nonce-to-idempotency-key.md
@@ -1,0 +1,11 @@
+---
+"@fragno-dev/db": patch
+---
+
+refactor: Rename `nonce` to `idempotencyKey` in public APIs
+
+Rename the `nonce` property to `idempotencyKey` in `HookContext` and `UnitOfWork` interfaces for
+better clarity and consistency. The database column name remains `nonce` for backward compatibility.
+
+**Breaking change**: Users accessing `this.nonce` in hook functions or `uow.nonce` in unit of work
+operations must update to `this.idempotencyKey` and `uow.idempotencyKey` respectively.

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/durable-hooks.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/durable-hooks.mdx
@@ -20,7 +20,7 @@ Hooks are defined on the fragment definition:
 <Callout title="Use defineHook() + function syntax" type="warn">
   Hook implementations must be created via `defineHook(...)` and written with `function (...) { ... }`
   (or `async function (...) { ... }`) so the hook `this` context is available and typed. Arrow
-  functions (`() => {}`) don't have their own `this`, so you won't be able to access `this.nonce`.
+  functions (`() => {}`) don't have their own `this`, so you won't be able to access `this.idempotencyKey`.
 </Callout>
 
 ```typescript
@@ -29,8 +29,8 @@ export const fragmentDef = defineFragment<Config>("my-fragment")
   .provideHooks(({ defineHook, config }) => ({
     onSubscribe: defineHook(async function (payload: { email: string }) {
       // Hook functions run outside the transaction, after commit.
-      // `this.nonce` is a unique idempotency key for this transaction.
-      await config.onSubscribe?.({ nonce: this.nonce, email: payload.email });
+      // `this.idempotencyKey` is a unique idempotency key for this transaction.
+      await config.onSubscribe?.({ idempotencyKey: this.idempotencyKey, email: payload.email });
     }),
   }))
   .build();
@@ -40,7 +40,7 @@ export const fragmentDef = defineFragment<Config>("my-fragment")
 
 Hook functions receive a `this` context that includes:
 
-- `nonce`: a unique nonce for the originating transaction (use for idempotency)
+- `idempotencyKey`: a unique idempotency key for the originating transaction (use for idempotency)
 
 ## Triggering hooks from services
 
@@ -90,7 +90,7 @@ defineRoute({
 If a hook execution fails, it will be retried with an exponential backoff policy. This makes hooks
 safe for "at least once" delivery, as long as your hook implementation is **idempotent**.
 
-Use the `nonce` to make idempotency easy:
+Use the `idempotencyKey` to make idempotency easy:
 
-- store processed nonces in your external system
-- or pass the nonce as an idempotency key to third-party APIs that support it
+- store processed idempotency keys in your external system
+- or pass the idempotencyKey as an idempotency key to third-party APIs that support it

--- a/packages/fragno-db/src/db-fragment-instantiator.test.ts
+++ b/packages/fragno-db/src/db-fragment-instantiator.test.ts
@@ -65,7 +65,7 @@ function createMockAdapter(): DatabaseAdapter {
         table: vi.fn(() => ({
           findMany: vi.fn(),
         })),
-        nonce: "test-nonce",
+        idempotencyKey: "test-nonce",
         state: "building-retrieval",
       };
     }),

--- a/packages/fragno-db/src/fragments/internal-fragment.test.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.test.ts
@@ -236,7 +236,7 @@ describe("Hook Service", () => {
       payload: { test: "data" },
       attempts: 0,
       maxAttempts: 5,
-      nonce,
+      idempotencyKey: nonce,
     });
   });
 

--- a/packages/fragno-db/src/fragments/internal-fragment.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.ts
@@ -152,7 +152,7 @@ export const internalFragmentDef = new DatabaseFragmentDefinitionBuilder(
               payload: event.payload as unknown,
               attempts: event.attempts,
               maxAttempts: event.maxAttempts,
-              nonce: event.nonce,
+              idempotencyKey: event.nonce,
             }));
           })
           .build();

--- a/packages/fragno-db/src/hooks/hooks.test.ts
+++ b/packages/fragno-db/src/hooks/hooks.test.ts
@@ -225,7 +225,7 @@ describe("Hook System", () => {
 
       // Verify hook context (this)
       const hookContext = hookFn.mock.contexts[0] as HookContext;
-      expect(hookContext.nonce).toBe("test-nonce");
+      expect(hookContext.idempotencyKey).toBe("test-nonce");
 
       // Verify event was marked as completed
       const result = await internalFragment.inContext(async function () {

--- a/packages/fragno-db/src/hooks/hooks.ts
+++ b/packages/fragno-db/src/hooks/hooks.ts
@@ -6,14 +6,14 @@ import type { TxResult } from "../query/unit-of-work/execute-unit-of-work";
 
 /**
  * Context available in hook functions via `this`.
- * Contains the nonce for idempotency and database access.
+ * Contains the idempotency key for idempotency and database access.
  */
 export interface HookContext {
   /**
-   * Unique nonce for this transaction.
+   * Unique idempotency key for this transaction.
    * Use this for idempotency checks in your hook implementation.
    */
-  nonce: string;
+  idempotencyKey: string;
 }
 
 /**
@@ -96,7 +96,7 @@ export function prepareHookMutations(uow: IUnitOfWork, config: HookProcessorConf
       lastAttemptAt: null,
       nextRetryAt: null,
       error: null,
-      nonce: uow.nonce,
+      nonce: uow.idempotencyKey,
     });
   }
 }
@@ -138,7 +138,7 @@ export async function processHooks(config: HookProcessorConfig): Promise<void> {
       }
 
       try {
-        const hookContext: HookContext = { nonce: event.nonce };
+        const hookContext: HookContext = { idempotencyKey: event.idempotencyKey };
         await hookFn.call(hookContext, event.payload);
         return {
           eventId: event.id,

--- a/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.ts
+++ b/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.ts
@@ -749,7 +749,7 @@ async function executeTx(
         forSchema: <S extends AnySchema, H extends HooksMap = THooks>(schema: S, hooks?: H) => {
           return baseUow.forSchema(schema, hooks);
         },
-        idempotencyKey: baseUow.nonce,
+        idempotencyKey: baseUow.idempotencyKey,
         currentAttempt: attempt,
       };
 

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work-coordinator.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work-coordinator.test.ts
@@ -722,51 +722,51 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
     // If we got here without Node.js throwing an unhandled rejection, the test passes
   });
 
-  it("should inherit nonce from parent to children for idempotent operations", () => {
+  it("should inherit idempotencyKey from parent to children for idempotent operations", () => {
     const executor = createMockExecutor();
     const parentUow = createUnitOfWork(createCompiler(), executor, createMockDecoder());
 
-    // Parent UOW should have a nonce
-    const parentNonce = parentUow.nonce;
-    expect(parentNonce).toBeDefined();
-    expect(typeof parentNonce).toBe("string");
-    expect(parentNonce.length).toBeGreaterThan(0);
+    // Parent UOW should have an idempotencyKey
+    const parentIdempotencyKey = parentUow.idempotencyKey;
+    expect(parentIdempotencyKey).toBeDefined();
+    expect(typeof parentIdempotencyKey).toBe("string");
+    expect(parentIdempotencyKey.length).toBeGreaterThan(0);
 
     // Create first child
     const child1 = parentUow.restrict();
-    expect(child1.nonce).toBe(parentNonce);
+    expect(child1.idempotencyKey).toBe(parentIdempotencyKey);
 
     // Create second child (sibling to child1)
     const child2 = parentUow.restrict();
-    expect(child2.nonce).toBe(parentNonce);
+    expect(child2.idempotencyKey).toBe(parentIdempotencyKey);
 
     // Create nested child (child of child1)
     const grandchild = child1.restrict();
-    expect(grandchild.nonce).toBe(parentNonce);
+    expect(grandchild.idempotencyKey).toBe(parentIdempotencyKey);
 
-    // All UOWs in the hierarchy should share the same nonce
-    expect(parentUow.nonce).toBe(child1.nonce);
-    expect(child1.nonce).toBe(child2.nonce);
-    expect(child2.nonce).toBe(grandchild.nonce);
+    // All UOWs in the hierarchy should share the same idempotencyKey
+    expect(parentUow.idempotencyKey).toBe(child1.idempotencyKey);
+    expect(child1.idempotencyKey).toBe(child2.idempotencyKey);
+    expect(child2.idempotencyKey).toBe(grandchild.idempotencyKey);
   });
 
-  it("should generate different nonces for separate UOW hierarchies", () => {
+  it("should generate different idempotencyKeys for separate UOW hierarchies", () => {
     const executor = createMockExecutor();
 
     // Create two separate parent UOWs
     const parentUow1 = createUnitOfWork(createCompiler(), executor, createMockDecoder());
     const parentUow2 = createUnitOfWork(createCompiler(), executor, createMockDecoder());
 
-    // They should have different nonces
-    expect(parentUow1.nonce).not.toBe(parentUow2.nonce);
+    // They should have different idempotencyKeys
+    expect(parentUow1.idempotencyKey).not.toBe(parentUow2.idempotencyKey);
 
-    // But children within each hierarchy should inherit their parent's nonce
+    // But children within each hierarchy should inherit their parent's idempotencyKey
     const child1 = parentUow1.restrict();
     const child2 = parentUow2.restrict();
 
-    expect(child1.nonce).toBe(parentUow1.nonce);
-    expect(child2.nonce).toBe(parentUow2.nonce);
-    expect(child1.nonce).not.toBe(child2.nonce);
+    expect(child1.idempotencyKey).toBe(parentUow1.idempotencyKey);
+    expect(child2.idempotencyKey).toBe(parentUow2.idempotencyKey);
+    expect(child1.idempotencyKey).not.toBe(child2.idempotencyKey);
   });
 
   it("should not cause unhandled rejection when service method awaits retrievalPhase and executeRetrieve fails", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed public property "nonce" to "idempotencyKey" in HookContext and UnitOfWork — update any code that accessed the old names.

* **Documentation**
  * Updated docs and examples to use "idempotencyKey" instead of "nonce".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->