### PR TITLE
fix(db): align migration SQL naming and defaults with Drizzle

### DIFF
--- a/.changeset/mighty-taxis-rescue.md
+++ b/.changeset/mighty-taxis-rescue.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+fix(db): align GenericSQL migration defaults and constraint names with Drizzle output.

--- a/packages/fragno-db/src/adapters/drizzle/generate.ts
+++ b/packages/fragno-db/src/adapters/drizzle/generate.ts
@@ -224,7 +224,7 @@ function mapDBTypeToDrizzleFunction(
       case "text":
         // Check if it's JSON
         if (column.type === "json") {
-          return { name: "blob", params: [`{ mode: "json" }`] };
+          return { name: "text", params: [`{ mode: "json" }`] };
         }
         return { name: "text" };
       case "real":
@@ -315,7 +315,12 @@ function generateColumnDefinition(
     } else if ("dbSpecial" in column.default) {
       // Database-level special functions: defaultTo(b => b.now())
       if (column.default.dbSpecial === "now") {
-        parts.push("defaultNow()");
+        if (ctx.provider === "mysql") {
+          ctx.imports.addImport("sql", "drizzle-orm");
+          parts.push("default(sql`(now())`)");
+        } else {
+          parts.push("defaultNow()");
+        }
       }
     } else if ("runtime" in column.default) {
       // Runtime defaults: defaultTo$()

--- a/packages/fragno-db/src/adapters/drizzle/migration-parity-drizzle-kit.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/migration-parity-drizzle-kit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createRequire } from "node:module";
-import { column, idColumn, schema } from "../../schema/create";
+import { column, idColumn, referenceColumn, schema } from "../../schema/create";
 import { writeAndLoadSchema } from "./test-utils";
 import { createPreparedMigrations } from "../generic-sql/migration/prepared-migrations";
 
@@ -15,16 +15,94 @@ const {
 } = require("drizzle-kit/api") as typeof import("drizzle-kit/api");
 
 const paritySchema = schema((s) => {
-  return s.addTable("items", (t) => {
-    return t
-      .addColumn("id", idColumn())
-      .addColumn("name", column("string"))
-      .addColumn("slug", column("varchar(64)"))
-      .addColumn("count", column("integer"))
-      .addColumn("isActive", column("bool"))
-      .addColumn("createdAt", column("timestamp"))
-      .createIndex("items_slug_idx", ["slug"], { unique: true });
-  });
+  return s
+    .addTable("users", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("email", column("varchar(255)"))
+        .addColumn("name", column("string"))
+        .addColumn("status", column("varchar(32)").defaultTo("active"))
+        .addColumn("isActive", column("bool").defaultTo(true))
+        .addColumn("loginCount", column("integer").defaultTo(0))
+        .addColumn("bigCounter", column("bigint"))
+        .addColumn("score", column("decimal").defaultTo(0))
+        .addColumn("profile", column("json").nullable())
+        .addColumn("avatar", column("binary").nullable())
+        .addColumn("birthday", column("date").nullable())
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .addColumn(
+          "updatedAt",
+          column("timestamp").defaultTo$((b) => b.now()),
+        )
+        .createIndex("users_email_idx", ["email"], { unique: true })
+        .createIndex("users_status_idx", ["status"]);
+    })
+    .addTable("posts", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("title", column("string"))
+        .addColumn("slug", column("varchar(64)"))
+        .addColumn("body", column("string"))
+        .addColumn("published", column("bool").defaultTo(false))
+        .addColumn("publishedAt", column("timestamp").nullable())
+        .addColumn("authorId", referenceColumn())
+        .addColumn("metadata", column("json").nullable())
+        .addColumn("rating", column("decimal").nullable())
+        .addColumn("contentHash", column("binary").nullable())
+        .createIndex("posts_slug_idx", ["slug"], { unique: true })
+        .createIndex("posts_author_idx", ["authorId"])
+        .createIndex("posts_author_title_idx", ["authorId", "title"], { unique: true });
+    })
+    .addTable("tags", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("label", column("string"))
+        .addColumn("slug", column("varchar(32)"))
+        .createIndex("tags_slug_idx", ["slug"], { unique: true });
+    })
+    .addTable("postTags", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("postId", referenceColumn())
+        .addColumn("tagId", referenceColumn())
+        .addColumn(
+          "addedAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .createIndex("post_tags_post_idx", ["postId"])
+        .createIndex("post_tags_tag_idx", ["tagId"])
+        .createIndex("post_tags_unique_idx", ["postId", "tagId"], { unique: true });
+    })
+    .addTable("categories", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("name", column("string"))
+        .addColumn("parentId", referenceColumn().nullable())
+        .createIndex("categories_parent_idx", ["parentId"]);
+    })
+    .addReference("posts_author", {
+      type: "one",
+      from: { table: "posts", column: "authorId" },
+      to: { table: "users", column: "id" },
+    })
+    .addReference("post_tags_post", {
+      type: "one",
+      from: { table: "postTags", column: "postId" },
+      to: { table: "posts", column: "id" },
+    })
+    .addReference("post_tags_tag", {
+      type: "one",
+      from: { table: "postTags", column: "tagId" },
+      to: { table: "tags", column: "id" },
+    })
+    .addReference("categories_parent", {
+      type: "one",
+      from: { table: "categories", column: "parentId" },
+      to: { table: "categories", column: "id" },
+    });
 });
 
 type Dialect = "postgresql" | "mysql" | "sqlite";
@@ -32,6 +110,19 @@ type Dialect = "postgresql" | "mysql" | "sqlite";
 type NormalizationRule = {
   reason: string;
   apply: (sql: string, dialect: Dialect) => string;
+};
+
+type StatementNormalizationContext = {
+  dialect: Dialect;
+  uniqueIdTables: Set<string>;
+  foreignKeys: Set<string>;
+  extraStatements: string[];
+  nameMarkers: string[];
+};
+
+type StatementNormalizationRule = {
+  reason: string;
+  apply: (sql: string, ctx: StatementNormalizationContext) => string | null;
 };
 
 const NORMALIZATION_RULES: NormalizationRule[] = [
@@ -54,6 +145,10 @@ const NORMALIZATION_RULES: NormalizationRule[] = [
   {
     reason: "now() and CURRENT_TIMESTAMP are equivalent default expressions in these dialects.",
     apply: (sql) => sql.replace(/\bnow\(\)/g, "current_timestamp"),
+  },
+  {
+    reason: "DEFAULT (current_timestamp) is equivalent to DEFAULT current_timestamp.",
+    apply: (sql) => sql.replace(/\bdefault\s+\(current_timestamp\)/g, "default current_timestamp"),
   },
   {
     reason: "Column constraint order doesn't change meaning; standardize ordering.",
@@ -101,6 +196,234 @@ const NORMALIZATION_RULES: NormalizationRule[] = [
     reason: "MySQL 'integer' and 'int' are synonyms; normalize for comparisons.",
     apply: (sql, dialect) => (dialect === "mysql" ? sql.replace(/\binteger\b/g, "int") : sql),
   },
+  {
+    reason: "Postgres 'numeric' and 'decimal' are synonyms; normalize for comparisons.",
+    apply: (sql, dialect) =>
+      dialect === "postgresql" ? sql.replace(/\bnumeric\b/g, "decimal") : sql,
+  },
+];
+
+const STATEMENT_NORMALIZATION_RULES: StatementNormalizationRule[] = [
+  {
+    reason:
+      "External-id uniqueness can appear as column UNIQUE or a table-level UNIQUE(id); normalize to markers.",
+    apply: (sql, ctx) => {
+      if (!sql.startsWith("create table ")) {
+        return sql;
+      }
+
+      const tableMatch = sql.match(/^create table\s+(\w+)\s*\(/);
+      const tableName = tableMatch?.[1];
+      if (!tableName) {
+        return sql;
+      }
+
+      const idUniqueRegex = /\bid\b([^,]*?)\bunique\b/;
+      if (idUniqueRegex.test(sql)) {
+        ctx.uniqueIdTables.add(tableName);
+        sql = sql.replace(idUniqueRegex, "id$1");
+      }
+
+      const tableUniqueRegex = /,\s*constraint\s+\w+\s+unique\s*\(\s*id\s*\)/g;
+      if (tableUniqueRegex.test(sql)) {
+        ctx.uniqueIdTables.add(tableName);
+        sql = sql.replace(tableUniqueRegex, "");
+      }
+
+      return sql;
+    },
+  },
+  {
+    reason:
+      "SQLite emits inline FK constraints on CREATE TABLE; normalize them to markers for parity.",
+    apply: (sql, ctx) => {
+      if (!sql.startsWith("create table ") || !sql.includes(" foreign key ")) {
+        return sql;
+      }
+
+      const tableMatch = sql.match(/^create table\s+(\w+)\s*\(/);
+      const tableName = tableMatch?.[1];
+      if (!tableName) {
+        return sql;
+      }
+
+      const fkRegex =
+        /,\s*(?:constraint\s+(\w+)\s+)?foreign key\s*\(([^)]+)\)\s+references\s+(\w+)\s*\(([^)]+)\)(?:\s+on delete\s+(\w+))?(?:\s+on update\s+(\w+))?/g;
+
+      let match: RegExpExecArray | null;
+      while ((match = fkRegex.exec(sql))) {
+        const constraintName = match[1]?.trim();
+        const columns = match[2].replace(/\s+/g, " ").trim();
+        const referencedTable = match[3].trim();
+        const referencedColumns = match[4].replace(/\s+/g, " ").trim();
+        const onDelete = (match[5] ?? "restrict").trim();
+        const onUpdate = (match[6] ?? "restrict").trim();
+        ctx.foreignKeys.add(
+          `__fk__ ${tableName}(${columns})->${referencedTable}(${referencedColumns}) on delete ${onDelete} on update ${onUpdate}`,
+        );
+        if (constraintName) {
+          ctx.nameMarkers.push(
+            `__fkname__ ${tableName}.${constraintName}(${columns})->${referencedTable}(${referencedColumns}) on delete ${onDelete} on update ${onUpdate}`,
+          );
+        }
+      }
+
+      return sql.replace(fkRegex, "");
+    },
+  },
+  {
+    reason: "Drizzle can emit inline column REFERENCES; normalize these to FK markers for parity.",
+    apply: (sql, ctx) => {
+      if (!sql.startsWith("create table ") || !sql.includes(" references ")) {
+        return sql;
+      }
+
+      const tableMatch = sql.match(/^create table\s+(\w+)\s*\(/);
+      const tableName = tableMatch?.[1];
+      if (!tableName) {
+        return sql;
+      }
+
+      const referencesRegex =
+        /\b(\w+)\b([^,]*?)\s+references\s+(\w+)\s*\(([^)]+)\)(?:\s+on delete\s+(\w+))?(?:\s+on update\s+(\w+))?/g;
+      let match: RegExpExecArray | null;
+
+      while ((match = referencesRegex.exec(sql))) {
+        const columnName = match[1].trim();
+        const referencedTable = match[3].trim();
+        const referencedColumns = match[4].replace(/\s+/g, " ").trim();
+        const onDelete = (match[5] ?? "restrict").trim();
+        const onUpdate = (match[6] ?? "restrict").trim();
+        ctx.foreignKeys.add(
+          `__fk__ ${tableName}(${columnName})->${referencedTable}(${referencedColumns}) on delete ${onDelete} on update ${onUpdate}`,
+        );
+      }
+
+      return sql.replace(referencesRegex, "$1$2");
+    },
+  },
+  {
+    reason:
+      "FK action clauses without any remaining FK/REFERENCES are orphaned; strip to avoid false diffs.",
+    apply: (sql) => {
+      if (
+        sql.startsWith("create table ") &&
+        !sql.includes(" references ") &&
+        !sql.includes(" foreign key ") &&
+        sql.includes(" on delete ")
+      ) {
+        return sql.replace(/\s+on delete\s+\w+/g, "").replace(/\s+on update\s+\w+/g, "");
+      }
+      return sql;
+    },
+  },
+  {
+    reason: "ALTER TABLE ADD FOREIGN KEY is equivalent to inline FK markers; normalize and drop.",
+    apply: (sql, ctx) => {
+      if (!sql.startsWith("alter table ") || !sql.includes(" foreign key ")) {
+        return sql;
+      }
+
+      const tableMatch = sql.match(/^alter table\s+(\w+)\s+/);
+      const tableName = tableMatch?.[1];
+      const fkRegex =
+        /(?:constraint\s+(\w+)\s+)?foreign key\s*\(([^)]+)\)\s+references\s+(\w+)\s*\(([^)]+)\)(?:\s+on delete\s+(\w+))?(?:\s+on update\s+(\w+))?/g;
+
+      if (tableName) {
+        let match: RegExpExecArray | null;
+        while ((match = fkRegex.exec(sql))) {
+          const constraintName = match[1]?.trim();
+          const columns = match[2].replace(/\s+/g, " ").trim();
+          const referencedTable = match[3].trim();
+          const referencedColumns = match[4].replace(/\s+/g, " ").trim();
+          const onDelete = (match[5] ?? "restrict").trim();
+          const onUpdate = (match[6] ?? "restrict").trim();
+          ctx.foreignKeys.add(
+            `__fk__ ${tableName}(${columns})->${referencedTable}(${referencedColumns}) on delete ${onDelete} on update ${onUpdate}`,
+          );
+          if (constraintName) {
+            ctx.nameMarkers.push(
+              `__fkname__ ${tableName}.${constraintName}(${columns})->${referencedTable}(${referencedColumns}) on delete ${onDelete} on update ${onUpdate}`,
+            );
+          }
+        }
+      }
+
+      return null;
+    },
+  },
+  {
+    reason:
+      "Some adapters emit a dedicated unique index for external IDs; normalize to external-id markers.",
+    apply: (sql, ctx) => {
+      const uniqueIndexMatch = sql.match(/^create unique index\s+\w+\s+on\s+(\w+)\s*\(\s*id\s*\)/);
+      if (!uniqueIndexMatch) {
+        return sql;
+      }
+
+      ctx.uniqueIdTables.add(uniqueIndexMatch[1]);
+      return null;
+    },
+  },
+  {
+    reason:
+      "MySQL inline constraints are semantically equivalent to separate statements; normalize to indexes and column PK.",
+    apply: (sql, ctx) => {
+      if (ctx.dialect !== "mysql" || !sql.startsWith("create table ")) {
+        return sql;
+      }
+
+      const tableMatch = sql.match(/^create table\s+(\w+)\s*\(/);
+      const tableName = tableMatch?.[1];
+      let pkColumn: string | undefined;
+      let pkConstraintName: string | undefined;
+
+      if (tableName) {
+        const uniqueRegex = /constraint\s+(\w+)\s+unique\s*\(([^)]+)\)/g;
+        let match: RegExpExecArray | null;
+        while ((match = uniqueRegex.exec(sql))) {
+          ctx.extraStatements.push(`create unique index ${match[1]} on ${tableName} (${match[2]})`);
+        }
+
+        const pkMatch = sql.match(/constraint\s+(\w+)\s+primary key\s*\(([^)]+)\)/);
+        if (pkMatch) {
+          pkConstraintName = pkMatch[1].trim();
+          pkColumn = pkMatch[2].trim();
+        }
+      }
+
+      sql = sql.replace(/,\s*constraint\s+\w+\s+unique\s*\([^)]+\)/g, "");
+      sql = sql.replace(/,\s*constraint\s+\w+\s+primary key\s*\([^)]+\)/g, "");
+      sql = sql.replace(/\s+,/g, ",").replace(/,\s+\)/g, ")");
+
+      if (pkColumn) {
+        if (tableName && pkConstraintName) {
+          ctx.nameMarkers.push(`__pkname__ ${tableName}.${pkConstraintName}(${pkColumn})`);
+        }
+
+        const pkRegex = new RegExp(`\\b${pkColumn}\\b([^,]*?)\\bprimary key\\b`);
+        if (!pkRegex.test(sql)) {
+          const columnRegex = new RegExp(`\\b${pkColumn}\\b([^,]*?)\\bnot null\\b`);
+          sql = sql.replace(columnRegex, `${pkColumn}$1not null primary key`);
+        }
+      }
+
+      return sql.replace(
+        /\bauto_increment not null primary key\b/g,
+        "not null primary key auto_increment",
+      );
+    },
+  },
+  {
+    reason: "Normalize commas/spaces for deterministic statement ordering.",
+    apply: (sql) =>
+      sql
+        .replace(/\s+/g, " ")
+        .replace(/\s+,/g, ",")
+        .replace(/,\s+/g, ",")
+        .replace(/,\s*\)/g, ")")
+        .trim(),
+  },
 ];
 
 function normalizeSql(sql: string, dialect: Dialect): string {
@@ -111,85 +434,70 @@ function normalizeSql(sql: string, dialect: Dialect): string {
   return normalized;
 }
 
+function applyStatementNormalization(
+  sql: string,
+  ctx: StatementNormalizationContext,
+): string | null {
+  let normalized = sql;
+  for (const rule of STATEMENT_NORMALIZATION_RULES) {
+    const next = rule.apply(normalized, ctx);
+    if (next === null) {
+      return null;
+    }
+    normalized = next;
+  }
+  return normalized;
+}
+
 function normalizeStatements(statements: string[], dialect: Dialect): string[] {
   const normalized: string[] = [];
-  const uniqueIdTables = new Set<string>();
+  const context: StatementNormalizationContext = {
+    dialect,
+    uniqueIdTables: new Set<string>(),
+    foreignKeys: new Set<string>(),
+    extraStatements: [],
+    nameMarkers: [],
+  };
 
   for (const statement of statements) {
-    let sql = normalizeSql(statement, dialect);
+    const normalizedSql = normalizeSql(statement, dialect);
+    let sql = normalizedSql;
     if (!sql) {
       continue;
     }
 
-    // Canonicalize external-id uniqueness across representations.
-    if (sql.startsWith("create table ")) {
-      const tableMatch = sql.match(/^create table\s+(\w+)\s*\(/);
-      const tableName = tableMatch?.[1];
-
-      if (tableName) {
-        const idUniqueRegex = /\bid\b([^,]*?)\bunique\b/;
-        if (idUniqueRegex.test(sql)) {
-          uniqueIdTables.add(tableName);
-          sql = sql.replace(idUniqueRegex, "id$1");
-        }
-
-        const tableUniqueRegex = /,\s*constraint\s+\w+\s+unique\s*\(\s*id\s*\)/g;
-        if (tableUniqueRegex.test(sql)) {
-          uniqueIdTables.add(tableName);
-          sql = sql.replace(tableUniqueRegex, "");
-        }
-      }
+    const normalizedStatement = applyStatementNormalization(sql, context);
+    if (normalizedStatement) {
+      normalized.push(normalizedStatement);
     }
-
-    const uniqueIndexMatch = sql.match(/^create unique index\s+\w+\s+on\s+(\w+)\s*\(\s*id\s*\)/);
-    if (uniqueIndexMatch) {
-      uniqueIdTables.add(uniqueIndexMatch[1]);
-      continue;
-    }
-
-    sql = sql.replace(/\s+/g, " ").replace(/\s+,/g, ",").trim();
-
-    if (dialect === "mysql" && sql.startsWith("create table ")) {
-      const tableMatch = sql.match(/^create table\s+(\w+)\s*\(/);
-      const tableName = tableMatch?.[1];
-      let pkColumn: string | undefined;
-
-      if (tableName) {
-        const uniqueRegex = /constraint\s+(\w+)\s+unique\s*\(([^)]+)\)/g;
-        let match: RegExpExecArray | null;
-        while ((match = uniqueRegex.exec(sql))) {
-          normalized.push(`create unique index ${match[1]} on ${tableName} (${match[2]})`);
-        }
-
-        const pkMatch = sql.match(/constraint\s+\w+\s+primary key\s*\(([^)]+)\)/);
-        if (pkMatch) {
-          pkColumn = pkMatch[1].trim();
-        }
-      }
-
-      sql = sql.replace(/,\s*constraint\s+\w+\s+unique\s*\([^)]+\)/g, "");
-      sql = sql.replace(/,\s*constraint\s+\w+\s+primary key\s*\([^)]+\)/g, "");
-      sql = sql.replace(/\s+,/g, ",").replace(/,\s+\)/g, ")");
-
-      if (pkColumn) {
-        const pkRegex = new RegExp(`\\b${pkColumn}\\b([^,]*?)\\bprimary key\\b`);
-        if (!pkRegex.test(sql)) {
-          const columnRegex = new RegExp(`\\b${pkColumn}\\b([^,]*?)\\bnot null\\b`);
-          sql = sql.replace(columnRegex, `${pkColumn}$1not null primary key`);
-        }
-      }
-
-      sql = sql.replace(
-        /\bauto_increment not null primary key\b/g,
-        "not null primary key auto_increment",
-      );
-    }
-
-    normalized.push(sql);
   }
 
-  for (const tableName of uniqueIdTables) {
+  for (const tableName of context.uniqueIdTables) {
     normalized.push(`__unique__ ${tableName}.id`);
+  }
+
+  for (const fk of context.foreignKeys) {
+    normalized.push(fk);
+  }
+
+  for (const marker of context.nameMarkers) {
+    const normalizedMarker = applyStatementNormalization(
+      normalizeSql(marker, context.dialect),
+      context,
+    );
+    if (normalizedMarker) {
+      normalized.push(normalizedMarker);
+    }
+  }
+
+  for (const extra of context.extraStatements) {
+    const normalizedExtra = applyStatementNormalization(
+      normalizeSql(extra, context.dialect),
+      context,
+    );
+    if (normalizedExtra) {
+      normalized.push(normalizedExtra);
+    }
   }
 
   return normalized.sort();
@@ -267,6 +575,7 @@ describe("drizzle-kit migrations match generic SQL DDL", () => {
       for (const [index, statement] of normalizedDrizzle.entries()) {
         expect(statement).toEqual(normalizedKysely[index]);
       }
+      expect(normalizedDrizzle.length).toEqual(normalizedKysely.length);
     });
   }
 });

--- a/packages/fragno-db/src/adapters/generic-sql/migration/dialect/mysql.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/dialect/mysql.test.ts
@@ -194,7 +194,7 @@ describe("MySQLSQLGenerator", () => {
 
       const sql = compileOne(operation);
       expect(sql).toMatchInlineSnapshot(
-        `"create table \`users\` (\`_internalId\` bigint not null primary key auto_increment, \`name\` text not null)"`,
+        `"create table \`users\` (\`_internalId\` bigint not null  auto_increment, \`name\` text not null, constraint \`users__internalId\` primary key (\`_internalId\`))"`,
       );
     });
   });

--- a/packages/fragno-db/src/adapters/generic-sql/migration/dialect/sqlite.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/dialect/sqlite.test.ts
@@ -166,7 +166,7 @@ describe("SQLiteSQLGenerator", () => {
 
       const sql = compileOne(operation);
       expect(sql).toMatchInlineSnapshot(
-        `"create table "timestamps_test" ("id" integer not null unique, "created_at" integer default CURRENT_TIMESTAMP not null)"`,
+        `"create table "timestamps_test" ("id" integer not null unique, "created_at" integer default (cast((julianday('now') - 2440587.5)*86400000 as integer)) not null)"`,
       );
     });
 
@@ -975,7 +975,6 @@ describe("SQLiteSQLGenerator", () => {
 
       // Posts table should contain inline FK constraint
       const postsSql = statements[2].sql;
-      expect(postsSql).toContain("posts_users_author_fk");
       expect(postsSql).toContain("foreign key");
       expect(postsSql).toContain("author_id");
       expect(postsSql).toContain("references");

--- a/packages/fragno-db/src/adapters/generic-sql/migration/prepared-migrations.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/prepared-migrations.test.ts
@@ -200,7 +200,7 @@ describe("PreparedMigrations - SQLite FK Merging", () => {
       `"create table "users_test" ("id" text not null unique)"`,
     );
     expect(statements[2].sql).toMatchInlineSnapshot(
-      `"create table "posts_test" ("id" text not null unique, "authorId" integer not null, constraint "posts_users_author_fk" foreign key ("authorId") references "users_test" ("_internalId") on delete restrict on update restrict)"`,
+      `"create table "posts_test" ("id" text not null unique, "authorId" integer not null, foreign key ("authorId") references "users_test" ("_internalId") on delete restrict on update restrict)"`,
     );
   });
 
@@ -286,7 +286,7 @@ describe("PreparedMigrations - MySQL", () => {
     expect(statements.length).toBe(3);
     expect(statements[0].sql).toMatchInlineSnapshot(`"SET FOREIGN_KEY_CHECKS = 0"`);
     expect(statements[1].sql).toMatchInlineSnapshot(
-      `"create table \`users\` (\`_internalId\` bigint not null primary key auto_increment)"`,
+      `"create table \`users\` (\`_internalId\` bigint not null  auto_increment, constraint \`users__internalId\` primary key (\`_internalId\`))"`,
     );
     expect(statements[2].sql).toMatchInlineSnapshot(`"SET FOREIGN_KEY_CHECKS = 1"`);
   });
@@ -593,7 +593,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
 
       create index "age_idx_users_test" on "users_test" ("age");
 
-      create table "posts_test" ("id" text not null unique, "title" text not null, "authorId" integer not null, "_internalId" integer not null primary key autoincrement, "_version" integer default 0 not null, constraint "posts_users_author_fk" foreign key ("authorId") references "users_test" ("_internalId") on delete restrict on update restrict);
+      create table "posts_test" ("id" text not null unique, "title" text not null, "authorId" integer not null, "_internalId" integer not null primary key autoincrement, "_version" integer default 0 not null, foreign key ("authorId") references "users_test" ("_internalId") on delete restrict on update restrict);
 
       insert into "fragno_db_settings" ("id", "key", "value") values ('BflimUWc1NbCMMDD9SM3gQ', 'test.schema_version', '4');"
     `);
@@ -611,7 +611,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
     expect(sql).toMatchInlineSnapshot(`
       "SET FOREIGN_KEY_CHECKS = 0;
 
-      create table \`users_test\` (\`id\` varchar(30) not null unique, \`name\` text not null, \`_internalId\` bigint not null primary key auto_increment, \`_version\` integer default 0 not null);
+      create table \`users_test\` (\`id\` varchar(30) not null unique, \`name\` text not null, \`_internalId\` bigint not null  auto_increment, \`_version\` integer default 0 not null, constraint \`users_test__internalId\` primary key (\`_internalId\`));
 
       alter table \`users_test\` add column \`age\` integer;
 
@@ -619,7 +619,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
 
       create index \`age_idx_users_test\` on \`users_test\` (\`age\`);
 
-      create table \`posts_test\` (\`id\` varchar(30) not null unique, \`title\` text not null, \`authorId\` bigint not null, \`_internalId\` bigint not null primary key auto_increment, \`_version\` integer default 0 not null);
+      create table \`posts_test\` (\`id\` varchar(30) not null unique, \`title\` text not null, \`authorId\` bigint not null, \`_internalId\` bigint not null  auto_increment, \`_version\` integer default 0 not null, constraint \`posts_test__internalId\` primary key (\`_internalId\`));
 
       alter table \`posts_test\` add constraint \`posts_users_author_fk\` foreign key (\`authorId\`) references \`users_test\` (\`_internalId\`) on delete restrict on update restrict;
 


### PR DESCRIPTION
- align sqlite timestamp defaults and drop inline FK constraint names
- emit named mysql PK constraints for internal IDs
- fix drizzle schema defaults and sqlite json type mapping
- expand drizzle-kit parity schema and normalization coverage
- update migration snapshots for mysql/sqlite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aligned migration defaults and constraint naming with Drizzle for consistent SQL across dialects
  * Adjusted MySQL primary-key generation for internal ID columns
  * Improved SQLite timestamp default handling
  * Removed inline named foreign-key constraints to standardize FK declarations

* **Tests**
  * Added expanded parity tests and normalization to ensure deterministic migration output across databases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->