### PR TITLE
feat(db,docs): default sqlite adapter fallback

### DIFF
--- a/.changeset/quiet-sqlite-default.md
+++ b/.changeset/quiet-sqlite-default.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+feat: default to sqlite adapter when databaseAdapter is omitted (better-sqlite3 installed)

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/overview.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/overview.mdx
@@ -85,7 +85,9 @@ export function createCommentFragment(
 
 <Callout title="Make sure to allow your users to provide their database adapter" type="info">
   Your Fragment's creation function must accept `FragnoPublicConfigWithDatabase`, or
-  `DatabaseAdapter` in the options.
+  `DatabaseAdapter` in the options. If `better-sqlite3` is installed, users can omit
+  `databaseAdapter` to use a local SQLite file per fragment under `FRAGNO_DATA_DIR` (default:
+  `~/.fragno`).
 </Callout>
 
 ## Querying using transactions

--- a/apps/docs/content/docs/fragno/for-users/database-fragments/overview.mdx
+++ b/apps/docs/content/docs/fragno/for-users/database-fragments/overview.mdx
@@ -7,8 +7,9 @@ import { Callout } from "fumadocs-ui/components/callout";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 
 Some Fragno Fragments include a built-in database layer for persistent storage. When integrating
-these Fragments, you need to provide a **database adapter** that connects the Fragment to your
-existing database.
+these Fragments, you typically provide a **database adapter** that connects the Fragment to your
+existing database. If `better-sqlite3` is installed, Fragno can default to a local SQLite file per
+fragment under `FRAGNO_DATA_DIR` (default: `~/.fragno`).
 
 <Callout title="Fragment Handles Schema" type="info">
   The Fragment defines its own schema and handles migrations. You just provide the database
@@ -26,7 +27,7 @@ Check the Fragment's creation function:
 // Fragment without database
 createExampleFragment(config, options);
 
-// Fragment with database - requires databaseAdapter
+// Fragment with database - may require databaseAdapter
 createCommentFragment(config, { databaseAdapter });
 ```
 
@@ -117,6 +118,9 @@ export function createCommentFragmentInstance() {
 // IMPORTANT: Export the Fragment so it's accessible by the Fragno CLI.
 export const fragment = createCommentFragmentInstance();
 ```
+
+If `better-sqlite3` is installed, you can omit `databaseAdapter` to use the default local SQLite
+file.
 
 </Step>
 

--- a/apps/docs/content/docs/fragno/for-users/integrating-a-fragment.mdx
+++ b/apps/docs/content/docs/fragno/for-users/integrating-a-fragment.mdx
@@ -50,12 +50,14 @@ the specific Fragment you are integrating to figure out what configuration is re
 
 ## Fragments with Databases
 
-Some Fragments include a database layer for persistent storage. These Fragments require you to
-provide a **database adapter** that connects the Fragment to your existing database.
+Some Fragments include a database layer for persistent storage. These Fragments typically require
+you to provide a **database adapter** that connects the Fragment to your existing database. If
+`better-sqlite3` is installed, Fragno can default to a local SQLite file per fragment under
+`FRAGNO_DATA_DIR` (default: `~/.fragno`).
 
 <Callout title="Database Integration Required" type="warn">
   If a Fragment requires `FragnoPublicConfigWithDatabase` or mentions `databaseAdapter` in its
-  documentation, you must set up database integration before using it.
+  documentation, set up database integration unless you're using the default SQLite adapter.
 </Callout>
 
 Fragno’s DB adapters use **Kysely’s `Dialect` interface** as the query execution layer. This lets us

--- a/apps/docs/content/docs/fragno/user-quick-start.mdx
+++ b/apps/docs/content/docs/fragno/user-quick-start.mdx
@@ -49,7 +49,8 @@ export function createExampleFragmentInstance() {
 
 <Callout title="Optional Step" type="info">
   Only required if the Fragment uses a database layer. Check the Fragment's documentation to see if
-  it requires `databaseAdapter`.
+  it requires `databaseAdapter`. If `better-sqlite3` is installed, Fragno can default to a local
+  SQLite file per fragment under `FRAGNO_DATA_DIR` (default: `~/.fragno`).
 </Callout>
 
 If the Fragment requires database integration:

--- a/packages/fragno-db/README.md
+++ b/packages/fragno-db/README.md
@@ -92,7 +92,9 @@ export function createCommentLibrary(
 }
 ```
 
-Your users pass a SqlAdapter via `options`.
+Your users pass a SqlAdapter via `options`. If `better-sqlite3` is installed, `databaseAdapter` is
+optional and defaults to a local SQLite file per fragment in `FRAGNO_DATA_DIR` (default:
+`~/.fragno`).
 
 ```ts
 // User's application code

--- a/packages/fragno-db/package.json
+++ b/packages/fragno-db/package.json
@@ -141,6 +141,9 @@
     "kysely": "^0.28.10",
     "superjson": "^2.2.1"
   },
+  "optionalDependencies": {
+    "better-sqlite3": "^12.6.2"
+  },
   "peerDependencies": {
     "drizzle-orm": "^0.44.6"
   },

--- a/packages/fragno-db/src/adapters/drizzle/test-utils.ts
+++ b/packages/fragno-db/src/adapters/drizzle/test-utils.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile, rm, access } from "node:fs/promises";
 import { join } from "node:path";
 import { generateDrizzleSchema, type SupportedProvider } from "../../schema-output/drizzle";
 import type { Schema } from "../../schema/create";
-import { internalSchema } from "../../fragments/internal-fragment";
+import { internalSchema } from "../../fragments/internal-fragment.schema";
 
 /**
  * Writes a Fragno schema to a temporary TypeScript file and dynamically imports it.

--- a/packages/fragno-db/src/adapters/generic-sql/generic-sql-uow-executor.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/generic-sql-uow-executor.ts
@@ -11,7 +11,7 @@ import { sql } from "../../sql-driver/sql";
 import { createId } from "../../id";
 import superjson from "superjson";
 import { createColdKysely } from "./migration/cold-kysely";
-import { SETTINGS_NAMESPACE, internalSchema } from "../../fragments/internal-fragment";
+import { SETTINGS_NAMESPACE, internalSchema } from "../../fragments/internal-fragment.schema";
 import {
   type OutboxConfig,
   type OutboxRefLookup,

--- a/packages/fragno-db/src/adapters/generic-sql/migration/sql-generator.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/sql-generator.ts
@@ -12,7 +12,7 @@ import type {
   ColumnOperation,
   MigrationOperation,
 } from "../../../migration-engine/shared";
-import { SETTINGS_TABLE_NAME } from "../../../fragments/internal-fragment";
+import { SETTINGS_TABLE_NAME } from "../../../fragments/internal-fragment.schema";
 import type { NamingResolver } from "../../../naming/sql-naming";
 import type { DriverConfig, SupportedDatabase } from "../driver-config";
 import type { SQLiteStorageMode } from "../sqlite-storage";

--- a/packages/fragno-db/src/fragments/internal-fragment.schema.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.schema.ts
@@ -1,0 +1,51 @@
+import { schema, idColumn, column } from "../schema/create";
+
+// Constants for Fragno's internal settings table
+export const SETTINGS_TABLE_NAME = "fragno_db_settings" as const;
+// FIXME: In some places we simply use empty string "" as namespace, which is not correct.
+export const SETTINGS_NAMESPACE = "fragno-db-settings" as const;
+
+export const internalSchema = schema("fragno_internal", (s) => {
+  return s
+    .addTable(SETTINGS_TABLE_NAME, (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("key", column("string"))
+        .addColumn("value", column("string"))
+        .createIndex("unique_key", ["key"], { unique: true });
+    })
+    .addTable("fragno_hooks", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("namespace", column("string"))
+        .addColumn("hookName", column("string"))
+        .addColumn("payload", column("json"))
+        .addColumn("status", column("string")) // "pending" | "processing" | "completed" | "failed"
+        .addColumn("attempts", column("integer").defaultTo(0))
+        .addColumn("maxAttempts", column("integer").defaultTo(5))
+        .addColumn("lastAttemptAt", column("timestamp").nullable())
+        .addColumn("nextRetryAt", column("timestamp").nullable())
+        .addColumn("error", column("string").nullable())
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .addColumn("nonce", column("string"))
+        .createIndex("idx_namespace_status_retry", ["namespace", "status", "nextRetryAt"])
+        .createIndex("idx_nonce", ["nonce"]);
+    })
+    .addTable("fragno_db_outbox", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("versionstamp", column("string"))
+        .addColumn("uowId", column("string"))
+        .addColumn("payload", column("json"))
+        .addColumn("refMap", column("json").nullable())
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .createIndex("idx_outbox_versionstamp", ["versionstamp"], { unique: true })
+        .createIndex("idx_outbox_uow", ["uowId"]);
+    });
+});

--- a/packages/fragno-db/src/fragments/internal-fragment.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.ts
@@ -9,59 +9,19 @@ import {
   type ImplicitDatabaseDependencies,
 } from "../db-fragment-definition-builder";
 import { FragnoId } from "../schema/create";
-import { schema, idColumn, column } from "../schema/create";
 import type { RetryPolicy } from "../query/unit-of-work/retry-policy";
 import { dbNow } from "../query/db-now";
+import {
+  internalSchema,
+  SETTINGS_NAMESPACE,
+  SETTINGS_TABLE_NAME,
+} from "./internal-fragment.schema";
 
-// Constants for Fragno's internal settings table
-export const SETTINGS_TABLE_NAME = "fragno_db_settings" as const;
-// FIXME: In some places we simply use empty string "" as namespace, which is not correct.
-export const SETTINGS_NAMESPACE = "fragno-db-settings" as const;
-
-export const internalSchema = schema("fragno_internal", (s) => {
-  return s
-    .addTable(SETTINGS_TABLE_NAME, (t) => {
-      return t
-        .addColumn("id", idColumn())
-        .addColumn("key", column("string"))
-        .addColumn("value", column("string"))
-        .createIndex("unique_key", ["key"], { unique: true });
-    })
-    .addTable("fragno_hooks", (t) => {
-      return t
-        .addColumn("id", idColumn())
-        .addColumn("namespace", column("string"))
-        .addColumn("hookName", column("string"))
-        .addColumn("payload", column("json"))
-        .addColumn("status", column("string")) // "pending" | "processing" | "completed" | "failed"
-        .addColumn("attempts", column("integer").defaultTo(0))
-        .addColumn("maxAttempts", column("integer").defaultTo(5))
-        .addColumn("lastAttemptAt", column("timestamp").nullable())
-        .addColumn("nextRetryAt", column("timestamp").nullable())
-        .addColumn("error", column("string").nullable())
-        .addColumn(
-          "createdAt",
-          column("timestamp").defaultTo((b) => b.now()),
-        )
-        .addColumn("nonce", column("string"))
-        .createIndex("idx_namespace_status_retry", ["namespace", "status", "nextRetryAt"])
-        .createIndex("idx_nonce", ["nonce"]);
-    })
-    .addTable("fragno_db_outbox", (t) => {
-      return t
-        .addColumn("id", idColumn())
-        .addColumn("versionstamp", column("string"))
-        .addColumn("uowId", column("string"))
-        .addColumn("payload", column("json"))
-        .addColumn("refMap", column("json").nullable())
-        .addColumn(
-          "createdAt",
-          column("timestamp").defaultTo((b) => b.now()),
-        )
-        .createIndex("idx_outbox_versionstamp", ["versionstamp"], { unique: true })
-        .createIndex("idx_outbox_uow", ["uowId"]);
-    });
-});
+export {
+  internalSchema,
+  SETTINGS_NAMESPACE,
+  SETTINGS_TABLE_NAME,
+} from "./internal-fragment.schema";
 
 // This uses DatabaseFragmentDefinitionBuilder directly
 // to avoid circular dependency (it doesn't need to link to itself)

--- a/packages/fragno-db/src/migration-engine/generation-engine.ts
+++ b/packages/fragno-db/src/migration-engine/generation-engine.ts
@@ -6,13 +6,12 @@ import {
 } from "../adapters/adapters";
 import { generateDrizzleSchema } from "../schema-output/drizzle";
 import { generatePrismaSchema } from "../schema-output/prisma";
+import { internalFragmentDef, getSchemaVersionFromDatabase } from "../fragments/internal-fragment";
 import {
-  internalFragmentDef,
   internalSchema,
   SETTINGS_NAMESPACE,
   SETTINGS_TABLE_NAME,
-  getSchemaVersionFromDatabase,
-} from "../fragments/internal-fragment";
+} from "../fragments/internal-fragment.schema";
 import { instantiate } from "@fragno-dev/core";
 import { supportedDatabases, type SupportedDatabase } from "../adapters/generic-sql/driver-config";
 

--- a/packages/fragno-db/src/mod.ts
+++ b/packages/fragno-db/src/mod.ts
@@ -12,6 +12,7 @@ import {
   getSchemaVersionFromDatabase,
   type InternalFragmentInstance,
 } from "./fragments/internal-fragment";
+import { resolveDatabaseAdapter } from "./util/default-database-adapter";
 
 export type { DatabaseAdapter, CursorResult };
 export { Cursor };
@@ -199,7 +200,7 @@ export async function migrate<TSchema extends AnySchema>(
   fragment: AnyFragnoInstantiatedDatabaseFragment<TSchema>,
 ): Promise<void> {
   const { options, deps, linkedFragments } = fragment.$internal;
-  const adapter = options.databaseAdapter;
+  const adapter = resolveDatabaseAdapter(options, deps.schema);
 
   // Check if adapter supports prepareMigrations
   if (!adapter.prepareMigrations) {

--- a/packages/fragno-db/src/outbox/outbox-builder.ts
+++ b/packages/fragno-db/src/outbox/outbox-builder.ts
@@ -1,7 +1,7 @@
 import type { MutationOperation } from "../query/unit-of-work/unit-of-work";
 import type { AnySchema, AnyTable } from "../schema/create";
 import { FragnoId, FragnoReference } from "../schema/create";
-import { internalSchema } from "../fragments/internal-fragment";
+import { internalSchema } from "../fragments/internal-fragment.schema";
 import type { OutboxRefLookup, OutboxPayload, OutboxMutation } from "./outbox";
 import { encodeVersionstamp, versionstampToHex } from "./outbox";
 

--- a/packages/fragno-db/src/schema-output/drizzle.ts
+++ b/packages/fragno-db/src/schema-output/drizzle.ts
@@ -13,7 +13,7 @@ import {
   type NamingResolver,
   type SqlNamingStrategy,
 } from "../naming/sql-naming";
-import { internalSchema } from "../fragments/internal-fragment";
+import { internalSchema } from "../fragments/internal-fragment.schema";
 import { type DatabaseTypeLiteral } from "../schema/type-conversion/type-mapping";
 import { createSQLTypeMapper } from "../schema/type-conversion/create-sql-type-mapper";
 import {

--- a/packages/fragno-db/src/util/default-database-adapter.ts
+++ b/packages/fragno-db/src/util/default-database-adapter.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { SqliteDialect } from "kysely";
+import { SqlAdapter } from "../adapters/generic-sql/generic-sql-adapter";
+import { BetterSQLite3DriverConfig } from "../adapters/generic-sql/driver-config";
+import type { DatabaseAdapter } from "../adapters/adapters";
+import type { AnySchema } from "../schema/create";
+type DatabaseAdapterConfig = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  databaseAdapter?: DatabaseAdapter<any>;
+  databaseNamespace?: string | null;
+};
+
+type BetterSqlite3Constructor = typeof import("better-sqlite3");
+
+const isNodeRuntime = (): boolean => {
+  return (
+    typeof process !== "undefined" &&
+    typeof process.versions?.node === "string" &&
+    process.versions.node.length > 0
+  );
+};
+
+const createNodeRequire = (): NodeRequire | null => {
+  if (!isNodeRuntime()) {
+    return null;
+  }
+  const metaUrl = typeof import.meta !== "undefined" ? import.meta.url : undefined;
+  if (!metaUrl || typeof metaUrl !== "string") {
+    return null;
+  }
+  return createRequire(metaUrl);
+};
+
+const loadBetterSqlite3 = (): BetterSqlite3Constructor | null => {
+  const requireFn = createNodeRequire();
+  if (!requireFn) {
+    return null;
+  }
+  try {
+    const module = requireFn("better-sqlite3") as {
+      default?: BetterSqlite3Constructor;
+    };
+    return (module.default ?? module) as BetterSqlite3Constructor;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    const code = err.code;
+    if (
+      (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") &&
+      err.message?.includes("better-sqlite3")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const betterSqlite3Constructor = loadBetterSqlite3();
+
+const defaultDataDir = (): string => {
+  const configured = process.env["FRAGNO_DATA_DIR"];
+  if (configured && configured.trim().length > 0) {
+    return configured;
+  }
+  return path.join(process.env["HOME"] ?? process.cwd(), ".fragno");
+};
+
+const sanitizeFileSegment = (name: string): string => {
+  const sanitized = name.replace(/[^a-z0-9-]/gi, "_");
+  return sanitized.length > 0 ? sanitized : "fragno";
+};
+
+const resolveSqliteDatabasePath = <TSchema extends AnySchema>(
+  options: DatabaseAdapterConfig,
+  schema: TSchema,
+): string => {
+  const baseName =
+    typeof options.databaseNamespace === "string" && options.databaseNamespace.length > 0
+      ? options.databaseNamespace
+      : schema.name;
+  const fileName = `${sanitizeFileSegment(baseName)}.sqlite`;
+  return path.join(defaultDataDir(), fileName);
+};
+
+const createDefaultSqliteAdapter = <TSchema extends AnySchema>(
+  options: DatabaseAdapterConfig,
+  schema: TSchema,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): DatabaseAdapter<any> | null => {
+  if (!betterSqlite3Constructor) {
+    return null;
+  }
+
+  const dbPath = resolveSqliteDatabasePath(options, schema);
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+  const dialect = new SqliteDialect({
+    database: new betterSqlite3Constructor(dbPath),
+  });
+  const driverConfig = new BetterSQLite3DriverConfig();
+  return new SqlAdapter({ dialect, driverConfig });
+};
+
+export const resolveDatabaseAdapter = <TSchema extends AnySchema>(
+  options: DatabaseAdapterConfig,
+  schema: TSchema,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): DatabaseAdapter<any> => {
+  if (options.databaseAdapter) {
+    return options.databaseAdapter;
+  }
+
+  const defaultAdapter = createDefaultSqliteAdapter(options, schema);
+  if (!defaultAdapter) {
+    throw new Error(
+      "Database fragment requires options.databaseAdapter, or install better-sqlite3 to use the default SQLite adapter.",
+    );
+  }
+
+  options.databaseAdapter = defaultAdapter;
+  return defaultAdapter;
+};

--- a/packages/fragno-db/src/with-database.ts
+++ b/packages/fragno-db/src/with-database.ts
@@ -16,9 +16,13 @@ import {
 import { internalFragmentDef, type InternalFragmentInstance } from "./fragments/internal-fragment";
 import { internalFragmentRoutes } from "./fragments/internal-fragment.routes";
 import type { HooksMap } from "./hooks/hooks";
+import { resolveDatabaseAdapter } from "./util/default-database-adapter";
 
-function shouldExposeOutboxRoutes(options: FragnoPublicConfigWithDatabase): boolean {
-  const adapter = options.databaseAdapter as { outbox?: { enabled?: boolean } };
+function shouldExposeOutboxRoutes(
+  options: FragnoPublicConfigWithDatabase,
+  schema: AnySchema,
+): boolean {
+  const adapter = resolveDatabaseAdapter(options, schema) as { outbox?: { enabled?: boolean } };
   return adapter.outbox?.enabled ?? false;
 }
 
@@ -109,7 +113,10 @@ export function withDatabase<TSchema extends AnySchema>(
     const builderWithInternal = builder.withLinkedFragment(
       "_fragno_internal",
       ({ config, options }) => {
-        const internalRoutes = shouldExposeOutboxRoutes(options as FragnoPublicConfigWithDatabase)
+        const internalRoutes = shouldExposeOutboxRoutes(
+          options as FragnoPublicConfigWithDatabase,
+          schema,
+        )
           ? [internalFragmentRoutes]
           : [];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1720,9 +1720,6 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
-      better-sqlite3:
-        specifier: ^12.6.2
-        version: 12.6.2
       drizzle-kit:
         specifier: ^0.31.8
         version: 0.31.8
@@ -1744,6 +1741,10 @@ importers:
       zod:
         specifier: ^4.3.5
         version: 4.3.5
+    optionalDependencies:
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.6.2
 
   packages/fragno-node:
     dependencies:


### PR DESCRIPTION
Make databaseAdapter optional with default sqlite per fragment

Guard optional better-sqlite3 and avoid internal schema cycle

Document FRAGNO_DATA_DIR default behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - The database adapter configuration is now optional. When better-sqlite3 is installed, Fragno automatically defaults to using a local SQLite file per fragment, with data stored in FRAGNO_DATA_DIR (default: ~/.fragno), eliminating the need for manual adapter setup.

* **Documentation**
  - Updated database integration documentation across all relevant guides to explain the optional adapter behavior and default SQLite storage mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->