### PR TITLE
fix(db): enforce external id uniqueness in Drizzle SQLite

### DIFF
--- a/.changeset/curly-actors-laugh.md
+++ b/.changeset/curly-actors-laugh.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+fix(db): ensure Drizzle SQLite external ids are enforced as unique indexes.

--- a/packages/fragno-db/src/adapters/drizzle/generate.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/generate.test.ts
@@ -45,7 +45,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const users_test = pgTable("users_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           email: text("email").notNull(),
           age: integer("age"),
@@ -57,7 +57,7 @@ describe("generateSchema", () => {
         ])
 
         export const posts_test = pgTable("posts_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           title: text("title").notNull(),
           content: text("content").notNull(),
           userId: bigint("userId", { mode: "number" }).notNull(),
@@ -116,7 +116,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const users_test = mysqlTable("users_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           email: text("email").notNull(),
           age: int("age"),
@@ -128,7 +128,7 @@ describe("generateSchema", () => {
         ])
 
         export const posts_test = mysqlTable("posts_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           title: text("title").notNull(),
           content: text("content").notNull(),
           userId: bigint("userId", { mode: "number" }).notNull(),
@@ -187,7 +187,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const users_test = sqliteTable("users_test", {
-          id: text("id").notNull().$defaultFn(() => createId()),
+          id: text("id").notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           email: text("email").notNull(),
           age: integer("age"),
@@ -195,11 +195,12 @@ describe("generateSchema", () => {
           _version: integer("_version").notNull().default(0)
         }, (table) => [
           uniqueIndex("idx_email_test").on(table.email),
-          index("idx_name_test").on(table.name)
+          index("idx_name_test").on(table.name),
+          uniqueIndex("idx_users_external_id_test").on(table.id)
         ])
 
         export const posts_test = sqliteTable("posts_test", {
-          id: text("id").notNull().$defaultFn(() => createId()),
+          id: text("id").notNull().unique().$defaultFn(() => createId()),
           title: text("title").notNull(),
           content: text("content").notNull(),
           userId: integer("userId").notNull(),
@@ -213,7 +214,8 @@ describe("generateSchema", () => {
             name: "fk_posts_users_author_test"
           }),
           index("idx_user_test").on(table.userId),
-          index("idx_title_test").on(table.title)
+          index("idx_title_test").on(table.title),
+          uniqueIndex("idx_posts_external_id_test").on(table.id)
         ])
 
         export const users_testRelations = relations(users_test, ({ many }) => ({
@@ -269,7 +271,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const events_test = pgTable("events_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           createdAt: timestamp("createdAt").notNull().$defaultFn(() => new Date()),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
           _version: integer("_version").notNull().default(0)
@@ -306,7 +308,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const events_test = pgTable("events_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           createdAt: timestamp("createdAt").notNull().defaultNow(),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
           _version: integer("_version").notNull().default(0)
@@ -355,7 +357,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const files_test = pgTable("files_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           data: customBinary("data").notNull(),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
           _version: integer("_version").notNull().default(0)
@@ -410,14 +412,14 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const users_test = pgTable("users_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
           _version: integer("_version").notNull().default(0)
         })
 
         export const posts_test = pgTable("posts_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           title: text("title").notNull(),
           userId: bigint("userId", { mode: "number" }).notNull(),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
@@ -474,14 +476,14 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const users_test = mysqlTable("users_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           _internalId: bigint("_internalId", { mode: "number" }).primaryKey().autoincrement().notNull(),
           _version: int("_version").notNull().default(0)
         })
 
         export const posts_test = mysqlTable("posts_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           title: text("title").notNull(),
           userId: bigint("userId", { mode: "number" }).notNull(),
           _internalId: bigint("_internalId", { mode: "number" }).primaryKey().autoincrement().notNull(),
@@ -529,7 +531,7 @@ describe("generateSchema", () => {
     it("should generate SQLite schema with many relations", () => {
       const generated = generateSchema([{ namespace: "test", schema: oneToManySchema }], "sqlite");
       expect(generated).toMatchInlineSnapshot(`
-        "import { sqliteTable, text, integer, foreignKey, index } from "drizzle-orm/sqlite-core"
+        "import { sqliteTable, text, integer, uniqueIndex, foreignKey, index } from "drizzle-orm/sqlite-core"
         import { createId } from "@fragno-dev/db/id"
         import { relations } from "drizzle-orm"
 
@@ -538,14 +540,16 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const users_test = sqliteTable("users_test", {
-          id: text("id").notNull().$defaultFn(() => createId()),
+          id: text("id").notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           _internalId: integer("_internalId").primaryKey({ autoIncrement: true }).notNull(),
           _version: integer("_version").notNull().default(0)
-        })
+        }, (table) => [
+          uniqueIndex("idx_users_external_id_test").on(table.id)
+        ])
 
         export const posts_test = sqliteTable("posts_test", {
-          id: text("id").notNull().$defaultFn(() => createId()),
+          id: text("id").notNull().unique().$defaultFn(() => createId()),
           title: text("title").notNull(),
           userId: integer("userId").notNull(),
           _internalId: integer("_internalId").primaryKey({ autoIncrement: true }).notNull(),
@@ -556,7 +560,8 @@ describe("generateSchema", () => {
             foreignColumns: [users_test._internalId],
             name: "fk_posts_users_author_test"
           }),
-          index("idx_user_test").on(table.userId)
+          index("idx_user_test").on(table.userId),
+          uniqueIndex("idx_posts_external_id_test").on(table.id)
         ])
 
         export const users_testRelations = relations(users_test, ({ many }) => ({
@@ -638,14 +643,14 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const categories_test = pgTable("categories_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
           _version: integer("_version").notNull().default(0)
         })
 
         export const products_test = pgTable("products_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           categoryId: bigint("categoryId", { mode: "number" }).notNull(),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
@@ -714,7 +719,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const category_test = pgTable("category_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           parentId: bigint("parentId", { mode: "number" }),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
@@ -784,7 +789,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const comment_test = pgTable("comment_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           content: text("content").notNull(),
           parentId: bigint("parentId", { mode: "number" }),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
@@ -831,7 +836,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const comment_test = mysqlTable("comment_test", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           content: text("content").notNull(),
           parentId: bigint("parentId", { mode: "number" }),
           _internalId: bigint("_internalId", { mode: "number" }).primaryKey().autoincrement().notNull(),
@@ -869,7 +874,7 @@ describe("generateSchema", () => {
     it("should generate SQLite self-referencing foreign key using table parameter", () => {
       const generated = generateSchema([{ namespace: "test", schema: selfRefSchema }], "sqlite");
       expect(generated).toMatchInlineSnapshot(`
-        "import { sqliteTable, text, integer, foreignKey, index } from "drizzle-orm/sqlite-core"
+        "import { sqliteTable, text, integer, foreignKey, index, uniqueIndex } from "drizzle-orm/sqlite-core"
         import { createId } from "@fragno-dev/db/id"
         import { relations } from "drizzle-orm"
 
@@ -878,7 +883,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const comment_test = sqliteTable("comment_test", {
-          id: text("id").notNull().$defaultFn(() => createId()),
+          id: text("id").notNull().unique().$defaultFn(() => createId()),
           content: text("content").notNull(),
           parentId: integer("parentId"),
           _internalId: integer("_internalId").primaryKey({ autoIncrement: true }).notNull(),
@@ -889,7 +894,8 @@ describe("generateSchema", () => {
             foreignColumns: [table._internalId],
             name: "fk_comment_comment_parent_test"
           }),
-          index("idx_parent_test").on(table.parentId)
+          index("idx_parent_test").on(table.parentId),
+          uniqueIndex("idx_comment_external_id_test").on(table.id)
         ])
 
         export const comment_testRelations = relations(comment_test, ({ one, many }) => ({
@@ -995,7 +1001,7 @@ describe("generateSchema", () => {
         // ============================================================================
 
         export const users_my_fragment_v2 = pgTable("users_my_fragment_v2", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           name: text("name").notNull(),
           email: text("email").notNull(),
           age: integer("age"),
@@ -1007,7 +1013,7 @@ describe("generateSchema", () => {
         ])
 
         export const posts_my_fragment_v2 = pgTable("posts_my_fragment_v2", {
-          id: varchar("id", { length: 30 }).notNull().$defaultFn(() => createId()),
+          id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
           title: text("title").notNull(),
           content: text("content").notNull(),
           userId: bigint("userId", { mode: "number" }).notNull(),

--- a/packages/fragno-db/src/adapters/drizzle/migrate-drizzle.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/migrate-drizzle.test.ts
@@ -155,7 +155,8 @@ describe("generateSchema and migrate", () => {
       	"key" text NOT NULL,
       	"value" text NOT NULL,
       	"_internalId" bigserial PRIMARY KEY NOT NULL,
-      	"_version" integer DEFAULT 0 NOT NULL
+      	"_version" integer DEFAULT 0 NOT NULL,
+      	CONSTRAINT "fragno_db_settings_id_unique" UNIQUE("id")
       );
 
       CREATE TABLE "fragno_hooks" (
@@ -172,7 +173,8 @@ describe("generateSchema and migrate", () => {
       	"createdAt" timestamp DEFAULT now() NOT NULL,
       	"nonce" text NOT NULL,
       	"_internalId" bigserial PRIMARY KEY NOT NULL,
-      	"_version" integer DEFAULT 0 NOT NULL
+      	"_version" integer DEFAULT 0 NOT NULL,
+      	CONSTRAINT "fragno_hooks_id_unique" UNIQUE("id")
       );
 
       CREATE TABLE "users" (
@@ -185,7 +187,8 @@ describe("generateSchema and migrate", () => {
       	"createdAt" timestamp DEFAULT now() NOT NULL,
       	"updatedAt" timestamp DEFAULT now() NOT NULL,
       	"_internalId" bigserial PRIMARY KEY NOT NULL,
-      	"_version" integer DEFAULT 0 NOT NULL
+      	"_version" integer DEFAULT 0 NOT NULL,
+      	CONSTRAINT "users_id_unique" UNIQUE("id")
       );
 
       CREATE TABLE "posts" (
@@ -204,7 +207,8 @@ describe("generateSchema and migrate", () => {
       	"thumbnail" "bytea",
       	"createdAt" timestamp DEFAULT now() NOT NULL,
       	"_internalId" bigserial PRIMARY KEY NOT NULL,
-      	"_version" integer DEFAULT 0 NOT NULL
+      	"_version" integer DEFAULT 0 NOT NULL,
+      	CONSTRAINT "posts_id_unique" UNIQUE("id")
       );
 
       CREATE TABLE "comments" (
@@ -217,7 +221,8 @@ describe("generateSchema and migrate", () => {
       	"editedAt" timestamp,
       	"isDeleted" boolean DEFAULT false NOT NULL,
       	"_internalId" bigserial PRIMARY KEY NOT NULL,
-      	"_version" integer DEFAULT 0 NOT NULL
+      	"_version" integer DEFAULT 0 NOT NULL,
+      	CONSTRAINT "comments_id_unique" UNIQUE("id")
       );
 
       CREATE TABLE "tags" (
@@ -228,7 +233,8 @@ describe("generateSchema and migrate", () => {
       	"color" varchar(7),
       	"usageCount" bigint DEFAULT 0 NOT NULL,
       	"_internalId" bigserial PRIMARY KEY NOT NULL,
-      	"_version" integer DEFAULT 0 NOT NULL
+      	"_version" integer DEFAULT 0 NOT NULL,
+      	CONSTRAINT "tags_id_unique" UNIQUE("id")
       );
 
       CREATE TABLE "postTags" (
@@ -238,7 +244,8 @@ describe("generateSchema and migrate", () => {
       	"order" integer DEFAULT 0 NOT NULL,
       	"createdAt" timestamp DEFAULT now() NOT NULL,
       	"_internalId" bigserial PRIMARY KEY NOT NULL,
-      	"_version" integer DEFAULT 0 NOT NULL
+      	"_version" integer DEFAULT 0 NOT NULL,
+      	CONSTRAINT "postTags_id_unique" UNIQUE("id")
       );
 
       ALTER TABLE "posts" ADD CONSTRAINT "posts_users_author_fk" FOREIGN KEY ("userId") REFERENCES "public"."users"("_internalId") ON DELETE no action ON UPDATE no action;

--- a/packages/fragno-db/src/adapters/drizzle/migration-parity-drizzle-kit.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/migration-parity-drizzle-kit.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import { column, idColumn, schema } from "../../schema/create";
+import { writeAndLoadSchema } from "./test-utils";
+import { createPreparedMigrations } from "../generic-sql/migration/prepared-migrations";
+
+const require = createRequire(import.meta.url);
+const {
+  generateDrizzleJson,
+  generateMigration,
+  generateSQLiteDrizzleJson,
+  generateSQLiteMigration,
+  generateMySQLDrizzleJson,
+  generateMySQLMigration,
+} = require("drizzle-kit/api") as typeof import("drizzle-kit/api");
+
+const paritySchema = schema((s) => {
+  return s.addTable("items", (t) => {
+    return t
+      .addColumn("id", idColumn())
+      .addColumn("name", column("string"))
+      .addColumn("slug", column("varchar(64)"))
+      .addColumn("count", column("integer"))
+      .addColumn("isActive", column("bool"))
+      .addColumn("createdAt", column("timestamp"))
+      .createIndex("items_slug_idx", ["slug"], { unique: true });
+  });
+});
+
+type Dialect = "postgresql" | "mysql" | "sqlite";
+
+type NormalizationRule = {
+  reason: string;
+  apply: (sql: string, dialect: Dialect) => string;
+};
+
+const NORMALIZATION_RULES: NormalizationRule[] = [
+  {
+    reason: "Whitespace/semicolons don't change SQL semantics; normalize for stable comparisons.",
+    apply: (sql) => sql.replace(/;\s*$/g, "").trim().replace(/\s+/g, " "),
+  },
+  {
+    reason: "Identifier quoting style differs by dialect/formatter but is semantically equivalent.",
+    apply: (sql) => sql.replace(/["`]/g, ""),
+  },
+  {
+    reason: "Extra spaces around parentheses are formatting-only.",
+    apply: (sql) => sql.replace(/\(\s+/g, "(").replace(/\s+\)/g, ")"),
+  },
+  {
+    reason: "Case is not semantically meaningful for SQL keywords/identifiers here.",
+    apply: (sql) => sql.toLowerCase(),
+  },
+  {
+    reason: "now() and CURRENT_TIMESTAMP are equivalent default expressions in these dialects.",
+    apply: (sql) => sql.replace(/\bnow\(\)/g, "current_timestamp"),
+  },
+  {
+    reason: "Column constraint order doesn't change meaning; standardize ordering.",
+    apply: (sql) => sql.replace(/\bprimary key not null\b/g, "not null primary key"),
+  },
+  {
+    reason: "SQLite autoincrement PK constraint order doesn't change meaning.",
+    apply: (sql) =>
+      sql.replace(/\bprimary key autoincrement not null\b/g, "not null primary key autoincrement"),
+  },
+  {
+    reason: "Default value and NOT NULL order is equivalent in DDL.",
+    apply: (sql) => sql.replace(/\bdefault\s+([^\s,]+)\s+not null\b/g, "not null default $1"),
+  },
+  {
+    reason: "MySQL allows reordering AUTO_INCREMENT/NOT NULL/PRIMARY KEY without meaning change.",
+    apply: (sql) =>
+      sql.replace(
+        /\bauto_increment not null primary key\b/g,
+        "not null primary key auto_increment",
+      ),
+  },
+  {
+    // In PostgreSQL, NO ACTION and RESTRICT behave the same for immediate constraints,
+    // but they can differ with deferrable constraints: NO ACTION can be deferred, RESTRICT is always enforced
+    // immediately. So treating them as equivalent is only safe if we’re not using deferrable constraints (which we
+    // aren’t in these migrations).
+    reason:
+      "Postgres FK action defaults to NO ACTION; Fragno uses RESTRICT. Treat as equivalent for DDL parity.",
+    apply: (sql) =>
+      sql
+        .replace(/\bon delete no action\b/g, "on delete restrict")
+        .replace(/\bon update no action\b/g, "on update restrict"),
+  },
+  {
+    reason: "Postgres implicit public schema qualifiers are redundant in migrations.",
+    apply: (sql, dialect) => (dialect === "postgresql" ? sql.replace(/\bpublic\./g, "") : sql),
+  },
+  {
+    reason: "Postgres index method defaults to btree; explicit USING btree is redundant.",
+    apply: (sql, dialect) =>
+      dialect === "postgresql" ? sql.replace(/\s+using\s+btree\b/g, "") : sql,
+  },
+  {
+    reason: "MySQL 'integer' and 'int' are synonyms; normalize for comparisons.",
+    apply: (sql, dialect) => (dialect === "mysql" ? sql.replace(/\binteger\b/g, "int") : sql),
+  },
+];
+
+function normalizeSql(sql: string, dialect: Dialect): string {
+  let normalized = sql;
+  for (const rule of NORMALIZATION_RULES) {
+    normalized = rule.apply(normalized, dialect);
+  }
+  return normalized;
+}
+
+function normalizeStatements(statements: string[], dialect: Dialect): string[] {
+  const normalized: string[] = [];
+  const uniqueIdTables = new Set<string>();
+
+  for (const statement of statements) {
+    let sql = normalizeSql(statement, dialect);
+    if (!sql) {
+      continue;
+    }
+
+    // Canonicalize external-id uniqueness across representations.
+    if (sql.startsWith("create table ")) {
+      const tableMatch = sql.match(/^create table\s+(\w+)\s*\(/);
+      const tableName = tableMatch?.[1];
+
+      if (tableName) {
+        const idUniqueRegex = /\bid\b([^,]*?)\bunique\b/;
+        if (idUniqueRegex.test(sql)) {
+          uniqueIdTables.add(tableName);
+          sql = sql.replace(idUniqueRegex, "id$1");
+        }
+
+        const tableUniqueRegex = /,\s*constraint\s+\w+\s+unique\s*\(\s*id\s*\)/g;
+        if (tableUniqueRegex.test(sql)) {
+          uniqueIdTables.add(tableName);
+          sql = sql.replace(tableUniqueRegex, "");
+        }
+      }
+    }
+
+    const uniqueIndexMatch = sql.match(/^create unique index\s+\w+\s+on\s+(\w+)\s*\(\s*id\s*\)/);
+    if (uniqueIndexMatch) {
+      uniqueIdTables.add(uniqueIndexMatch[1]);
+      continue;
+    }
+
+    sql = sql.replace(/\s+/g, " ").replace(/\s+,/g, ",").trim();
+
+    if (dialect === "mysql" && sql.startsWith("create table ")) {
+      const tableMatch = sql.match(/^create table\s+(\w+)\s*\(/);
+      const tableName = tableMatch?.[1];
+      let pkColumn: string | undefined;
+
+      if (tableName) {
+        const uniqueRegex = /constraint\s+(\w+)\s+unique\s*\(([^)]+)\)/g;
+        let match: RegExpExecArray | null;
+        while ((match = uniqueRegex.exec(sql))) {
+          normalized.push(`create unique index ${match[1]} on ${tableName} (${match[2]})`);
+        }
+
+        const pkMatch = sql.match(/constraint\s+\w+\s+primary key\s*\(([^)]+)\)/);
+        if (pkMatch) {
+          pkColumn = pkMatch[1].trim();
+        }
+      }
+
+      sql = sql.replace(/,\s*constraint\s+\w+\s+unique\s*\([^)]+\)/g, "");
+      sql = sql.replace(/,\s*constraint\s+\w+\s+primary key\s*\([^)]+\)/g, "");
+      sql = sql.replace(/\s+,/g, ",").replace(/,\s+\)/g, ")");
+
+      if (pkColumn) {
+        const pkRegex = new RegExp(`\\b${pkColumn}\\b([^,]*?)\\bprimary key\\b`);
+        if (!pkRegex.test(sql)) {
+          const columnRegex = new RegExp(`\\b${pkColumn}\\b([^,]*?)\\bnot null\\b`);
+          sql = sql.replace(columnRegex, `${pkColumn}$1not null primary key`);
+        }
+      }
+
+      sql = sql.replace(
+        /\bauto_increment not null primary key\b/g,
+        "not null primary key auto_increment",
+      );
+    }
+
+    normalized.push(sql);
+  }
+
+  for (const tableName of uniqueIdTables) {
+    normalized.push(`__unique__ ${tableName}.id`);
+  }
+
+  return normalized.sort();
+}
+
+function isNonDdlStatement(statement: string): boolean {
+  const trimmed = statement.trim().toLowerCase();
+  return (
+    trimmed.startsWith("pragma defer_foreign_keys") || trimmed.startsWith("set foreign_key_checks")
+  );
+}
+
+async function getDrizzleMigrationSql(dialect: Dialect): Promise<string[]> {
+  const result = await writeAndLoadSchema(
+    `drizzle-kit-parity-${dialect}`,
+    paritySchema,
+    dialect,
+    "",
+    false,
+  );
+
+  try {
+    const schemaModule = await import(`${result.schemaFilePath}?t=${Date.now()}`);
+    let migrationStatements: string[];
+
+    if (dialect === "postgresql") {
+      migrationStatements = await generateMigration(
+        generateDrizzleJson({}),
+        generateDrizzleJson(schemaModule),
+      );
+    } else if (dialect === "sqlite") {
+      migrationStatements = await generateSQLiteMigration(
+        await generateSQLiteDrizzleJson({}),
+        await generateSQLiteDrizzleJson(schemaModule),
+      );
+    } else {
+      migrationStatements = await generateMySQLMigration(
+        await generateMySQLDrizzleJson({}),
+        await generateMySQLDrizzleJson(schemaModule),
+      );
+    }
+
+    return migrationStatements.filter((statement) => !isNonDdlStatement(statement));
+  } finally {
+    await result.cleanup();
+  }
+}
+
+function getKyselyMigrationSql(dialect: Dialect): string[] {
+  const prepared = createPreparedMigrations({
+    schema: paritySchema,
+    namespace: "",
+    database: dialect,
+    updateVersionInMigration: false,
+  });
+
+  const statements = prepared
+    .compile(0, paritySchema.version, { updateVersionInMigration: false })
+    .statements.map((statement) => statement.sql);
+
+  return statements.filter((statement) => !isNonDdlStatement(statement));
+}
+
+describe("drizzle-kit migrations match generic SQL DDL", () => {
+  const cases: Dialect[] = ["postgresql", "sqlite", "mysql"];
+
+  for (const dialect of cases) {
+    it(`matches DDL for ${dialect}`, async () => {
+      const drizzleSql = await getDrizzleMigrationSql(dialect);
+      const kyselySql = getKyselyMigrationSql(dialect);
+
+      const normalizedDrizzle = normalizeStatements(drizzleSql, dialect);
+      const normalizedKysely = normalizeStatements(kyselySql, dialect);
+
+      for (const [index, statement] of normalizedDrizzle.entries()) {
+        expect(statement).toEqual(normalizedKysely[index]);
+      }
+    });
+  }
+});

--- a/packages/fragno-db/src/adapters/drizzle/test-utils.ts
+++ b/packages/fragno-db/src/adapters/drizzle/test-utils.ts
@@ -20,6 +20,7 @@ export async function writeAndLoadSchema(
   schema: Schema,
   dialect: SupportedProvider,
   namespace?: string,
+  includeInternalSchema: boolean = true,
 ) {
   // Create test-specific directory inside _generated
   const baseDir = join(import.meta.dirname, "_generated");
@@ -41,9 +42,11 @@ export async function writeAndLoadSchema(
   // Generate and write the Drizzle schema to file
   // Always include settings schema first (as done in generation-engine.ts), then the test schema
   // De-duplicate: if the test schema IS the settings schema, don't add it twice
-  const fragments: Array<{ namespace: string; schema: Schema }> = [
-    { namespace: "", schema: internalSchema },
-  ];
+  const fragments: Array<{ namespace: string; schema: Schema }> = [];
+
+  if (includeInternalSchema) {
+    fragments.push({ namespace: "", schema: internalSchema });
+  }
 
   if (schema !== internalSchema) {
     fragments.push({ namespace: namespace ?? "", schema });

--- a/packages/fragno-db/src/adapters/generic-sql/migration/adapter-migration-parity.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/adapter-migration-parity.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  DummyDriver,
+  MysqlAdapter,
+  MysqlQueryCompiler,
+  PostgresAdapter,
+  PostgresQueryCompiler,
+  SqliteAdapter,
+  SqliteQueryCompiler,
+} from "kysely";
+import { KyselyAdapter } from "../../kysely/kysely-adapter";
+import { DrizzleAdapter } from "../../drizzle/drizzle-adapter";
+import type { Dialect } from "../../../sql-driver/sql-driver";
+import {
+  MySQL2DriverConfig,
+  NodePostgresDriverConfig,
+  SQLocalDriverConfig,
+} from "../driver-config";
+import { column, idColumn, referenceColumn, schema } from "../../../schema/create";
+
+const paritySchema = schema((s) => {
+  return s
+    .addTable("users", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("email", column("string"))
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .createIndex("users_email_idx", ["email"], { unique: true });
+    })
+    .alterTable("users", (t) => {
+      return t.addColumn("age", column("integer").nullable()).createIndex("users_age_idx", ["age"]);
+    })
+    .addTable("posts", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("authorId", referenceColumn())
+        .addColumn("title", column("string"))
+        .addColumn("isPublished", column("bool").defaultTo(false))
+        .createIndex("posts_author_idx", ["authorId"]);
+    })
+    .addReference("author", {
+      type: "one",
+      from: { table: "posts", column: "authorId" },
+      to: { table: "users", column: "id" },
+    });
+});
+
+function createDummyDialect(database: "postgresql" | "mysql" | "sqlite"): Dialect {
+  switch (database) {
+    case "postgresql":
+      return {
+        createAdapter: () => new PostgresAdapter(),
+        createDriver: () => new DummyDriver(),
+        createQueryCompiler: () => new PostgresQueryCompiler(),
+      };
+    case "mysql":
+      return {
+        createAdapter: () => new MysqlAdapter(),
+        createDriver: () => new DummyDriver(),
+        createQueryCompiler: () => new MysqlQueryCompiler(),
+      };
+    case "sqlite":
+      return {
+        createAdapter: () => new SqliteAdapter(),
+        createDriver: () => new DummyDriver(),
+        createQueryCompiler: () => new SqliteQueryCompiler(),
+      };
+  }
+}
+
+function getMigrationSql(adapter: KyselyAdapter | DrizzleAdapter, namespace: string): string[] {
+  const prepared = adapter.prepareMigrations(paritySchema, namespace);
+  const migration = prepared.compile(0, paritySchema.version, {
+    updateVersionInMigration: false,
+  });
+  return migration.statements.map((statement) => statement.sql);
+}
+
+describe("migration SQL parity across adapters", () => {
+  const cases = [
+    {
+      name: "postgresql",
+      driverConfig: new NodePostgresDriverConfig(),
+    },
+    {
+      name: "sqlite",
+      driverConfig: new SQLocalDriverConfig(),
+    },
+    {
+      name: "mysql",
+      driverConfig: new MySQL2DriverConfig(),
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    it(`generates identical SQL for ${testCase.name}`, () => {
+      const dialect = createDummyDialect(testCase.name);
+      const namespace = "parity";
+
+      const kyselyAdapter = new KyselyAdapter({
+        dialect,
+        driverConfig: testCase.driverConfig,
+      });
+      const drizzleAdapter = new DrizzleAdapter({
+        dialect,
+        driverConfig: testCase.driverConfig,
+      });
+
+      const kyselySql = getMigrationSql(kyselyAdapter, namespace);
+      const drizzleSql = getMigrationSql(drizzleAdapter, namespace);
+
+      console.log(kyselySql);
+
+      expect(kyselySql).toEqual(drizzleSql);
+    });
+  }
+});


### PR DESCRIPTION
Tests: add drizzle-kit migration parity coverage across adapters

Tests: add generic adapter SQL migration parity checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed database schema generation to properly enforce unique constraints on external ID columns. This now works consistently across PostgreSQL, MySQL, and SQLite, preventing duplicate identifiers in your database.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->