### PR TITLE
docs(forms): add install prompt button

### DIFF
--- a/apps/docs/app/components/copy-forms-prompt-button.tsx
+++ b/apps/docs/app/components/copy-forms-prompt-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Copy, Check } from "lucide-react";
+
+const LLM_PROMPT = `Add Fragno Forms to my application following docs on https://fragno.dev/docs/forms
+For examples on how to use client hooks see: https://fragno.dev/docs/forms/hooks
+Key steps:
+- Server: Re-use or initialize a Fragno DB adapter, create fragment instance, mount api routes
+- Database: Generate schema for this fragment using fragno-cli, generate a db schema migration once generated
+- Client: Create client instance, use hooks (useForm, useSubmitForm)
+- Render forms with JSON Schema + JSONForms UI Schema
+
+Check with me the following:
+- What path to mount the api routes (default /api/forms)
+- What JSONforms Renderer to use (default shadcn/ui: https://fragno.dev/docs/forms/shadcn-renderer)
+`;
+
+export function CopyFormsPromptButton() {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(LLM_PROMPT);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, []);
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="flex items-center gap-2 rounded-lg border border-gray-300 px-6 py-3 font-semibold text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+    >
+      {copied ? (
+        <>
+          <Check className="size-4" />
+          Prompt Copied!
+        </>
+      ) : (
+        <>
+          <Copy className="size-4" />
+          Copy Install Prompt
+        </>
+      )}
+    </button>
+  );
+}

--- a/apps/docs/app/routes/forms/form-index.tsx
+++ b/apps/docs/app/routes/forms/form-index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Palette, Database, FileJson, Check } from "lucide-react";
 import { SurveyAboutForms } from "../../components/survey-about-forms";
 import { FormDemo } from "../../components/form-demo";
+import { CopyFormsPromptButton } from "../../components/copy-forms-prompt-button";
 import type { Route } from "./+types/form-index";
 import { CloudflareContext } from "@/cloudflare/cloudflare-context";
 import { Link } from "react-router";
@@ -84,6 +85,7 @@ export default function FormsPage({ loaderData }: Route.ComponentProps) {
               <GitHub className="size-4" />
               Star on GitHub
             </a>
+            <CopyFormsPromptButton />
           </div>
         </section>
 

--- a/apps/docs/content/docs/forms/index.mdx
+++ b/apps/docs/content/docs/forms/index.mdx
@@ -5,6 +5,7 @@ icon: Album
 ---
 
 import { FormsDemoCallout } from "@/components/forms-demo-callout";
+import { CopyFormsPromptButton } from "@/components/copy-forms-prompt-button";
 
 ## Overview
 
@@ -12,6 +13,10 @@ The form fragment built on top of Fragno provides a complete form management and
 system built on open standards: JSON Schema and JSON Forms.
 
 <FormsDemoCallout />
+
+Let an AI agent install and configure this fragment for you:
+
+<CopyFormsPromptButton />
 
 Rendering forms can be done by using one of the [official](https://jsonforms.io/docs/renderer-sets)
 or [community-made](https://jsonforms.io/community/#community-projects) JSON Forms renderers or our


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copy-to-clipboard button on the Forms documentation page. Users can now easily copy a predefined Forms integration prompt designed for AI agent configuration and setup. The button provides clear visual feedback indicating when the prompt has been successfully copied to the clipboard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->