### PR TITLE
feat(db): add runtime validation for table inserts

### DIFF
--- a/.changeset/calm-validators-null.md
+++ b/.changeset/calm-validators-null.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+feat: add runtime validation for table inserts

--- a/packages/fragno-db/package.json
+++ b/packages/fragno-db/package.json
@@ -138,6 +138,7 @@
   "license": "MIT",
   "dependencies": {
     "@paralleldrive/cuid2": "^2.3.1",
+    "@standard-schema/spec": "^1.1.0",
     "kysely": "^0.28.10",
     "superjson": "^2.2.1"
   },

--- a/packages/fragno-db/src/schema/validator.test.ts
+++ b/packages/fragno-db/src/schema/validator.test.ts
@@ -1,0 +1,197 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { describe, expect, it } from "vitest";
+import {
+  FragnoDbValidationError,
+  FragnoId,
+  FragnoReference,
+  column,
+  idColumn,
+  referenceColumn,
+  schema,
+} from "./create";
+
+const testSchema = schema("validation", (s) => {
+  return s
+    .addTable("users", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("name", column("string"))
+        .addColumn("age", column("integer").nullable())
+        .addColumn("status", column("string").defaultTo("active"));
+    })
+    .addTable("posts", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("userId", referenceColumn())
+        .addColumn("title", column("varchar(10)"));
+    })
+    .addTable("all_types", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("name", column("string"))
+        .addColumn("nickname", column("varchar(5)"))
+        .addColumn("age", column("integer"))
+        .addColumn("score", column("decimal"))
+        .addColumn("active", column("bool"))
+        .addColumn("bytes", column("binary"))
+        .addColumn("createdAt", column("timestamp"))
+        .addColumn("birthday", column("date"))
+        .addColumn("data", column("json"))
+        .addColumn("bigValue", column("bigint"))
+        .addColumn("ref", referenceColumn())
+        .addColumn("optionalWithDefault", column("string").defaultTo("x"))
+        .addColumn("optionalNullable", column("string").nullable());
+    });
+});
+
+const getIssues = async <Output>(
+  result: StandardSchemaV1.Result<Output> | Promise<StandardSchemaV1.Result<Output>>,
+) => {
+  const resolved = await result;
+  if (!("issues" in resolved) || !resolved.issues) {
+    throw new Error("Expected validation issues");
+  }
+
+  return resolved.issues;
+};
+
+const validAllTypes = () => ({
+  id: "id-1",
+  name: "Ada",
+  nickname: "Ada",
+  age: 30,
+  score: 12.5,
+  active: true,
+  bytes: new Uint8Array([1, 2, 3]),
+  createdAt: new Date(),
+  birthday: new Date("2000-01-01"),
+  data: { ok: true },
+  bigValue: 10n,
+  ref: "user-1",
+});
+
+describe("table validation", () => {
+  it("strips unknown keys by default", () => {
+    const users = testSchema.tables.users;
+    const result = users.validate({ id: "user-1", name: "Ada", extra: "nope" } as never);
+    expect(result).toEqual({ id: "user-1", name: "Ada" });
+  });
+
+  it("supports strict unknown keys via Standard Schema options", async () => {
+    const users = testSchema.tables.users;
+    const result = users["~standard"].validate(
+      { id: "user-1", name: "Ada", extra: "nope" },
+      { libraryOptions: { unknownKeys: "strict" } },
+    );
+
+    const issues = await getIssues(result);
+    expect(issues.length).toBeGreaterThan(0);
+  });
+
+  it("treats defaults as optional", () => {
+    const users = testSchema.tables.users;
+    expect(() => users.validate({ id: "user-1", name: "Ada" })).not.toThrow();
+  });
+
+  it("allows null for nullable columns", () => {
+    const users = testSchema.tables.users;
+    expect(() => users.validate({ id: "user-1", name: "Ada", age: null })).not.toThrow();
+  });
+
+  it("throws on missing required fields", () => {
+    const users = testSchema.tables.users;
+    expect(() => users.validate({} as never)).toThrow(FragnoDbValidationError);
+  });
+
+  it("accepts all supported column types", () => {
+    const allTypes = testSchema.tables.all_types;
+    const payload = validAllTypes();
+    const result = allTypes.validate(payload);
+    expect(result).toEqual(payload);
+  });
+
+  it("rejects non-object input", async () => {
+    const allTypes = testSchema.tables.all_types;
+    const result = allTypes["~standard"].validate("nope");
+    const issues = await getIssues(result);
+    expect(issues.length).toBeGreaterThan(0);
+  });
+
+  it("validates string and varchar length", async () => {
+    const users = testSchema.tables.users;
+    const posts = testSchema.tables.posts;
+
+    const longId = "a".repeat(31);
+    const longTitleResult = posts["~standard"].validate({
+      id: "post-1",
+      userId: "user-1",
+      title: "this is too long",
+    });
+    expect((await getIssues(longTitleResult)).length).toBeGreaterThan(0);
+
+    const longIdResult = users["~standard"].validate({ id: longId, name: "Ada" });
+    expect((await getIssues(longIdResult)).length).toBeGreaterThan(0);
+
+    const longIdFragno = new FragnoId({ externalId: longId, version: 1 });
+    const longFragnoResult = users["~standard"].validate({ id: longIdFragno, name: "Ada" });
+    expect((await getIssues(longFragnoResult)).length).toBeGreaterThan(0);
+  });
+
+  it("accepts and rejects reference values", async () => {
+    const posts = testSchema.tables.posts;
+
+    const ref = FragnoReference.fromInternal(1n);
+    const post = posts.validate({ id: "post-1", userId: ref, title: "hello" });
+    expect(post.userId).toBe(ref);
+
+    const fragnoId = FragnoId.fromExternal("user-1", 1);
+    expect(() => posts.validate({ id: "post-1", userId: fragnoId, title: "hello" })).not.toThrow();
+    expect(() => posts.validate({ id: "post-1", userId: 1n, title: "hello" })).not.toThrow();
+
+    const invalidRefResult = posts["~standard"].validate({
+      id: "post-1",
+      userId: { id: 1 },
+      title: "hello",
+    });
+    expect((await getIssues(invalidRefResult)).length).toBeGreaterThan(0);
+  });
+
+  it("accepts FragnoId values for id columns", () => {
+    const users = testSchema.tables.users;
+    const userId = FragnoId.fromExternal("user-1", 1);
+    const user = users.validate({ id: userId, name: "Ada" });
+    expect(user.id).toBe(userId);
+  });
+
+  it("validates integer, decimal, bool, bigint, binary, date, and timestamp", async () => {
+    const allTypes = testSchema.tables.all_types;
+
+    const invalidCases = [
+      { key: "name", value: 123 },
+      { key: "nickname", value: "toolong" },
+      { key: "age", value: 1.2 },
+      { key: "score", value: Number.NaN },
+      { key: "active", value: "true" },
+      { key: "bigValue", value: 1 },
+      { key: "bytes", value: "nope" },
+      { key: "createdAt", value: new Date("invalid") },
+      { key: "birthday", value: new Date("invalid") },
+    ] as const;
+
+    for (const testCase of invalidCases) {
+      const value = { ...validAllTypes(), [testCase.key]: testCase.value } as never;
+      const result = allTypes["~standard"].validate(value);
+      expect((await getIssues(result)).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects null for non-nullable fields", async () => {
+    const allTypes = testSchema.tables.all_types;
+    const result = allTypes["~standard"].validate({
+      ...validAllTypes(),
+      name: null,
+    });
+
+    expect((await getIssues(result)).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/fragno-db/src/schema/validator.ts
+++ b/packages/fragno-db/src/schema/validator.ts
@@ -1,0 +1,231 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type {
+  AnyColumn,
+  Table,
+  TableInsertValues,
+  TableUnknownKeysMode,
+  TableValidationOptions,
+} from "./create";
+
+export class FragnoDbValidationError extends Error {
+  readonly issues: readonly StandardSchemaV1.Issue[];
+
+  constructor(message: string, issues: readonly StandardSchemaV1.Issue[]) {
+    super(message);
+    this.name = "FragnoDbValidationError";
+    this.issues = issues;
+  }
+}
+
+type FragnoIdCtor = typeof import("./create").FragnoId;
+type FragnoReferenceCtor = typeof import("./create").FragnoReference;
+
+type ValidationClasses = {
+  FragnoId: FragnoIdCtor;
+  FragnoReference: FragnoReferenceCtor;
+};
+
+const defaultUnknownKeysMode: TableUnknownKeysMode = "strip";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseVarcharLength = (type: string): number | undefined => {
+  if (!type.startsWith("varchar(") || !type.endsWith(")")) {
+    return;
+  }
+
+  const rawLength = type.slice("varchar(".length, -1);
+  const length = Number(rawLength);
+  if (!Number.isFinite(length)) {
+    return;
+  }
+
+  return length;
+};
+
+const getUnknownKeysMode = (options?: StandardSchemaV1.Options): TableUnknownKeysMode => {
+  const libraryOptions = options?.libraryOptions as TableValidationOptions | undefined;
+  return libraryOptions?.unknownKeys ?? defaultUnknownKeysMode;
+};
+
+const validateColumnValue = (
+  col: AnyColumn,
+  value: unknown,
+  classes: ValidationClasses,
+): string | undefined => {
+  if (col.role === "external-id") {
+    if (value instanceof classes.FragnoId) {
+      const maxLength = parseVarcharLength(col.type);
+      if (maxLength !== undefined && value.externalId.length > maxLength) {
+        return `String must have at most ${maxLength} characters`;
+      }
+      return;
+    }
+
+    if (typeof value === "string") {
+      const maxLength = parseVarcharLength(col.type);
+      if (maxLength !== undefined && value.length > maxLength) {
+        return `String must have at most ${maxLength} characters`;
+      }
+      return;
+    }
+
+    return "Expected string or FragnoId";
+  }
+
+  if (col.role === "reference") {
+    if (
+      value instanceof classes.FragnoReference ||
+      value instanceof classes.FragnoId ||
+      typeof value === "string" ||
+      typeof value === "bigint"
+    ) {
+      return;
+    }
+
+    return "Expected reference (string, bigint, FragnoId, or FragnoReference)";
+  }
+
+  if (col.type === "string" || col.type.startsWith("varchar(")) {
+    if (typeof value !== "string") {
+      return "Expected string";
+    }
+
+    const maxLength = parseVarcharLength(col.type);
+    if (maxLength !== undefined && value.length > maxLength) {
+      return `String must have at most ${maxLength} characters`;
+    }
+
+    return;
+  }
+
+  if (col.type === "bigint") {
+    return typeof value === "bigint" ? undefined : "Expected bigint";
+  }
+
+  if (col.type === "integer") {
+    if (typeof value !== "number" || !Number.isInteger(value)) {
+      return "Expected integer";
+    }
+    return;
+  }
+
+  if (col.type === "decimal") {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return "Expected number";
+    }
+    return;
+  }
+
+  if (col.type === "bool") {
+    return typeof value === "boolean" ? undefined : "Expected boolean";
+  }
+
+  if (col.type === "binary") {
+    return value instanceof Uint8Array ? undefined : "Expected Uint8Array";
+  }
+
+  if (col.type === "date" || col.type === "timestamp") {
+    if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+      return "Expected valid Date";
+    }
+    return;
+  }
+
+  if (col.type === "json") {
+    return;
+  }
+
+  return;
+};
+
+const validateTableInsertValues = <TTable extends Table>(
+  table: TTable,
+  value: unknown,
+  options: StandardSchemaV1.Options | undefined,
+  classes: ValidationClasses,
+): StandardSchemaV1.Result<TableInsertValues<TTable>> => {
+  const issues: StandardSchemaV1.Issue[] = [];
+
+  if (!isRecord(value)) {
+    return { issues: [{ message: "Expected object" }] };
+  }
+
+  const input = value as Record<string, unknown>;
+  const entries = Object.entries(table.columns).filter(([, col]) => !col.isHidden);
+  const allowedKeys = new Set(entries.map(([key]) => key));
+  const unknownKeysMode = getUnknownKeysMode(options);
+
+  if (unknownKeysMode === "strict") {
+    for (const key of Object.keys(input)) {
+      if (!allowedKeys.has(key)) {
+        issues.push({ message: `Unknown key "${key}"`, path: [key] });
+      }
+    }
+  }
+
+  const output: Record<string, unknown> = {};
+
+  for (const [key, col] of entries) {
+    const hasKey = Object.prototype.hasOwnProperty.call(input, key);
+    const colValue = hasKey ? input[key] : undefined;
+    const allowsUndefined = col.isNullable || col.default !== undefined;
+    const allowsNull = col.isNullable;
+
+    if (colValue === undefined) {
+      if (!allowsUndefined) {
+        issues.push({ message: "Required", path: [key] });
+      }
+      continue;
+    }
+
+    if (colValue === null) {
+      if (!allowsNull) {
+        issues.push({ message: "Required", path: [key] });
+      } else {
+        output[key] = null;
+      }
+      continue;
+    }
+
+    const issue = validateColumnValue(col, colValue, classes);
+    if (issue) {
+      issues.push({ message: issue, path: [key] });
+      continue;
+    }
+
+    output[key] = colValue;
+  }
+
+  if (issues.length > 0) {
+    return { issues };
+  }
+
+  return { value: output as TableInsertValues<TTable> };
+};
+
+export const createTableStandardSchemaProps = <TTable extends Table>(
+  table: TTable,
+  classes: ValidationClasses,
+): StandardSchemaV1.Props<TableInsertValues<TTable>, TableInsertValues<TTable>> => ({
+  version: 1,
+  vendor: "fragno-db",
+  validate: (value: unknown, options?: StandardSchemaV1.Options) =>
+    validateTableInsertValues(table, value, options, classes),
+});
+
+export const createTableValidator = <TTable extends Table>(
+  table: TTable,
+  classes: ValidationClasses,
+) => {
+  return (value: unknown, options?: TableValidationOptions) => {
+    const result = validateTableInsertValues(table, value, { libraryOptions: options }, classes);
+
+    if (result.issues) {
+      throw new FragnoDbValidationError("Validation failed", result.issues);
+    }
+
+    return result.value as TableInsertValues<TTable>;
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1689,6 +1689,9 @@ importers:
       '@paralleldrive/cuid2':
         specifier: ^2.3.1
         version: 2.3.1
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       kysely:
         specifier: ^0.28.10
         version: 0.28.10


### PR DESCRIPTION
move table validation helpers into schema/validator

enforce null vs default handling for inserts

add schema validator tests