### PR TITLE
fix(db): disable handlerTx retries without retrieve ops

### DIFF
--- a/.changeset/fresh-knives-retry.md
+++ b/.changeset/fresh-knives-retry.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+fix: disable handlerTx retries when no retrieve ops and reject explicit retry policies

--- a/packages/fragno-db/src/db-fragment-instantiator.test.ts
+++ b/packages/fragno-db/src/db-fragment-instantiator.test.ts
@@ -35,6 +35,8 @@ function createMockAdapter(): DatabaseAdapter {
           mutationPhase: Promise.resolve(),
         })),
         restrict: vi.fn(() => createMockRestrictedUow()),
+        getRetrievalOperations: vi.fn(() => []),
+        getMutationOperations: vi.fn(() => []),
         table: vi.fn(() => ({
           findMany: vi.fn(),
         })),
@@ -62,6 +64,9 @@ function createMockAdapter(): DatabaseAdapter {
         commit: vi.fn(),
         rollback: vi.fn(),
         reset: vi.fn(),
+        getRetrievalOperations: vi.fn(() => []),
+        getMutationOperations: vi.fn(() => []),
+        getCreatedIds: vi.fn(() => []),
         table: vi.fn(() => ({
           findMany: vi.fn(),
         })),

--- a/packages/fragno-db/src/db-fragment-integration.test.ts
+++ b/packages/fragno-db/src/db-fragment-integration.test.ts
@@ -414,6 +414,8 @@ describe.sequential("Database Fragment Integration", () => {
 
     const result = await usersFragment.inContext(async function () {
       return await this.handlerTx()
+        // Add a retrieve op so retry is allowed for the forced conflict below.
+        .retrieve(({ forSchema }) => forSchema(usersSchema).find("users"))
         .mutate(({ forSchema, idempotencyKey, currentAttempt }) => {
           if (currentAttempt === 0) {
             firstIdempotencyKey = idempotencyKey;

--- a/packages/fragno-db/src/fragments/internal-fragment.test.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.test.ts
@@ -319,7 +319,7 @@ describe("Hook Service", () => {
 
     await expect(
       fragment.inContext(async function () {
-        await this.handlerTx({ retryPolicy: new NoRetryPolicy() })
+        await this.handlerTx()
           .withServiceCalls(
             () => [fragment.services.hookService.markHookCompleted(staleId)] as const,
           )


### PR DESCRIPTION
default to no retries for mutate-only transactions throw if retryPolicy is provided without retrieve ops update tests and mocks to reflect new guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction retry behavior to disable retries for mutate-only transactions without retrieve operations.

* **New Features**
  * Transactions with retrieve operations now use exponential backoff retry policy by default.
  * Added validation to enforce retry policies only when retrieve operations are included in the transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->