### PR TITLE
feat(db): migrate fragments to handlerTx/serviceTx

### DIFF
--- a/.changeset/clean-mice-heal.md
+++ b/.changeset/clean-mice-heal.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+feat: remove deps.db and add db-time helpers on builders

--- a/.changeset/sync-stripe-subscriptions.md
+++ b/.changeset/sync-stripe-subscriptions.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/stripe": patch
+---
+
+feat: accept fetched subscriptions in syncStripeSubscriptions

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/querying.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/querying.mdx
@@ -110,6 +110,20 @@ const [user] = await this.handlerTx()
 // user is User | null
 ```
 
+### Database Time in Queries
+
+Use `eb.now()` when you need the database’s notion of “now” inside query conditions:
+
+```typescript
+const [activeUsers] = await this.handlerTx()
+  .retrieve(({ forSchema }) =>
+    forSchema(mySchema).find("users", (b) =>
+      b.whereIndex("idx_expires_at", (eb) => eb("expiresAt", ">", eb.now())),
+    ),
+  )
+  .execute();
+```
+
 ### Cursor-Based Pagination
 
 Use cursor-based pagination for efficient paging through large result sets. Fragno DB provides
@@ -199,6 +213,18 @@ const { userId } = await this.handlerTx()
 await this.handlerTx()
   .mutate(({ forSchema }) => {
     forSchema(mySchema).update("users", userId, (b) => b.set({ name: "Alice Updated", age: 26 }));
+  })
+  .execute();
+```
+
+Use `b.now()` when writing database timestamps in mutations:
+
+```typescript
+await this.handlerTx()
+  .mutate(({ forSchema }) => {
+    forSchema(mySchema).update("users", userId, (b) =>
+      b.set({ updatedAt: b.now(), name: "Alice Updated" }),
+    );
   })
   .execute();
 ```

--- a/apps/docs/content/docs/fragno/for-library-authors/features/dependencies-and-services.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/features/dependencies-and-services.mdx
@@ -219,10 +219,11 @@ Fragments support three kinds of services:
 
 ## Database Integration
 
-Fragments with database layers have access to an additional `db` object in both `withDependencies()`
-and `providesService()` contexts. The `db` object provides type-safe database operations:
+Database fragments use the transaction builders exposed on the service/handler context:
+`this.serviceTx(schema)` inside services and `this.handlerTx()` inside handlers.
 
-Note that when using `withDatabase`, the database context is available in dependencies and services.
+For advanced cases, dependencies include `databaseAdapter`, `schema`, `namespace`, and
+`createUnitOfWork`, but the recommended path is the builder API.
 
 ```typescript
 import { defineFragment } from "@fragno-dev/core";
@@ -230,24 +231,20 @@ import { withDatabase } from "@fragno-dev/db";
 
 const fragmentDef = defineFragment("my-fragment")
   .extend(withDatabase(mySchema))
-  .withDependencies(({ config, db }) => {
-    // DB available in dependencies
-    return {
-      commentRepo: {
-        create: (data) => db.create("comment", data),
+  .providesBaseService(({ defineService }) =>
+    defineService({
+      createComment: function (data) {
+        return this.serviceTx(mySchema)
+          .mutate(({ uow }) => uow.create("comment", data))
+          .transform(({ mutateResult }) => ({ id: mutateResult.toString(), ...data }))
+          .build();
       },
-    };
-  })
-  .providesBaseService(({ config, deps, db }) => {
-    // DB available in services
-    return {
-      createComment: async (data) => {
-        const id = await deps.commentRepo.create(data);
-        return { id: id.toJSON(), ...data };
-      },
-    };
-  });
+    }),
+  );
 ```
+
+Use `function` (not an arrow function) for service or handler methods that call
+`this.serviceTx(...)` or `this.handlerTx()`. Arrow functions do not bind `this`.
 
 For more information, see the
 [Database Integration](/docs/fragno/for-library-authors/database-integration/overview) section.

--- a/apps/docs/content/docs/stripe/subscriptions.mdx
+++ b/apps/docs/content/docs/stripe/subscriptions.mdx
@@ -289,9 +289,9 @@ the checkout success page.
 
 ### Using `syncStripeSubscriptions`
 
-The fragment provides the `syncStripeSubscriptions` method as a fragment service. This method will
-fetch the latest subscriptions from Stripe and write it to your database. If no subscriptions are
-found for a customer, then the subscription will be dropped from the database.
+The fragment provides the `syncStripeSubscriptions` method as a fragment service. This method takes
+Stripe subscriptions you have already fetched and writes them to your database. If no subscriptions
+are provided for a customer, then the subscription will be dropped from the database.
 
 ```typescript
 import { stripeFragment } from "@/lib/stripe";
@@ -300,11 +300,17 @@ import { getSession } from "@/lib/auth";
 /* ... */
 
 const session = await getSession();
+const stripeClient = stripeFragment.services.getStripeClient();
+const stripeSubscriptions = await stripeClient.subscriptions.list({
+  customer: session.user.stripeCustomerId,
+  status: "all",
+});
 
-// Fetch latest subscription data from Stripe and sync to database
+// Sync latest subscription data to the database
 await stripeFragment.services.syncStripeSubscriptions(
   session.user.id, // referenceId
   session.user.stripeCustomerId, // stripeCustomerId
+  stripeSubscriptions.data,
 );
 
 // Now you can assume the db state is recent

--- a/apps/fragno-cli/src/utils/find-fragno-databases.ts
+++ b/apps/fragno-cli/src/utils/find-fragno-databases.ts
@@ -201,13 +201,15 @@ export function findFragnoDatabases(
       const options = internal.options as Record<string, unknown>;
 
       // Check if this is a database fragment by looking for implicit database dependencies
-      if (!deps["db"] || !deps["schema"]) {
+      if (!deps["schema"]) {
         continue;
       }
 
       const schema = deps["schema"] as AnySchema;
-      const namespace = deps["namespace"] as string;
-      const databaseAdapter = options["databaseAdapter"] as DatabaseAdapter | undefined;
+      const namespace = deps["namespace"] as string | null;
+      const databaseAdapter =
+        (deps["databaseAdapter"] as DatabaseAdapter | undefined) ??
+        (options["databaseAdapter"] as DatabaseAdapter | undefined);
 
       if (!databaseAdapter) {
         console.warn(

--- a/example-apps/fragno-db-usage-drizzle/src/commands/comment.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/commands/comment.ts
@@ -32,14 +32,16 @@ const commentCreateCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createCommentFragmentServer(adapter).services;
+    const fragment = createCommentFragmentServer(adapter);
 
-    const comment = await services.createComment({
-      title: ctx.values["title"] as string,
-      content: ctx.values["content"] as string,
-      postReference: ctx.values["postReference"] as string,
-      userReference: ctx.values["userReference"] as string,
-    });
+    const comment = await fragment.callServices(() =>
+      fragment.services.createComment({
+        title: ctx.values["title"] as string,
+        content: ctx.values["content"] as string,
+        postReference: ctx.values["postReference"] as string,
+        userReference: ctx.values["userReference"] as string,
+      }),
+    );
 
     console.log("Created comment:");
     console.log(JSON.stringify(comment, null, 2));
@@ -57,9 +59,11 @@ const commentListCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createCommentFragmentServer(adapter).services;
+    const fragment = createCommentFragmentServer(adapter);
     const postReference = ctx.values["postReference"] as string;
-    const comments = await services.getComments(postReference);
+    const comments = await fragment.callServices(() =>
+      fragment.services.getComments(postReference),
+    );
     console.log(`Comments for post ${postReference}:`);
     console.log(JSON.stringify(comments, null, 2));
   },

--- a/example-apps/fragno-db-usage-drizzle/src/commands/rating.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/commands/rating.ts
@@ -13,12 +13,12 @@ const ratingUpvoteCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer(adapter).services;
+    const fragment = createRatingFragmentServer(adapter);
     const reference = ctx.values["reference"] as string;
 
-    await services.postUpvote(reference);
+    await fragment.callServices(() => fragment.services.postUpvote(reference));
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Upvoted reference: ${reference}`);
     console.log(`Current rating: ${total}`);
   },
@@ -35,12 +35,12 @@ const ratingDownvoteCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer(adapter).services;
+    const fragment = createRatingFragmentServer(adapter);
     const reference = ctx.values["reference"] as string;
 
-    await services.postDownvote(reference);
+    await fragment.callServices(() => fragment.services.postDownvote(reference));
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Downvoted reference: ${reference}`);
     console.log(`Current rating: ${total}`);
   },
@@ -57,10 +57,10 @@ const ratingGetCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer(adapter).services;
+    const fragment = createRatingFragmentServer(adapter);
     const reference = ctx.values["reference"] as string;
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Rating for reference ${reference}: ${total}`);
   },
 };

--- a/example-apps/fragno-db-usage-kysely/src/commands/comment.ts
+++ b/example-apps/fragno-db-usage-kysely/src/commands/comment.ts
@@ -31,14 +31,16 @@ const commentCreateCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createCommentFragmentServer().services;
+    const fragment = createCommentFragmentServer();
 
-    const comment = await services.createComment({
-      title: ctx.values["title"] as string,
-      content: ctx.values["content"] as string,
-      postReference: ctx.values["postReference"] as string,
-      userReference: ctx.values["userReference"] as string,
-    });
+    const comment = await fragment.callServices(() =>
+      fragment.services.createComment({
+        title: ctx.values["title"] as string,
+        content: ctx.values["content"] as string,
+        postReference: ctx.values["postReference"] as string,
+        userReference: ctx.values["userReference"] as string,
+      }),
+    );
 
     console.log("Created comment:");
     console.log(JSON.stringify(comment, null, 2));
@@ -56,9 +58,11 @@ const commentListCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createCommentFragmentServer().services;
+    const fragment = createCommentFragmentServer();
     const postReference = ctx.values["postReference"] as string;
-    const comments = await services.getComments(postReference);
+    const comments = await fragment.callServices(() =>
+      fragment.services.getComments(postReference),
+    );
     console.log(`Comments for post ${postReference}:`);
     console.log(JSON.stringify(comments, null, 2));
   },

--- a/example-apps/fragno-db-usage-kysely/src/commands/rating.ts
+++ b/example-apps/fragno-db-usage-kysely/src/commands/rating.ts
@@ -12,12 +12,12 @@ const ratingUpvoteCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer().services;
+    const fragment = createRatingFragmentServer();
     const reference = ctx.values["reference"] as string;
 
-    await services.postUpvote(reference);
+    await fragment.callServices(() => fragment.services.postUpvote(reference));
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Upvoted reference: ${reference}`);
     console.log(`Current rating: ${total}`);
   },
@@ -34,12 +34,12 @@ const ratingDownvoteCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer().services;
+    const fragment = createRatingFragmentServer();
     const reference = ctx.values["reference"] as string;
 
-    await services.postDownvote(reference);
+    await fragment.callServices(() => fragment.services.postDownvote(reference));
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Downvoted reference: ${reference}`);
     console.log(`Current rating: ${total}`);
   },
@@ -56,10 +56,10 @@ const ratingGetCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer().services;
+    const fragment = createRatingFragmentServer();
     const reference = ctx.values["reference"] as string;
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Rating for reference ${reference}: ${total}`);
   },
 };

--- a/example-apps/fragno-db-usage-prisma/src/commands/comment.ts
+++ b/example-apps/fragno-db-usage-prisma/src/commands/comment.ts
@@ -31,15 +31,17 @@ const commentCreateCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createCommentFragmentServer().services;
+    const fragment = createCommentFragmentServer();
 
-    const comment = await services.createComment({
-      title: ctx.values["title"] as string,
-      content: ctx.values["content"] as string,
-      postReference: ctx.values["postReference"] as string,
-      userReference: ctx.values["userReference"] as string,
-      parentId: ctx.values["parentId"] as string | undefined,
-    });
+    const comment = await fragment.callServices(() =>
+      fragment.services.createComment({
+        title: ctx.values["title"] as string,
+        content: ctx.values["content"] as string,
+        postReference: ctx.values["postReference"] as string,
+        userReference: ctx.values["userReference"] as string,
+        parentId: ctx.values["parentId"] as string | undefined,
+      }),
+    );
 
     console.log("Created comment:");
     console.log(JSON.stringify(comment, null, 2));
@@ -57,9 +59,11 @@ const commentListCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createCommentFragmentServer().services;
+    const fragment = createCommentFragmentServer();
     const postReference = ctx.values["postReference"] as string;
-    const comments = await services.getComments(postReference);
+    const comments = await fragment.callServices(() =>
+      fragment.services.getComments(postReference),
+    );
     console.log(`Comments for post ${postReference}:`);
     console.log(JSON.stringify(comments, null, 2));
   },

--- a/example-apps/fragno-db-usage-prisma/src/commands/rating.ts
+++ b/example-apps/fragno-db-usage-prisma/src/commands/rating.ts
@@ -12,12 +12,12 @@ const ratingUpvoteCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer().services;
+    const fragment = createRatingFragmentServer();
     const reference = ctx.values["reference"] as string;
 
-    await services.postUpvote(reference);
+    await fragment.callServices(() => fragment.services.postUpvote(reference));
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Upvoted reference: ${reference}`);
     console.log(`Current rating: ${total}`);
   },
@@ -34,12 +34,12 @@ const ratingDownvoteCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer().services;
+    const fragment = createRatingFragmentServer();
     const reference = ctx.values["reference"] as string;
 
-    await services.postDownvote(reference);
+    await fragment.callServices(() => fragment.services.postDownvote(reference));
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Downvoted reference: ${reference}`);
     console.log(`Current rating: ${total}`);
   },
@@ -56,10 +56,10 @@ const ratingGetCommand: Command = {
     },
   },
   run: async (ctx) => {
-    const services = createRatingFragmentServer().services;
+    const fragment = createRatingFragmentServer();
     const reference = ctx.values["reference"] as string;
 
-    const total = await services.getRating(reference);
+    const total = await fragment.callServices(() => fragment.services.getRating(reference));
     console.log(`Rating for reference ${reference}: ${total}`);
   },
 };

--- a/example-apps/stripe-webshop/src/routes/api/subscription/status.ts
+++ b/example-apps/stripe-webshop/src/routes/api/subscription/status.ts
@@ -11,10 +11,17 @@ export const Route = createFileRoute("/api/subscription/status")({
         });
 
         if (session?.user?.id && session?.user?.stripeCustomerId) {
+          const stripeClient = stripeFragment.services.getStripeClient();
+          const stripeSubscriptions = await stripeClient.subscriptions.list({
+            customer: session.user.stripeCustomerId,
+            status: "all",
+          });
+
           // Sync subscription from Stripe to ensure database is up-to-date
           await stripeFragment.services.syncStripeSubscriptions(
             session.user.id,
             session.user.stripeCustomerId,
+            stripeSubscriptions.data,
           );
         } else {
           throw new Error("User not linked to Stripe account");

--- a/example-fragments/fragno-db-library/src/mod.test.ts
+++ b/example-fragments/fragno-db-library/src/mod.test.ts
@@ -10,12 +10,14 @@ describe("comment-fragment", () => {
       .withFragment("comment", instantiate(commentFragmentDef).withConfig({}).withRoutes([]))
       .build();
 
-    const query = await fragments.comment.services.createComment({
-      title: "Test comment",
-      content: "Test content",
-      postReference: "123",
-      userReference: "456",
-    });
+    const query = await fragments.comment.fragment.callServices(() =>
+      fragments.comment.services.createComment({
+        title: "Test comment",
+        content: "Test content",
+        postReference: "123",
+        userReference: "456",
+      }),
+    );
 
     expect(query).toMatchObject({
       id: expect.any(String),
@@ -25,7 +27,9 @@ describe("comment-fragment", () => {
       userReference: "456",
     });
 
-    const comments = await fragments.comment.services.getComments("123");
+    const comments = await fragments.comment.fragment.callServices(() =>
+      fragments.comment.services.getComments("123"),
+    );
     expect(comments).toMatchObject([query]);
 
     await test.cleanup();
@@ -53,7 +57,9 @@ describe("comment-fragment", () => {
       });
     });
 
-    const comments = await fragments.comment.services.getComments("post-sync");
+    const comments = await fragments.comment.fragment.callServices(() =>
+      fragments.comment.services.getComments("post-sync"),
+    );
     expect(comments).toHaveLength(1);
     expect(comments[0]).toMatchObject({
       title: "Sync comment",

--- a/example-fragments/fragno-db-library/src/upvote.test.ts
+++ b/example-fragments/fragno-db-library/src/upvote.test.ts
@@ -26,7 +26,9 @@ describe("rating-fragment sync commands", () => {
       });
     });
 
-    const total = await fragments.rating.services.getRating("post-1");
+    const total = await fragments.rating.fragment.callServices(() =>
+      fragments.rating.services.getRating("post-1"),
+    );
     expect(total).toBe(1);
 
     const upvotes = await test.inContext(function () {

--- a/packages/forms/src/routes.ts
+++ b/packages/forms/src/routes.ts
@@ -51,14 +51,17 @@ export const publicRoutes = defineRoutes(formsFragmentDef).create(
         path: "/:slug",
         outputSchema: FormSchema,
         errorCodes: ["NOT_FOUND"] as const,
-        handler: async ({ pathParams }, { json, error }) => {
+        handler: async function ({ pathParams }, { json, error }) {
           // Check static forms first
           const staticForm = config.staticForms?.find((f) => f.slug === pathParams.slug);
           if (staticForm) {
             return json(staticAsRegularForm(staticForm));
           }
 
-          const form = await services.getFormBySlug(pathParams.slug);
+          const form = await this.handlerTx()
+            .withServiceCalls(() => [services.getFormBySlug(pathParams.slug)] as const)
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
           if (!form) {
             return error({ message: "Form not found", code: "NOT_FOUND" }, 404);
           }
@@ -73,14 +76,17 @@ export const publicRoutes = defineRoutes(formsFragmentDef).create(
         inputSchema: NewFormResponseSchema,
         outputSchema: z.string(),
         errorCodes: ["NOT_FOUND", "VALIDATION_ERROR", "FORM_NOT_OPEN"] as const,
-        handler: async ({ input, pathParams, headers }, { json, error }) => {
+        handler: async function ({ input, pathParams, headers }, { json, error }) {
           const { data } = await input.valid();
 
           // Check static forms first
           const staticFormConfig = config.staticForms?.find((f) => f.slug === pathParams.slug);
           const form = staticFormConfig
             ? staticAsRegularForm(staticFormConfig)
-            : await services.getFormBySlug(pathParams.slug);
+            : await this.handlerTx()
+                .withServiceCalls(() => [services.getFormBySlug(pathParams.slug)] as const)
+                .transform(({ serviceResult: [result] }) => result)
+                .execute();
 
           if (!form) {
             return error({ message: "Form not found", code: "NOT_FOUND" }, 404);
@@ -105,12 +111,13 @@ export const publicRoutes = defineRoutes(formsFragmentDef).create(
           // Extract and validate request metadata from headers
           const metadata = extractRequestMetadata(headers);
 
-          const responseId = await services.createResponse(
-            form.id,
-            form.version,
-            result.data,
-            metadata,
-          );
+          const responseId = await this.handlerTx()
+            .withServiceCalls(
+              () =>
+                [services.createResponse(form.id, form.version, result.data, metadata)] as const,
+            )
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
 
           if (config.onResponseSubmitted) {
             await config.onResponseSubmitted({
@@ -139,8 +146,11 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
         method: "GET",
         path: "/admin/forms",
         outputSchema: z.array(FormSchema),
-        handler: async (_ctx, { json }) => {
-          const dbForms = await services.listForms();
+        handler: async function (_ctx, { json }) {
+          const dbForms = await this.handlerTx()
+            .withServiceCalls(() => [services.listForms()] as const)
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
           const staticForms = (config.staticForms ?? []).map(staticAsRegularForm);
           return json([...staticForms, ...dbForms]);
         },
@@ -151,14 +161,17 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
         path: "/admin/forms/:id",
         outputSchema: FormSchema,
         errorCodes: ["NOT_FOUND"] as const,
-        handler: async ({ pathParams }, { json, error }) => {
+        handler: async function ({ pathParams }, { json, error }) {
           // Check static forms first
           const staticForm = config.staticForms?.find((f) => f.id === pathParams.id);
           if (staticForm) {
             return json(staticAsRegularForm(staticForm));
           }
 
-          const form = await services.getForm(pathParams.id);
+          const form = await this.handlerTx()
+            .withServiceCalls(() => [services.getForm(pathParams.id)] as const)
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
           if (!form) {
             return error({ message: "Form not found", code: "NOT_FOUND" }, 404);
           }
@@ -173,7 +186,7 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
         inputSchema: NewFormSchema,
         outputSchema: z.string(),
         errorCodes: ["CREATE_FAILED", "INVALID_JSON_SCHEMA"] as const,
-        handler: async ({ input }, { json, error }) => {
+        handler: async function ({ input }, { json, error }) {
           const data = await input.valid();
 
           // Validate that dataSchema is valid JSON Schema
@@ -184,7 +197,10 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
             return error({ message, code: "INVALID_JSON_SCHEMA" }, 400);
           }
 
-          const formId = await services.createForm(data);
+          const formId = await this.handlerTx()
+            .withServiceCalls(() => [services.createForm(data)] as const)
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
           if (config.onFormCreated) {
             await config.onFormCreated({ ...data, id: formId });
           }
@@ -197,7 +213,7 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
         path: "/admin/forms/:id",
         inputSchema: UpdateFormSchema,
         errorCodes: ["NOT_FOUND", "STATIC_FORM_READ_ONLY", "INVALID_JSON_SCHEMA"] as const,
-        handler: async ({ input, pathParams }, { json, error }) => {
+        handler: async function ({ input, pathParams }, { json, error }) {
           const isStatic = config.staticForms?.some((f) => f.id === pathParams.id);
           if (isStatic) {
             return error(
@@ -217,7 +233,10 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
             }
           }
 
-          const { success } = await services.updateForm(pathParams.id, data);
+          const { success } = await this.handlerTx()
+            .withServiceCalls(() => [services.updateForm(pathParams.id, data)] as const)
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
           if (!success) {
             return error({ message: "Form not found", code: "NOT_FOUND" }, 404);
           }
@@ -229,7 +248,7 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
         method: "DELETE",
         path: "/admin/forms/:id",
         errorCodes: ["NOT_FOUND", "STATIC_FORM_READ_ONLY"] as const,
-        handler: async ({ pathParams }, { json, error }) => {
+        handler: async function ({ pathParams }, { json, error }) {
           const isStatic = config.staticForms?.some((f) => f.id === pathParams.id);
           if (isStatic) {
             return error(
@@ -237,7 +256,9 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
               403,
             );
           }
-          await services.deleteForm(pathParams.id);
+          await this.handlerTx()
+            .withServiceCalls(() => [services.deleteForm(pathParams.id)] as const)
+            .execute();
           // TODO: 404 when form not found
           // if (!deleted) {
           //   return error({ message: "Form not found", code: "NOT_FOUND" }, 404);
@@ -251,12 +272,20 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
         path: "/admin/forms/:id/submissions",
         queryParameters: ["sortOrder"] as const,
         outputSchema: z.array(FormResponseSchema),
-        handler: async ({ pathParams, query }, { json }) => {
+        handler: async function ({ pathParams, query }, { json }) {
           const sortOrder = query.get("sortOrder") === "asc" ? "asc" : "desc";
-          const responses = await services.listResponses(pathParams.id, {
-            field: "submittedAt",
-            order: sortOrder,
-          });
+          const responses = await this.handlerTx()
+            .withServiceCalls(
+              () =>
+                [
+                  services.listResponses(pathParams.id, {
+                    field: "submittedAt",
+                    order: sortOrder,
+                  }),
+                ] as const,
+            )
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
           return json(responses);
         },
       }),
@@ -266,8 +295,11 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
         path: "/admin/submissions/:id",
         outputSchema: FormResponseSchema,
         errorCodes: ["NOT_FOUND"] as const,
-        handler: async ({ pathParams }, { json, error }) => {
-          const response = await services.getResponse(pathParams.id);
+        handler: async function ({ pathParams }, { json, error }) {
+          const response = await this.handlerTx()
+            .withServiceCalls(() => [services.getResponse(pathParams.id)] as const)
+            .transform(({ serviceResult: [result] }) => result)
+            .execute();
           if (!response) {
             return error({ message: "Submission not found", code: "NOT_FOUND" }, 404);
           }
@@ -279,8 +311,10 @@ export const adminRoutes = defineRoutes(formsFragmentDef).create(
         method: "DELETE",
         path: "/admin/submissions/:id",
         errorCodes: ["NOT_FOUND"] as const,
-        handler: async ({ pathParams }, { json }) => {
-          await services.deleteResponse(pathParams.id);
+        handler: async function ({ pathParams }, { json }) {
+          await this.handlerTx()
+            .withServiceCalls(() => [services.deleteResponse(pathParams.id)] as const)
+            .execute();
           // TODO: 404 when response not found
           // if (!deleted) {
           //   return error({ message: "Submission not found", code: "NOT_FOUND" }, 404);

--- a/packages/fragment-workflows/src/definition.ts
+++ b/packages/fragment-workflows/src/definition.ts
@@ -294,9 +294,9 @@ export const workflowsFragmentDefinition = defineFragment<WorkflowsFragmentConfi
       await config.runner?.tick();
     }),
   }))
-  .providesBaseService(({ defineService, config, deps }) => {
+  .providesBaseService(({ defineService, config }) => {
     const getNow = () => config.runtime.time.now();
-    const getDbNow = async () => (deps.db.now ? deps.db.now() : getNow());
+    const getDbNow = async () => getNow();
     const getRunAtNow = () => config.dbNow?.() ?? dbNow();
     const randomFloat = () => config.runtime.random.float();
     const workflowsByName = new Map<string, WorkflowRegistryEntry>();

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-adapter.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-adapter.ts
@@ -7,6 +7,7 @@ import {
 } from "../adapters";
 import type { AnySchema, AnyTable, FragnoId } from "../../schema/create";
 import type { SimpleQueryInterface, TableToUpdateValues } from "../../query/simple-query-interface";
+import { dbNow } from "../../query/db-now";
 import {
   resolveInMemoryAdapterOptions,
   type InMemoryAdapterOptions,
@@ -41,6 +42,10 @@ class UpdateManySpecialBuilder<TTable extends AnyTable> {
   set(values: TableToUpdateValues<TTable>): this {
     this.#setValues = values;
     return this;
+  }
+
+  now() {
+    return dbNow();
   }
 
   getConfig() {

--- a/packages/fragno-db/src/adapters/shared/from-unit-of-work-compiler.ts
+++ b/packages/fragno-db/src/adapters/shared/from-unit-of-work-compiler.ts
@@ -1,4 +1,5 @@
 import type { SimpleQueryInterface, TableToUpdateValues } from "../../query/simple-query-interface";
+import { dbNow } from "../../query/db-now";
 import type { AnySchema, AnyTable, FragnoId } from "../../schema/create";
 import type {
   CompiledMutation,
@@ -91,6 +92,10 @@ class UpdateManySpecialBuilder<TTable extends AnyTable> {
   set(values: TableToUpdateValues<TTable>): this {
     this.#setValues = values;
     return this;
+  }
+
+  now() {
+    return dbNow();
   }
 
   getConfig() {

--- a/packages/fragno-db/src/browser/mod.ts
+++ b/packages/fragno-db/src/browser/mod.ts
@@ -34,6 +34,8 @@ export {
   type CursorResult,
 } from "../query/cursor";
 
+export { dbNow, type DbNow } from "../query/db-now";
+
 export const withDatabase: typeof withDatabaseType = () => {
   throw new Error("withDatabase is not available in browser builds.");
 };

--- a/packages/fragno-db/src/fragments/internal-fragment.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.ts
@@ -87,14 +87,6 @@ export const internalFragmentDef = new DatabaseFragmentDefinitionBuilder(
   >("$fragno-internal-fragment"),
   internalSchema,
 )
-  .providesBaseService(({ deps }) => ({
-    getDbNow: async () => {
-      if (deps.db.now) {
-        return deps.db.now();
-      }
-      return new Date();
-    },
-  }))
   .providesService("settingsService", ({ defineService }) => {
     return defineService({
       /**

--- a/packages/fragno-db/src/hooks/durable-hooks-processor.test.ts
+++ b/packages/fragno-db/src/hooks/durable-hooks-processor.test.ts
@@ -88,8 +88,7 @@ describe("createDurableHooksProcessor", () => {
     expect(processor).not.toBeNull();
 
     const internalFragment = getInternalFragment(adapter);
-    const services = internalFragment.services as { getDbNow?: () => Promise<Date> };
-    const baseNow = services.getDbNow ? await services.getDbNow() : new Date();
+    const baseNow = new Date();
 
     await internalFragment.inContext(async function () {
       await this.handlerTx()
@@ -113,6 +112,6 @@ describe("createDurableHooksProcessor", () => {
 
     const wakeAt = await processor!.getNextWakeAt();
     expect(wakeAt).toBeInstanceOf(Date);
-    expect(wakeAt!.getTime()).toBeLessThanOrEqual(baseNow.getTime());
+    expect(wakeAt!.getTime()).toBeLessThanOrEqual(Date.now());
   });
 });

--- a/packages/fragno-db/src/hooks/durable-hooks-processor.ts
+++ b/packages/fragno-db/src/hooks/durable-hooks-processor.ts
@@ -45,8 +45,7 @@ export function createDurableHooksProcessor<TSchema extends AnySchema>(
     process: async () => scheduler.schedule(),
     drain: async () => scheduler.drain(),
     getNextWakeAt: async () => {
-      const services = internalFragment.services as { getDbNow?: () => Promise<Date> };
-      const now = services.getDbNow ? await services.getDbNow() : new Date();
+      const now = new Date();
       return await internalFragment.inContext(async function () {
         return await this.handlerTx()
           .withServiceCalls(

--- a/packages/fragno-db/src/hooks/hooks.ts
+++ b/packages/fragno-db/src/hooks/hooks.ts
@@ -206,14 +206,7 @@ export async function processHooks<THooks extends HooksMap>(
   const stuckProcessingTimeoutMinutes = resolveStuckProcessingTimeoutMinutes(
     config.stuckProcessingTimeoutMinutes,
   );
-  const getDbNow = async () => {
-    const services = internalFragment.services as { getDbNow?: () => Promise<Date> };
-    if (services.getDbNow) {
-      return services.getDbNow();
-    }
-    return new Date();
-  };
-  const dbNow = await getDbNow();
+  const dbNow = new Date();
 
   if (stuckProcessingTimeoutMinutes !== false) {
     const staleBefore = new Date(dbNow.getTime() - stuckProcessingTimeoutMinutes * 60_000);

--- a/packages/fragno-db/src/query/condition-builder.test.ts
+++ b/packages/fragno-db/src/query/condition-builder.test.ts
@@ -101,6 +101,12 @@ describe("ConditionBuilder", () => {
       });
     });
 
+    it("should expose db now helper", () => {
+      const builder = createBuilder(usersTable.columns);
+
+      expect(builder.now()).toEqual({ tag: "db-now" });
+    });
+
     it("should support boolean columns", () => {
       const postsTable = testSchema.tables.posts;
       const builder = createBuilder(postsTable.columns);

--- a/packages/fragno-db/src/query/condition-builder.ts
+++ b/packages/fragno-db/src/query/condition-builder.ts
@@ -1,4 +1,5 @@
 import type { AnyColumn, FragnoId, IdColumn } from "../schema/create";
+import { dbNow, type DbNow } from "./db-now";
 
 export type ConditionType = "compare" | "and" | "or" | "not";
 
@@ -54,6 +55,7 @@ export type ConditionBuilder<Columns extends Record<string, AnyColumn>> = {
 
   isNull: (a: keyof Columns) => Condition;
   isNotNull: (a: keyof Columns) => Condition;
+  now: () => DbNow;
 };
 
 // replacement for `like` (Prisma doesn't support `like`)
@@ -117,6 +119,7 @@ export function createBuilder<Columns extends Record<string, AnyColumn>>(
 
   builder.isNull = (a) => builder(a, "is", null);
   builder.isNotNull = (a) => builder(a, "is not", null);
+  builder.now = () => dbNow();
   builder.not = (condition) => {
     if (typeof condition === "boolean") {
       return !condition;
@@ -249,6 +252,7 @@ export function createIndexedBuilder<Columns extends Record<string, AnyColumn>>(
 
   builder.isNull = (a) => builder(a, "is", null);
   builder.isNotNull = (a) => builder(a, "is not", null);
+  builder.now = () => dbNow();
   builder.not = (condition) => {
     if (typeof condition === "boolean") {
       return !condition;

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
@@ -9,6 +9,7 @@ import type {
 import { FragnoId } from "../../schema/create";
 import { generateId } from "../../schema/generate-id";
 import type { Condition, ConditionBuilder } from "../condition-builder";
+import { dbNow, type DbNow } from "../db-now";
 import type {
   SelectClause,
   TableToInsertValues,
@@ -33,6 +34,7 @@ export interface UpdateManyBuilder<TTable extends AnyTable> {
     condition?: (eb: IndexSpecificConditionBuilder<TTable, TIndexName>) => Condition | boolean,
   ): this;
   set(values: TableToUpdateValues<TTable>): this;
+  now(): DbNow;
 }
 
 /**
@@ -574,6 +576,13 @@ export class UpdateBuilder<TTable extends AnyTable> {
   set(values: TableToUpdateValues<TTable>): this {
     this.#setValues = values;
     return this;
+  }
+
+  /**
+   * Database timestamp helper for mutation values.
+   */
+  now(): DbNow {
+    return dbNow();
   }
 
   /**

--- a/packages/fragno/src/api/fragment-instantiator.ts
+++ b/packages/fragno/src/api/fragment-instantiator.ts
@@ -437,11 +437,12 @@ export class FragnoInstantiatedFragment<
 
     let callWasArray = false;
     const execute = () => {
-      const calls = serviceCalls();
-      callWasArray = Array.isArray(calls);
-      const callArray = (callWasArray ? calls : [calls]) as readonly unknown[];
       return handlerContext.handlerTx!()
-        .withServiceCalls(() => callArray)
+        .withServiceCalls(() => {
+          const calls = serviceCalls();
+          callWasArray = Array.isArray(calls);
+          return (callWasArray ? calls : [calls]) as readonly unknown[];
+        })
         .execute();
     };
 

--- a/packages/lofi/src/query/conditions.ts
+++ b/packages/lofi/src/query/conditions.ts
@@ -1,3 +1,4 @@
+import { dbNow, type DbNow } from "@fragno-dev/db";
 import type { AnyColumn } from "@fragno-dev/db/schema";
 
 export type ConditionType = "compare" | "and" | "or" | "not";
@@ -39,6 +40,7 @@ export type ConditionBuilder<Columns extends Record<string, AnyColumn>> = {
 
   isNull: (a: keyof Columns) => Condition;
   isNotNull: (a: keyof Columns) => Condition;
+  now: () => DbNow;
 };
 
 const stringOperators = [
@@ -97,6 +99,7 @@ export function createBuilder<Columns extends Record<string, AnyColumn>>(
 
   builder.isNull = (a) => builder(a, "is", null);
   builder.isNotNull = (a) => builder(a, "is not", null);
+  builder.now = () => dbNow();
   builder.not = (condition) => {
     if (typeof condition === "boolean") {
       return !condition;

--- a/packages/lofi/src/testing/outbox-sync.test.ts
+++ b/packages/lofi/src/testing/outbox-sync.test.ts
@@ -14,6 +14,7 @@ import { defineFragment, instantiate } from "@fragno-dev/core";
 import {
   InMemoryAdapter,
   getInternalFragment,
+  type ImplicitDatabaseDependencies,
   type InternalFragmentInstance,
   type OutboxEntry,
   withDatabase,
@@ -74,10 +75,11 @@ async function buildOutboxContext(): Promise<OutboxContext> {
     .withOptions({ databaseAdapter: adapter, outbox: { enabled: true } })
     .build();
 
-  const deps = fragment.$internal.deps as { db: OutboxContext["db"] };
+  const deps = fragment.$internal.deps as ImplicitDatabaseDependencies<typeof appSchema>;
+  const db = deps.databaseAdapter.createQueryEngine(deps.schema, deps.namespace);
 
   return {
-    db: deps.db,
+    db,
     internalFragment: getInternalFragment(adapter),
     cleanup: async () => {
       await adapter.close();

--- a/packages/stripe/src/routes/subscriptions.test.ts
+++ b/packages/stripe/src/routes/subscriptions.test.ts
@@ -86,20 +86,22 @@ describe("subscription handlers", async () => {
 
     test("should return all subscriptions after creating one", async () => {
       // Create test subscription
-      await fragment.services.createSubscription({
-        referenceId: "user_1",
-        stripePriceId: "price_1",
-        stripeCustomerId: "cus_1",
-        stripeSubscriptionId: "sub_1",
-        status: "active",
-        periodStart: new Date(),
-        periodEnd: new Date(),
-        trialStart: null,
-        trialEnd: null,
-        cancelAtPeriodEnd: false,
-        cancelAt: null,
-        seats: 1,
-      });
+      await fragment.fragment.callServices(() =>
+        fragment.services.createSubscription({
+          referenceId: "user_1",
+          stripePriceId: "price_1",
+          stripeCustomerId: "cus_1",
+          stripeSubscriptionId: "sub_1",
+          status: "active",
+          periodStart: new Date(),
+          periodEnd: new Date(),
+          trialStart: null,
+          trialEnd: null,
+          cancelAtPeriodEnd: false,
+          cancelAt: null,
+          seats: 1,
+        }),
+      );
 
       const response = await fragment.callRoute("GET", "/admin/subscriptions");
 
@@ -257,20 +259,22 @@ describe("subscription handlers", async () => {
 
     test("should upgrade existing active subscription using billing portal", async () => {
       // Create existing subscription
-      const subscription = await fragment.services.createSubscription({
-        referenceId: "user_123",
-        stripePriceId: "price_old",
-        stripeCustomerId: "cus_123",
-        stripeSubscriptionId: "sub_123",
-        status: "active",
-        periodStart: new Date(),
-        periodEnd: new Date(),
-        trialStart: null,
-        trialEnd: null,
-        cancelAtPeriodEnd: false,
-        cancelAt: null,
-        seats: 1,
-      });
+      const subscription = await fragment.fragment.callServices(() =>
+        fragment.services.createSubscription({
+          referenceId: "user_123",
+          stripePriceId: "price_old",
+          stripeCustomerId: "cus_123",
+          stripeSubscriptionId: "sub_123",
+          status: "active",
+          periodStart: new Date(),
+          periodEnd: new Date(),
+          trialStart: null,
+          trialEnd: null,
+          cancelAtPeriodEnd: false,
+          cancelAt: null,
+          seats: 1,
+        }),
+      );
 
       // Mock auth middleware to return user with existing subscription
       mockResolveEntityFromRequest.mockResolvedValue({
@@ -343,20 +347,22 @@ describe("subscription handlers", async () => {
   describe("POST /subscription/cancel", () => {
     test("should cancel active subscription", async () => {
       // Create active subscription
-      await fragment.services.createSubscription({
-        referenceId: "user_123",
-        stripePriceId: "price_123",
-        stripeCustomerId: "cust_active_1",
-        stripeSubscriptionId: "sub_123",
-        status: "active",
-        periodStart: new Date(),
-        periodEnd: new Date(),
-        trialStart: null,
-        trialEnd: null,
-        cancelAtPeriodEnd: false,
-        cancelAt: null,
-        seats: 1,
-      });
+      await fragment.fragment.callServices(() =>
+        fragment.services.createSubscription({
+          referenceId: "user_123",
+          stripePriceId: "price_123",
+          stripeCustomerId: "cust_active_1",
+          stripeSubscriptionId: "sub_123",
+          status: "active",
+          periodStart: new Date(),
+          periodEnd: new Date(),
+          trialStart: null,
+          trialEnd: null,
+          cancelAtPeriodEnd: false,
+          cancelAt: null,
+          seats: 1,
+        }),
+      );
 
       // Mock auth middleware to return user with active subscription
       mockResolveEntityFromRequest.mockResolvedValue({
@@ -425,20 +431,22 @@ describe("subscription handlers", async () => {
 
     test("should return error when subscription already canceled", async () => {
       // Create canceled subscription
-      await fragment.services.createSubscription({
-        referenceId: "user_123",
-        stripePriceId: "price_123",
-        stripeCustomerId: "cus_of_cancelled_sub",
-        stripeSubscriptionId: "sub_123",
-        status: "canceled",
-        periodStart: new Date(),
-        periodEnd: new Date(),
-        trialStart: null,
-        trialEnd: null,
-        cancelAtPeriodEnd: true,
-        cancelAt: new Date(),
-        seats: 1,
-      });
+      await fragment.fragment.callServices(() =>
+        fragment.services.createSubscription({
+          referenceId: "user_123",
+          stripePriceId: "price_123",
+          stripeCustomerId: "cus_of_cancelled_sub",
+          stripeSubscriptionId: "sub_123",
+          status: "canceled",
+          periodStart: new Date(),
+          periodEnd: new Date(),
+          trialStart: null,
+          trialEnd: null,
+          cancelAtPeriodEnd: true,
+          cancelAt: new Date(),
+          seats: 1,
+        }),
+      );
 
       // Mock auth middleware to return user with canceled subscription
       mockResolveEntityFromRequest.mockResolvedValue({
@@ -476,11 +484,15 @@ describe("subscription handlers", async () => {
         cancelAt: null,
         seats: 1,
       };
-      const sub1 = await fragment.services.createSubscription(subscriptionData);
-      const _sub2 = await fragment.services.createSubscription({
-        ...subscriptionData,
-        stripeSubscriptionId: "sub_456",
-      });
+      const sub1 = await fragment.fragment.callServices(() =>
+        fragment.services.createSubscription(subscriptionData),
+      );
+      const _sub2 = await fragment.fragment.callServices(() =>
+        fragment.services.createSubscription({
+          ...subscriptionData,
+          stripeSubscriptionId: "sub_456",
+        }),
+      );
 
       mockResolveEntityFromRequest.mockResolvedValue({
         referenceId: "user_123",

--- a/packages/stripe/src/routes/webhooks.ts
+++ b/packages/stripe/src/routes/webhooks.ts
@@ -14,7 +14,7 @@ export const webhookRoutesFactory = defineRoutes(stripeFragmentDefinition).creat
           success: z.boolean(),
         }),
         errorCodes: ["MISSING_SIGNATURE", "WEBHOOK_SIGNATURE_INVALID", "WEBHOOK_ERROR"] as const,
-        handler: async ({ headers, rawBody }, { json, error }) => {
+        handler: async function ({ headers, rawBody }, { json, error }) {
           // Get the signature
           const signature = headers.get("stripe-signature");
 
@@ -76,7 +76,7 @@ export const webhookRoutesFactory = defineRoutes(stripeFragmentDefinition).creat
           }
 
           deps.log.info(`Executing event handler for ${event.type}: ${event.id}`);
-          await eventHandler({ event, services, deps, config });
+          await eventHandler({ event, services, deps, config, handlerTx: this.handlerTx });
 
           return json({ success: true });
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database time helpers (db-now / now()) for use in queries and updates.

* **Refactor**
  * Migrated many fragments and services to a transaction-driven service API (serviceTx/handlerTx) and introduced a callServices wrapper.
  * Renamed public dependency surface from "db" to "databaseAdapter".
  * Updated APIs and routes to use function handlers and the new transaction patterns.

* **Documentation**
  * Updated docs and examples for database-time usage and the pre-fetched Stripe subscriptions pattern (syncStripeSubscriptions now accepts subscriptions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->