### PR TITLE
feat(core,db): add callServices helper

### DIFF
--- a/.changeset/bright-shrimps-callservices.md
+++ b/.changeset/bright-shrimps-callservices.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/core": patch
+"@fragno-dev/db": patch
+---
+
+feat: add callServices helper with implicit request context

--- a/packages/fragno/src/api/request-context-storage.ts
+++ b/packages/fragno/src/api/request-context-storage.ts
@@ -29,6 +29,13 @@ export class RequestContextStorage<TRequestStorage> {
   }
 
   /**
+   * Check whether a store is currently active.
+   */
+  hasStore(): boolean {
+    return this.#storage.getStore() !== undefined;
+  }
+
+  /**
    * Get the current stored data from AsyncLocalStorage.
    * @throws an error if called outside of a run() callback.
    *

--- a/packages/fragno/src/mod-client.ts
+++ b/packages/fragno/src/mod-client.ts
@@ -87,6 +87,7 @@ export function instantiate(_definition: unknown) {
     },
     withMiddleware: () => fragmentStub,
     inContext: <T>(callback: () => T) => callback(),
+    callServices: async (_serviceCalls: () => unknown) => [],
     handlersFor: () => ({}),
     handler: async () => new Response(),
     callRoute: async () => ({ ok: true, data: undefined, error: undefined }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `callServices` helper enabling execution of multiple service calls within a handler context with implicit request context support.
  * Supports executing single or batched service calls with results returned in matching input shapes.
  * Automatically detects and uses available request context storage when no explicit storage is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->