### PR TITLE
refactor(wf,docs,examples): replace class-based workflows

### DIFF
--- a/apps/docs/content/docs/workflows/fragment.mdx
+++ b/apps/docs/content/docs/workflows/fragment.mdx
@@ -18,7 +18,7 @@ npm install @fragno-dev/fragment-workflows @fragno-dev/db
 
 ```ts title="lib/workflows.ts"
 import {
-  WorkflowEntrypoint,
+  defineWorkflow,
   type WorkflowEvent,
   type WorkflowStep,
 } from "@fragno-dev/fragment-workflows";
@@ -32,8 +32,9 @@ type ApprovalEvent = { approved: boolean };
 
 type FulfillmentEvent = { confirmationId: string };
 
-export class ApprovalWorkflow extends WorkflowEntrypoint<unknown, ApprovalParams> {
-  async run(event: WorkflowEvent<ApprovalParams>, step: WorkflowStep) {
+export const ApprovalWorkflow = defineWorkflow(
+  { name: "approval-workflow" },
+  async (event: WorkflowEvent<ApprovalParams>, step: WorkflowStep) => {
     const approval = await step.waitForEvent<ApprovalEvent>("approval", {
       type: "approval",
       timeout: "15 min",
@@ -47,12 +48,32 @@ export class ApprovalWorkflow extends WorkflowEntrypoint<unknown, ApprovalParams
     });
 
     return { request: event.payload, approval, fulfillment };
-  }
-}
+  },
+);
 
 export const workflows = {
-  approval: { name: "approval-workflow", workflow: ApprovalWorkflow },
+  approval: ApprovalWorkflow,
 } as const;
+```
+
+## Schema validation + output typing
+
+If you provide a Standard Schema, params are validated on create/createBatch. If you provide an
+`outputSchema`, the workflow output is typed end-to-end.
+
+```ts
+import { z } from "zod";
+
+const paramsSchema = z.object({ requestId: z.string(), amount: z.number() });
+const outputSchema = z.object({ confirmationId: z.string() });
+
+export const ApprovalWorkflow = defineWorkflow(
+  { name: "approval-workflow", schema: paramsSchema, outputSchema },
+  async (event, step) => {
+    // ...
+    return { confirmationId: "conf_123" };
+  },
+);
 ```
 
 ## Create the Fragment Server

--- a/apps/docs/content/docs/workflows/quickstart.mdx
+++ b/apps/docs/content/docs/workflows/quickstart.mdx
@@ -22,11 +22,11 @@ npm install @fragno-dev/fragment-workflows @fragno-dev/db
 
 ## Define a Workflow
 
-Create a workflow class and a registry of workflows:
+Create a workflow definition and a registry of workflows:
 
 ```ts title="lib/workflows.ts"
 import {
-  WorkflowEntrypoint,
+  defineWorkflow,
   type WorkflowEvent,
   type WorkflowStep,
 } from "@fragno-dev/fragment-workflows";
@@ -40,8 +40,9 @@ type ApprovalEvent = { approved: boolean };
 
 type FulfillmentEvent = { confirmationId: string };
 
-export class ApprovalWorkflow extends WorkflowEntrypoint<unknown, ApprovalParams> {
-  async run(event: WorkflowEvent<ApprovalParams>, step: WorkflowStep) {
+export const ApprovalWorkflow = defineWorkflow(
+  { name: "approval-workflow" },
+  async (event: WorkflowEvent<ApprovalParams>, step: WorkflowStep) => {
     const approval = await step.waitForEvent<ApprovalEvent>("approval", {
       type: "approval",
       timeout: "15 min",
@@ -55,12 +56,27 @@ export class ApprovalWorkflow extends WorkflowEntrypoint<unknown, ApprovalParams
     });
 
     return { request: event.payload, approval, fulfillment };
-  }
-}
+  },
+);
 
 export const workflows = {
-  approval: { name: "approval-workflow", workflow: ApprovalWorkflow },
+  approval: ApprovalWorkflow,
 } as const;
+```
+
+Optional: pass a Standard Schema as `schema` to validate params, and an `outputSchema` to type
+output end-to-end.
+
+```ts
+import { z } from "zod";
+
+const paramsSchema = z.object({ requestId: z.string(), amount: z.number() });
+const outputSchema = z.object({ confirmationId: z.string() });
+
+export const ApprovalWorkflow = defineWorkflow(
+  { name: "approval-workflow", schema: paramsSchema, outputSchema },
+  async (event, step) => ({ confirmationId: "conf_123" }),
+);
 ```
 
 ## Create the Fragment Server

--- a/apps/docs/content/docs/workflows/routes.mdx
+++ b/apps/docs/content/docs/workflows/routes.mdx
@@ -46,6 +46,8 @@ Body:
 { "id": "optional-id", "params": { "...": "..." } }
 ```
 
+If the workflow defines a schema, invalid params return `WORKFLOW_PARAMS_INVALID`.
+
 ### Create a batch of instances
 
 `POST /workflows/:workflowName/instances/batch`
@@ -55,6 +57,8 @@ Body:
 ```json
 { "instances": [{ "id": "required-id", "params": { "...": "..." } }] }
 ```
+
+If the workflow defines a schema, invalid params return `WORKFLOW_PARAMS_INVALID`.
 
 ### Get instance details
 

--- a/apps/fragno-wf/src/utils/client.test.ts
+++ b/apps/fragno-wf/src/utils/client.test.ts
@@ -3,23 +3,25 @@ import { createServer, type Server } from "node:http";
 import { defaultFragnoRuntime, instantiate } from "@fragno-dev/core";
 import { buildDatabaseFragmentsTest } from "@fragno-dev/test";
 import {
-  WorkflowEntrypoint,
+  defineWorkflow,
   workflowsFragmentDefinition,
   workflowsRoutesFactory,
+  type WorkflowEvent,
+  type WorkflowStep,
 } from "@fragno-dev/fragment-workflows";
-import type { WorkflowEvent, WorkflowStep } from "@fragno-dev/fragment-workflows";
 import { toNodeHandler } from "@fragno-dev/node";
 import { createClient } from "./client.js";
 
-class DemoWorkflow extends WorkflowEntrypoint {
-  run(_event: WorkflowEvent<{ userId: string }>, _step: WorkflowStep) {
+const DemoWorkflow = defineWorkflow(
+  { name: "demo-workflow" },
+  (_event: WorkflowEvent<{ userId: string }>, _step: WorkflowStep) => {
     return undefined;
-  }
-}
+  },
+);
 
 describe("workflows CLI client", async () => {
   const workflows = {
-    DEMO: { name: "demo-workflow", workflow: DemoWorkflow },
+    DEMO: DemoWorkflow,
   } as const;
 
   const { fragments, test: testContext } = await buildDatabaseFragmentsTest()

--- a/example-apps/fragno-db-usage-drizzle/src/fragno/workflows-fragment.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/fragno/workflows-fragment.ts
@@ -5,10 +5,10 @@ import {
   createWorkflowsRunner,
   workflowsFragmentDefinition,
   workflowsRoutesFactory,
-  WorkflowEntrypoint,
   type WorkflowsFragmentConfig,
   type WorkflowEvent,
   type WorkflowStep,
+  defineWorkflow,
 } from "@fragno-dev/fragment-workflows";
 import { adapter } from "../fragno-adapter";
 
@@ -28,8 +28,9 @@ export type FulfillmentEventPayload = {
   confirmationId: string;
 };
 
-class ApprovalWorkflow extends WorkflowEntrypoint<unknown, ApprovalParams> {
-  async run(event: WorkflowEvent<ApprovalParams>, step: WorkflowStep) {
+const ApprovalWorkflow = defineWorkflow(
+  { name: "approval-workflow" },
+  async (event: WorkflowEvent<ApprovalParams>, step: WorkflowStep) => {
     const approval = await step.waitForEvent<ApprovalEventPayload>("approval", {
       type: "approval",
       timeout: "15 min",
@@ -47,11 +48,11 @@ class ApprovalWorkflow extends WorkflowEntrypoint<unknown, ApprovalParams> {
       approval,
       fulfillment,
     };
-  }
-}
+  },
+);
 
 const workflows = {
-  approval: { name: "approval-workflow", workflow: ApprovalWorkflow },
+  approval: ApprovalWorkflow,
 } as const;
 
 // oxlint-disable-next-line no-explicit-any

--- a/example-apps/wf-example/app/workflows/workflows.ts
+++ b/example-apps/wf-example/app/workflows/workflows.ts
@@ -1,7 +1,7 @@
 import {
-  WorkflowEntrypoint,
   type WorkflowEvent,
   type WorkflowStep,
+  defineWorkflow,
 } from "@fragno-dev/fragment-workflows";
 
 export type ApprovalParams = {
@@ -20,8 +20,9 @@ export type FulfillmentEventPayload = {
   confirmationId: string;
 };
 
-export class ApprovalWorkflow extends WorkflowEntrypoint<unknown, ApprovalParams> {
-  async run(event: WorkflowEvent<ApprovalParams>, step: WorkflowStep) {
+export const ApprovalWorkflow = defineWorkflow(
+  { name: "approval-workflow" },
+  async (event: WorkflowEvent<ApprovalParams>, step: WorkflowStep) => {
     const approval = await step.waitForEvent<ApprovalEventPayload>("approval", {
       type: "approval",
       timeout: "15 min",
@@ -39,11 +40,12 @@ export class ApprovalWorkflow extends WorkflowEntrypoint<unknown, ApprovalParams
       approval,
       fulfillment,
     };
-  }
-}
+  },
+);
 
-export class DemoDataWorkflow extends WorkflowEntrypoint {
-  async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+export const DemoDataWorkflow = defineWorkflow(
+  { name: "demo-data-workflow" },
+  async (_event: WorkflowEvent<unknown>, step: WorkflowStep) => {
     const randomValue = await step.do("random-number", () => Math.floor(Math.random() * 1000));
 
     const remoteData = await step.do("fetch-remote", async () => {
@@ -71,11 +73,12 @@ export class DemoDataWorkflow extends WorkflowEntrypoint {
       remoteData,
       flakyResult,
     };
-  }
-}
+  },
+);
 
-export class ParallelStepsWorkflow extends WorkflowEntrypoint {
-  async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+export const ParallelStepsWorkflow = defineWorkflow(
+  { name: "parallel-steps-workflow" },
+  async (_event: WorkflowEvent<unknown>, step: WorkflowStep) => {
     const startedAt = await step.do("record-start", () => Date.now());
     const [todo, user] = await Promise.all([
       step.do(
@@ -114,11 +117,12 @@ export class ParallelStepsWorkflow extends WorkflowEntrypoint {
       todo,
       user,
     };
-  }
-}
+  },
+);
 
-export class WaitTimeoutWorkflow extends WorkflowEntrypoint {
-  async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+export const WaitTimeoutWorkflow = defineWorkflow(
+  { name: "wait-timeout-workflow" },
+  async (_event: WorkflowEvent<unknown>, step: WorkflowStep) => {
     const startedAt = await step.do("record-start", () => Date.now());
     const edge = await step.waitForEvent("edge-wait", {
       type: "edge",
@@ -129,11 +133,12 @@ export class WaitTimeoutWorkflow extends WorkflowEntrypoint {
       startedAt,
       edge,
     };
-  }
-}
+  },
+);
 
-export class CrashTestWorkflow extends WorkflowEntrypoint {
-  async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+export const CrashTestWorkflow = defineWorkflow(
+  { name: "crash-test-workflow" },
+  async (_event: WorkflowEvent<unknown>, step: WorkflowStep) => {
     const startedAt = await step.do("record-start", () => Date.now());
     const slowStep = await step.do("slow-step", async () => {
       await new Promise((resolve) => setTimeout(resolve, 15_000));
@@ -146,13 +151,13 @@ export class CrashTestWorkflow extends WorkflowEntrypoint {
       slowStep,
       finishedAt,
     };
-  }
-}
+  },
+);
 
 export const workflows = {
-  approval: { name: "approval-workflow", workflow: ApprovalWorkflow },
-  demoData: { name: "demo-data-workflow", workflow: DemoDataWorkflow },
-  parallel: { name: "parallel-steps-workflow", workflow: ParallelStepsWorkflow },
-  waitTimeout: { name: "wait-timeout-workflow", workflow: WaitTimeoutWorkflow },
-  crashTest: { name: "crash-test-workflow", workflow: CrashTestWorkflow },
+  approval: ApprovalWorkflow,
+  demoData: DemoDataWorkflow,
+  parallel: ParallelStepsWorkflow,
+  waitTimeout: WaitTimeoutWorkflow,
+  crashTest: CrashTestWorkflow,
 } as const;

--- a/packages/fragment-workflows/src/bindings.ts
+++ b/packages/fragment-workflows/src/bindings.ts
@@ -1,5 +1,14 @@
 import type { TxResult } from "@fragno-dev/db";
-import type { InstanceStatus, WorkflowBindings, WorkflowsRegistry } from "./workflow";
+import type {
+  InstanceStatus,
+  InstanceStatusWithOutput,
+  WorkflowBindings,
+  WorkflowInstance,
+  WorkflowOutputFromEntry,
+  WorkflowParamsFromEntry,
+  WorkflowRegistryEntry,
+  WorkflowsRegistry,
+} from "./workflow";
 
 type WorkflowInstanceOptions = { id?: string; params?: unknown };
 type WorkflowInstanceBatchOptions = { id: string; params?: unknown };
@@ -53,14 +62,36 @@ const runWithContext = async <T>(
   return await result;
 };
 
-const createInstanceBinding = (
+const validateWorkflowParams = async (entry: WorkflowRegistryEntry, params: unknown) => {
+  if ("workflow" in entry) {
+    return params ?? {};
+  }
+
+  if (!entry.schema) {
+    return params ?? {};
+  }
+
+  const result = await entry.schema["~standard"].validate(params ?? {});
+  if (result.issues) {
+    const error = new Error("WORKFLOW_PARAMS_INVALID");
+    (error as { issues?: unknown }).issues = result.issues;
+    throw error;
+  }
+
+  return result.value;
+};
+
+const createInstanceBinding = <TOutput>(
   workflowName: string,
   instanceId: string,
   adapter: WorkflowsBindingsAdapter,
   runner?: RunInContext,
-) => ({
+): WorkflowInstance<TOutput> => ({
   id: instanceId,
-  status: () => runWithContext(runner, () => adapter.getInstanceStatus(workflowName, instanceId)),
+  status: async () =>
+    (await runWithContext(runner, () =>
+      adapter.getInstanceStatus(workflowName, instanceId),
+    )) as InstanceStatusWithOutput<TOutput>,
   pause: async () => {
     await runWithContext(runner, () => adapter.pauseInstance(workflowName, instanceId));
   },
@@ -83,43 +114,58 @@ const createInstanceBinding = (
   },
 });
 
-export function createWorkflowsBindings(
-  workflows: WorkflowsRegistry,
+export function createWorkflowsBindings<TRegistry extends WorkflowsRegistry>(
+  workflows: TRegistry,
   adapter: WorkflowsBindingsAdapter,
   options?: { runInContext?: RunInContext },
-): WorkflowBindings {
+): WorkflowBindings<TRegistry> {
   const runner = options?.runInContext;
-  const bindings: WorkflowBindings = {};
+  const bindings = {} as WorkflowBindings<TRegistry>;
 
-  for (const [bindingKey, entry] of Object.entries(workflows)) {
+  for (const bindingKey of Object.keys(workflows) as Array<keyof TRegistry>) {
+    const entry = workflows[bindingKey];
     const workflowName = entry.name;
+    type TParams = WorkflowParamsFromEntry<typeof entry>;
+    type TOutput = WorkflowOutputFromEntry<typeof entry>;
 
     bindings[bindingKey] = {
       create: async (options) => {
+        const params = await validateWorkflowParams(entry, options?.params);
         const created = await runWithContext(runner, () =>
-          adapter.createInstance(workflowName, options),
+          adapter.createInstance(workflowName, { id: options?.id, params }),
         );
-        return createInstanceBinding(workflowName, created.id, adapter, runner);
+        return createInstanceBinding<TOutput>(workflowName, created.id, adapter, runner);
       },
       createBatch: async (batch) => {
+        const validatedBatch = await Promise.all(
+          batch.map(async (instance) => ({
+            id: instance.id,
+            params: await validateWorkflowParams(entry, instance.params),
+          })),
+        );
         const created = await runWithContext(runner, () =>
-          adapter.createBatch(workflowName, batch),
+          adapter.createBatch(workflowName, validatedBatch),
         );
         return created.map((instance) =>
-          createInstanceBinding(workflowName, instance.id, adapter, runner),
+          createInstanceBinding<TOutput>(workflowName, instance.id, adapter, runner),
         );
       },
-      get: async (id) => createInstanceBinding(workflowName, id, adapter, runner),
+      get: async (id) => createInstanceBinding<TOutput>(workflowName, id, adapter, runner),
+    } as WorkflowBindings<TRegistry>[typeof bindingKey] & {
+      create: (options?: { id?: string; params?: TParams }) => Promise<WorkflowInstance<TOutput>>;
     };
   }
 
   return bindings;
 }
 
-export function attachWorkflowsBindings<T extends FragmentWithWorkflowsServices>(
+export function attachWorkflowsBindings<
+  T extends FragmentWithWorkflowsServices,
+  TRegistry extends WorkflowsRegistry,
+>(
   fragment: T,
-  workflows: WorkflowsRegistry = {},
-): T & { workflows: WorkflowBindings } {
+  workflows: TRegistry = {} as TRegistry,
+): T & { workflows: WorkflowBindings<TRegistry> } {
   const runService = <TResult>(call: () => unknown) =>
     fragment.inContext(function (this: { handlerTx: () => unknown }) {
       return (

--- a/packages/fragment-workflows/src/client/routes.ts
+++ b/packages/fragment-workflows/src/client/routes.ts
@@ -171,7 +171,12 @@ export const workflowsRoutesFactoryClient = defineRoutes().create(({ defineRoute
       id: z.string(),
       details: instanceStatusOutputSchema,
     }),
-    errorCodes: ["WORKFLOW_NOT_FOUND", "INVALID_INSTANCE_ID", "INSTANCE_ID_ALREADY_EXISTS"],
+    errorCodes: [
+      "WORKFLOW_NOT_FOUND",
+      "INVALID_INSTANCE_ID",
+      "INSTANCE_ID_ALREADY_EXISTS",
+      "WORKFLOW_PARAMS_INVALID",
+    ],
     handler: stubHandler,
   }),
   defineRoute({
@@ -186,7 +191,7 @@ export const workflowsRoutesFactoryClient = defineRoutes().create(({ defineRoute
         }),
       ),
     }),
-    errorCodes: ["WORKFLOW_NOT_FOUND", "INVALID_INSTANCE_ID"],
+    errorCodes: ["WORKFLOW_NOT_FOUND", "INVALID_INSTANCE_ID", "WORKFLOW_PARAMS_INVALID"],
     handler: stubHandler,
   }),
   defineRoute({

--- a/packages/fragment-workflows/src/index.test.ts
+++ b/packages/fragment-workflows/src/index.test.ts
@@ -6,18 +6,23 @@ import { workflowsFragmentDefinition } from "./definition";
 import { workflowsRoutesFactory } from "./routes";
 import { workflowsSchema } from "./schema";
 import { attachWorkflowsBindings } from "./bindings";
-import { NonRetryableError, WorkflowEntrypoint } from "./workflow";
-import type { WorkflowEvent, WorkflowStep } from "./workflow";
+import {
+  NonRetryableError,
+  defineWorkflow,
+  type WorkflowEvent,
+  type WorkflowStep,
+} from "./workflow";
 
 describe("Workflows Fragment", () => {
-  class DemoWorkflow extends WorkflowEntrypoint {
-    run(_event: WorkflowEvent<unknown>, _step: WorkflowStep) {
+  const DemoWorkflow = defineWorkflow(
+    { name: "demo-workflow" },
+    (_event: WorkflowEvent<unknown>, _step: WorkflowStep) => {
       return undefined;
-    }
-  }
+    },
+  );
 
   const workflows = {
-    DEMO: { name: "demo-workflow", workflow: DemoWorkflow },
+    DEMO: DemoWorkflow,
   } as const;
   const runner = {
     tick: vi.fn(),

--- a/packages/fragment-workflows/src/index.ts
+++ b/packages/fragment-workflows/src/index.ts
@@ -5,13 +5,13 @@ import { workflowsFragmentDefinition } from "./definition";
 import { workflowsRoutesFactory } from "./routes";
 import { workflowsSchema } from "./schema";
 import { createWorkflowsRunner } from "./runner";
-import type { WorkflowsFragmentConfig } from "./workflow";
+import type { WorkflowsFragmentConfig, WorkflowsRegistry } from "./workflow";
 
 const routes = [workflowsRoutesFactory] as const;
 
 /** Create a workflows fragment with routes, bindings, and database integration. */
-export function createWorkflowsFragment(
-  config: WorkflowsFragmentConfig,
+export function createWorkflowsFragment<TRegistry extends WorkflowsRegistry>(
+  config: WorkflowsFragmentConfig<TRegistry>,
   fragnoConfig: FragnoPublicConfigWithDatabase,
 ) {
   const fragment = instantiate(workflowsFragmentDefinition)
@@ -20,7 +20,7 @@ export function createWorkflowsFragment(
     .withOptions(fragnoConfig)
     .build();
 
-  return attachWorkflowsBindings(fragment, config.workflows ?? {});
+  return attachWorkflowsBindings(fragment, config.workflows ?? ({} as TRegistry));
 }
 
 export { workflowsFragmentDefinition };
@@ -29,4 +29,6 @@ export { workflowsSchema };
 export { createWorkflowsRunner };
 export { attachWorkflowsBindings };
 export { createWorkflowsClients } from "./client/clients";
+export { defineWorkflow } from "./workflow";
+export type { WorkflowContext, WorkflowDefinition } from "./workflow";
 export * from "./workflow";

--- a/packages/fragment-workflows/src/model-checker-runner.test.ts
+++ b/packages/fragment-workflows/src/model-checker-runner.test.ts
@@ -7,19 +7,20 @@ import {
 import type { SimpleQueryInterface } from "@fragno-dev/db/query";
 import type { UnitOfWorkConfig } from "@fragno-dev/db/unit-of-work";
 import { workflowsSchema } from "./schema";
-import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from "./workflow";
+import { defineWorkflow, type WorkflowEvent, type WorkflowStep } from "./workflow";
 import { createWorkflowsTestHarness, createWorkflowsTestRuntime } from "./test";
 import type { WorkflowsRegistry } from "./workflow";
 
-class DemoWorkflow extends WorkflowEntrypoint {
-  async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+const DemoWorkflow = defineWorkflow(
+  { name: "demo-workflow" },
+  async (_event: WorkflowEvent<unknown>, step: WorkflowStep) => {
     step.log.info("run", null, { category: "run" });
     return await step.do("noop", () => "ok");
-  }
-}
+  },
+);
 
 const workflows: WorkflowsRegistry = {
-  DEMO: { name: "demo-workflow", workflow: DemoWorkflow },
+  DEMO: DemoWorkflow,
 };
 
 describe("workflows model checker (runner)", () => {

--- a/specs/finished-implementation-plans/impl-workflows-fragment.md
+++ b/specs/finished-implementation-plans/impl-workflows-fragment.md
@@ -5,7 +5,7 @@ This plan assumes the design in `specs/spec-workflows-fragment.md`.
 ## Phase 0 — Grounding + references
 
 1. Pull Cloudflare API surface from `https://developers.cloudflare.com/workflows/llms-full.txt`:
-   - [x] `WorkflowEntrypoint`, `WorkflowStep`, `WorkflowEvent`, `WorkflowStepConfig`, `Workflow`
+   - [x] `defineWorkflow`, `WorkflowStep`, `WorkflowEvent`, `WorkflowStepConfig`, `Workflow`
    - [x] Instance management methods (`create/get/createBatch`,
          `pause/resume/restart/terminate/sendEvent`)
 2. Reconfirm Fragno DB primitives and durable hooks patterns:
@@ -23,11 +23,11 @@ This plan assumes the design in `specs/spec-workflows-fragment.md`.
 2. Ensure the main package is runtime-agnostic (SPEC §5.3 note); keep Cloudflare/Node APIs in the
    dispatcher packages.
 3. [x] Implement public types/classes per SPEC §6:
-   - `WorkflowEntrypoint`, `WorkflowStep`, `WorkflowEvent`, `WorkflowStepConfig`, `InstanceStatus`
+   - `defineWorkflow`, `WorkflowStep`, `WorkflowEvent`, `WorkflowStepConfig`, `InstanceStatus`
    - `NonRetryableError`
 4. [x] Implement the workflow registry + programmatic bindings API (SPEC §6.5, §6.6):
    - fragment exposes `fragment.workflows.<bindingKey>`
-   - workflows have access to `this.workflows` for child workflow creation
+   - workflows have access to `context.workflows` for child workflow creation
    - align `createBatch` typing with Cloudflare (`WorkflowInstanceCreateOptionsWithId`; SPEC §6.3)
 5. [x] Add minimal docs/examples mirroring `example-fragments/example-fragment/src/index.ts`.
 


### PR DESCRIPTION
- introduce defineWorkflow and schema-driven params/output typing
- validate params on create/createBatch (routes + bindings)
- update workflows docs, specs, tests, and examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `defineWorkflow` API for declaring workflows as functions instead of classes
  * Added parameter and output schema validation with TypeScript support
  * Enhanced type safety with generic typing for workflow registries and inputs/outputs

* **Bug Fixes**
  * Parameter validation now returns clear `WORKFLOW_PARAMS_INVALID` error for invalid inputs

* **Documentation**
  * Updated workflow examples and guides to demonstrate new API usage and schema validation patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->