### PR TITLE
fix(fragment-upload): invalidate upload queries after mutations

### DIFF
--- a/.changeset/solid-uploads-invalidate.md
+++ b/.changeset/solid-uploads-invalidate.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/fragment-upload": patch
+---
+
+fix(fragment-upload): invalidate file and upload queries after mutations.

--- a/packages/fragment-upload/package.json
+++ b/packages/fragment-upload/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fragno-dev/fragment-upload",
   "description": "Fragno upload fragment",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "files": [
     "dist",
     "bin"
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@fragno-dev/core": "workspace:*",
+    "@fragno-dev/db": "workspace:*",
     "@standard-schema/spec": "^1.0.0",
     "gunshi": "^0.26.3",
     "zod": "^4.0.5"
@@ -100,7 +101,6 @@
     "react": ">=18.0.0",
     "svelte": ">=4.0.0",
     "solid-js": ">=1.0.0",
-    "vue": ">=3.0.0",
-    "@fragno-dev/db": "workspace:*"
+    "vue": ">=3.0.0"
   }
 }

--- a/packages/fragment-upload/src/client/clients.ts
+++ b/packages/fragment-upload/src/client/clients.ts
@@ -18,10 +18,45 @@ export function createUploadFragmentClients(config: FragnoPublicClientConfig = {
     useFile: builder.createHook("/files/:fileKey"),
     useCreateUpload: builder.createMutator("POST", "/uploads"),
     useUploadStatus: builder.createHook("/uploads/:uploadId"),
-    useCompleteUpload: builder.createMutator("POST", "/uploads/:uploadId/complete"),
-    useAbortUpload: builder.createMutator("POST", "/uploads/:uploadId/abort"),
-    useUpdateFile: builder.createMutator("PATCH", "/files/:fileKey"),
-    useDeleteFile: builder.createMutator("DELETE", "/files/:fileKey"),
+    useCompleteUpload: builder.createMutator(
+      "POST",
+      "/uploads/:uploadId/complete",
+      (invalidate, params) => {
+        const uploadId = params.pathParams.uploadId;
+        if (!uploadId) {
+          return;
+        }
+        invalidate("GET", "/uploads/:uploadId", { pathParams: { uploadId } });
+        invalidate("GET", "/files", {});
+      },
+    ),
+    useAbortUpload: builder.createMutator(
+      "POST",
+      "/uploads/:uploadId/abort",
+      (invalidate, params) => {
+        const uploadId = params.pathParams.uploadId;
+        if (!uploadId) {
+          return;
+        }
+        invalidate("GET", "/uploads/:uploadId", { pathParams: { uploadId } });
+      },
+    ),
+    useUpdateFile: builder.createMutator("PATCH", "/files/:fileKey", (invalidate, params) => {
+      const fileKey = params.pathParams.fileKey;
+      if (!fileKey) {
+        return;
+      }
+      invalidate("GET", "/files/:fileKey", { pathParams: { fileKey } });
+      invalidate("GET", "/files", {});
+    }),
+    useDeleteFile: builder.createMutator("DELETE", "/files/:fileKey", (invalidate, params) => {
+      const fileKey = params.pathParams.fileKey;
+      if (!fileKey) {
+        return;
+      }
+      invalidate("GET", "/files/:fileKey", { pathParams: { fileKey } });
+      invalidate("GET", "/files", {});
+    }),
     useUploadHelpers: builder.createStore(helpers),
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1506,6 +1506,9 @@ importers:
       '@fragno-dev/core':
         specifier: workspace:*
         version: link:../fragno
+      '@fragno-dev/db':
+        specifier: workspace:*
+        version: link:../fragno-db
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
@@ -1534,9 +1537,6 @@ importers:
       '@fragno-dev/cli':
         specifier: workspace:*
         version: link:../../apps/fragno-cli
-      '@fragno-dev/db':
-        specifier: workspace:*
-        version: link:../fragno-db
       '@fragno-dev/test':
         specifier: workspace:*
         version: link:../fragno-test
@@ -22818,8 +22818,8 @@ snapshots:
       '@typescript-eslint/parser': 8.48.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -22842,7 +22842,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -22853,7 +22853,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22867,14 +22867,14 @@ snapshots:
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22902,7 +22902,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -22913,7 +22913,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
- add explicit invalidation for upload status and file list/detail after mutators

- move @fragno-dev/db to dependencies

- bump @fragno-dev/fragment-upload version to 0.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures file and upload lists refresh immediately after create/complete/update/delete actions to keep UI state accurate.
* **Chores**
  * Bumped package patch version and updated package metadata and dependencies for the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->