### PR TITLE
fix(db,examples): store outbox versionstamp as string

### DIFF
--- a/.changeset/shaggy-windows-approve.md
+++ b/.changeset/shaggy-windows-approve.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+fix(db): store outbox versionstamps as strings.

--- a/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.mysql.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.mysql.ts
@@ -1,22 +1,6 @@
-import { mysqlTable, varchar, text, bigint, int, uniqueIndex, json, datetime, index, customType, foreignKey, boolean } from "drizzle-orm/mysql-core"
+import { mysqlTable, varchar, text, bigint, int, uniqueIndex, json, datetime, index, foreignKey, boolean } from "drizzle-orm/mysql-core"
 import { createId } from "@fragno-dev/db/id"
 import { sql, relations } from "drizzle-orm"
-const customBinary = customType<
-  {
-    data: Uint8Array;
-    driverData: Buffer;
-  }
->({
-  dataType() {
-    return "longblob";
-  },
-  fromDriver(value) {
-    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
-  },
-  toDriver(value) {
-    return value instanceof Buffer? value : Buffer.from(value)
-  }
-});
 
 // ============================================================================
 // Fragment: (none)
@@ -54,7 +38,7 @@ export const fragno_hooks = mysqlTable("fragno_hooks", {
 
 export const fragno_db_outbox = mysqlTable("fragno_db_outbox", {
   id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
-  versionstamp: customBinary("versionstamp").notNull(),
+  versionstamp: text("versionstamp").notNull(),
   uowId: text("uowId").notNull(),
   payload: json("payload").notNull(),
   refMap: json("refMap"),

--- a/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.sqlite.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.sqlite.ts
@@ -1,22 +1,6 @@
-import { sqliteTable, text, integer, uniqueIndex, index, customType, foreignKey } from "drizzle-orm/sqlite-core"
+import { sqliteTable, text, integer, uniqueIndex, index, foreignKey } from "drizzle-orm/sqlite-core"
 import { createId } from "@fragno-dev/db/id"
 import { relations } from "drizzle-orm"
-const customBinary = customType<
-  {
-    data: Uint8Array;
-    driverData: Buffer;
-  }
->({
-  dataType() {
-    return "blob";
-  },
-  fromDriver(value) {
-    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
-  },
-  toDriver(value) {
-    return value instanceof Buffer? value : Buffer.from(value)
-  }
-});
 
 // ============================================================================
 // Fragment: (none)
@@ -56,7 +40,7 @@ export const fragno_hooks = sqliteTable("fragno_hooks", {
 
 export const fragno_db_outbox = sqliteTable("fragno_db_outbox", {
   id: text("id").notNull().unique().$defaultFn(() => createId()),
-  versionstamp: customBinary("versionstamp").notNull(),
+  versionstamp: text("versionstamp").notNull(),
   uowId: text("uowId").notNull(),
   payload: text("payload", { mode: "json" }).notNull(),
   refMap: text("refMap", { mode: "json" }),

--- a/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.ts
@@ -1,22 +1,6 @@
-import { pgTable, varchar, text, bigserial, integer, uniqueIndex, json, timestamp, index, customType, pgSchema, bigint, foreignKey, boolean } from "drizzle-orm/pg-core"
+import { pgTable, varchar, text, bigserial, integer, uniqueIndex, json, timestamp, index, pgSchema, bigint, foreignKey, boolean } from "drizzle-orm/pg-core"
 import { createId } from "@fragno-dev/db/id"
 import { relations } from "drizzle-orm"
-const customBinary = customType<
-  {
-    data: Uint8Array;
-    driverData: Buffer;
-  }
->({
-  dataType() {
-    return "bytea";
-  },
-  fromDriver(value) {
-    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
-  },
-  toDriver(value) {
-    return value instanceof Buffer? value : Buffer.from(value)
-  }
-});
 
 // ============================================================================
 // Fragment: (none)
@@ -54,7 +38,7 @@ export const fragno_hooks = pgTable("fragno_hooks", {
 
 export const fragno_db_outbox = pgTable("fragno_db_outbox", {
   id: varchar("id", { length: 30 }).notNull().unique().$defaultFn(() => createId()),
-  versionstamp: customBinary("versionstamp").notNull(),
+  versionstamp: text("versionstamp").notNull(),
   uowId: text("uowId").notNull(),
   payload: json("payload").notNull(),
   refMap: json("refMap"),

--- a/packages/fragno-db/src/adapters/drizzle/migrate-drizzle.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/migrate-drizzle.test.ts
@@ -179,7 +179,7 @@ describe("generateSchema and migrate", () => {
 
       CREATE TABLE "fragno_db_outbox" (
       	"id" varchar(30) NOT NULL,
-      	"versionstamp" "bytea" NOT NULL,
+      	"versionstamp" text NOT NULL,
       	"uowId" text NOT NULL,
       	"payload" json NOT NULL,
       	"refMap" json,

--- a/packages/fragno-db/src/adapters/generic-sql/generic-sql-uow-executor.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/generic-sql-uow-executor.ts
@@ -18,6 +18,7 @@ import {
   type OutboxRefMap,
   encodeVersionstamp,
   parseOutboxVersionValue,
+  versionstampToHex,
 } from "../../outbox/outbox";
 import { buildOutboxPlan, finalizeOutboxPayload } from "../../outbox/outbox-builder";
 import { createSQLSerializer } from "../../query/serialize/create-sql-serializer";
@@ -139,7 +140,7 @@ export async function executeMutation(
         );
         const payload = finalizeOutboxPayload(outboxPlan, outboxVersion);
         const payloadSerialized = superjson.serialize(payload);
-        const versionstamp = encodeVersionstamp(outboxVersion, 0);
+        const versionstamp = versionstampToHex(encodeVersionstamp(outboxVersion, 0));
 
         await insertOutboxRow(tx, driverConfig, {
           id: createId(),
@@ -329,7 +330,7 @@ async function insertOutboxRow(
   driverConfig: DriverConfig,
   options: {
     id: string;
-    versionstamp: Uint8Array;
+    versionstamp: string;
     uowId: string;
     payload: { json: unknown; meta?: Record<string, unknown> };
     refMap?: OutboxRefMap;

--- a/packages/fragno-db/src/outbox/outbox.ts
+++ b/packages/fragno-db/src/outbox/outbox.ts
@@ -104,22 +104,6 @@ export function hexToVersionstamp(hex: string): Uint8Array {
   return bytes;
 }
 
-export function coerceVersionstampBytes(value: unknown): Uint8Array {
-  if (value instanceof Uint8Array) {
-    return value;
-  }
-
-  if (typeof Buffer !== "undefined" && value instanceof Buffer) {
-    return new Uint8Array(value);
-  }
-
-  if (value instanceof ArrayBuffer) {
-    return new Uint8Array(value);
-  }
-
-  throw new Error(`Unsupported versionstamp type: ${typeof value}`);
-}
-
 export function parseOutboxVersionValue(value: unknown): bigint {
   if (typeof value === "bigint") {
     return value;

--- a/packages/fragno-db/src/schema-output/prisma.test.ts
+++ b/packages/fragno-db/src/schema-output/prisma.test.ts
@@ -186,7 +186,7 @@ describe("generatePrismaSchema", () => {
 
       model FragnoDbOutbox {
         id String @unique @default(cuid())
-        versionstamp Bytes
+        versionstamp String
         uowId String
         payload Json
         refMap Json?
@@ -280,7 +280,7 @@ describe("generatePrismaSchema", () => {
 
       model FragnoDbOutbox {
         id String @unique @default(cuid())
-        versionstamp Bytes
+        versionstamp String
         uowId String
         payload Json
         refMap Json?
@@ -373,7 +373,7 @@ describe("generatePrismaSchema", () => {
 
       model FragnoDbOutbox {
         id String @unique @default(cuid()) @db.VarChar(30)
-        versionstamp Bytes
+        versionstamp String
         uowId String
         payload Json @db.Json
         refMap Json? @db.Json


### PR DESCRIPTION
- switch internal outbox schema + writer to string/hex versionstamp
- update schema outputs, migrations, and drizzle example schemas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated outbox versionstamp storage from binary format to text/string format across all supported databases (MySQL, SQLite, PostgreSQL) for improved compatibility and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->