### PR TITLE
Wilco/query join refactor

### DIFF
--- a/.changeset/green-dingos-glow.md
+++ b/.changeset/green-dingos-glow.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+feat: add query-tree find APIs with nested joins and count support.

--- a/apps/backoffice/app/fragno/automation/routes.ts
+++ b/apps/backoffice/app/fragno/automation/routes.ts
@@ -175,7 +175,9 @@ export const automationFragmentRoutes = defineRoutes(automationFragmentDefinitio
         handler: async function (_, { json }) {
           const rows = await this.handlerTx()
             .retrieve(({ forSchema }) =>
-              forSchema(automationFragmentSchema).find("identity_binding"),
+              forSchema(automationFragmentSchema).find("identity_binding", (b) =>
+                b.whereIndex("primary"),
+              ),
             )
             .transformRetrieve(([identityBindings]) => identityBindings)
             .execute();

--- a/apps/docs/app/components/database-integration.tsx
+++ b/apps/docs/app/components/database-integration.tsx
@@ -19,7 +19,7 @@ export default function DatabaseIntegration() {
       content: (
         <FragnoCodeBlock
           lang="typescript"
-          code={`import { schema, idColumn, column }
+          code={`import { schema, idColumn, column, referenceColumn }
   from "@fragno-dev/db/schema";
 
 export const commentSchema = schema("comment", (s) => {
@@ -28,7 +28,7 @@ export const commentSchema = schema("comment", (s) => {
       return t
         .addColumn("id", idColumn())
         .addColumn("content", column("string"))
-        .addColumn("userId", column("string"))
+        .addColumn("userId", referenceColumn({ table: "user" }))
         .addColumn("postId", column("string"))
         .addColumn(
           "createdAt",
@@ -44,12 +44,7 @@ export const commentSchema = schema("comment", (s) => {
         .addColumn("id", idColumn())
         .addColumn("name", column("string"));
     })
-    .addReference("author", {
-      type: "one",
-      from: { table: "comment", column: "userId" },
-      to: { table: "user", column: "id" },
-      foreignKey: false
-    });
+    .noOp("removed obsolete comment -> user addReference history");
 });`}
           codeblock={{
             className: "text-sm",

--- a/apps/docs/app/components/database-integration.tsx
+++ b/apps/docs/app/components/database-integration.tsx
@@ -36,7 +36,8 @@ export const commentSchema = schema("comment", (s) => {
             .defaultTo((b) => b.now())
         )
         .createIndex("idx_user", ["userId"])
-        .createIndex("idx_post", ["postId"]);
+        .createIndex("idx_post", ["postId"])
+        .createIndex("idx_created", ["createdAt"]);
     })
     .addTable("user", (t) => {
       return t
@@ -72,10 +73,12 @@ const uow = orm.createUnitOfWork("read-comments").find(
         eb("postId", "=", postId)
       )
       .orderByIndex("idx_created", "desc")
-      .join((j) =>
-        j.author((authorBuilder) =>
-          authorBuilder.select(["name"])
-        )
+      .joinOne("author", "user", (authorBuilder) =>
+        authorBuilder
+          .onIndex("primary", (eb) =>
+            eb("id", "=", eb.parent("userId"))
+          )
+          .select(["name"])
       )
       .pageSize(20)
 );

--- a/apps/docs/app/routes/home/snippets.ts
+++ b/apps/docs/app/routes/home/snippets.ts
@@ -387,7 +387,7 @@ export const commentSchema = schema("comment", (s) => {
         .addColumn("content", column("string"))
         .addColumn("createdAt", column("timestamp").defaultTo((b) => b.now()))
         .addColumn("postReference", column("string"))
-        .addColumn("parentId", referenceColumn().nullable())
+        .addColumn("parentId", referenceColumn({ table: "comment" }).nullable())
         .createIndex("idx_comment_post", ["postReference"]);
     })
     .addTable("upvote_total", (t) => {
@@ -396,11 +396,6 @@ export const commentSchema = schema("comment", (s) => {
         .addColumn("reference", column("string"))
         .addColumn("total", column("integer").defaultTo(0))
         .createIndex("idx_upvote_total_reference", ["reference"], { unique: true });
-    })
-    .addReference("parent", {
-      type: "one",
-      from: { table: "comment", column: "parentId" },
-      to: { table: "comment", column: "id" },
     });
 });`,
       },

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/defining-schemas.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/defining-schemas.mdx
@@ -50,7 +50,7 @@ column("binary");
 
 // Special types
 idColumn(); // Auto-generated CUID primary key
-referenceColumn(); // Foreign key reference (bigint)
+referenceColumn({ table: "otherTable" }); // Foreign key reference (bigint)
 ```
 
 ### Modifiers
@@ -132,44 +132,27 @@ In Fragno, indexes are required for most operations such as `where` and `orderBy
 
 ## Relations
 
-Define relationships between tables using `addReference()`:
+Define foreign-key relationships directly on `referenceColumn({ table })`:
 
 ```typescript
 export const commentSchema = schema((s) => {
-  return (
-    s
-      .addTable("comment", (t) => {
-        return t
-          .addColumn("id", idColumn())
-          .addColumn("content", column("string"))
-          .addColumn("parentId", referenceColumn().nullable());
-      })
-      // Self-referencing: comment -> parent comment
-      .addReference("parent", {
-        type: "one",
-        from: { table: "comment", column: "parentId" },
-        to: { table: "comment", column: "id" },
-      })
-  );
+  return s.addTable("comment", (t) => {
+    return t
+      .addColumn("id", idColumn())
+      .addColumn("content", column("string"))
+      .addColumn("parentId", referenceColumn({ table: "comment" }).nullable())
+      .createIndex("idx_comment_parent", ["parentId"]);
+  });
 });
 ```
 
 ### Relation Types
 
 ```typescript
-// Many-to-one: post -> author
-.addReference("author", {
-  type: "one",
-  from: { table: "posts", column: "userId" },
-  to: { table: "users", column: "id" },
-})
+// Many-to-one / foreign key: post -> author
+.addColumn("userId", referenceColumn({ table: "users" }))
 
-// One-to-many: user -> posts
-.addReference("posts", {
-  type: "many",
-  from: { table: "users", column: "id" },
-  to: { table: "posts", column: "userId" },
-})
+// One-to-many is derived automatically by code generators from FK-bearing columns.
 ```
 
 ### External References
@@ -181,56 +164,17 @@ For references to user data outside your Fragment, use regular string columns:
   return t
     .addColumn("id", idColumn())
     .addColumn("content", column("string"))
-    // External references - NOT referenceColumn()
+    // External references - NOT referenceColumn({ table: "..." })
     .addColumn("userId", column("string"))
     .addColumn("postId", column("string"));
 })
 ```
 
-Use `referenceColumn()` only for internal relations between your Fragment's tables. User data lives
-in separate tables outside your control, so no foreign key constraint is needed.
+Use `referenceColumn({ table: "..." })` only for internal relations between your Fragment's tables.
+User data lives in separate tables outside your control, so no foreign key constraint is needed.
 
 You may also chose not to have any external references in your schema. The user can define their own
 association table in their application's schema.
-
-### Join-Only Relations (No Foreign Keys)
-
-If you want to define joins on non-FK columns (like external IDs or emails), use `foreignKey: false`
-and index both join columns:
-
-```typescript
-.addTable("users", (t) => {
-  return t
-    .addColumn("id", idColumn())
-    .addColumn("email", column("string"))
-    .createIndex("idx_users_email", ["email"]);
-})
-.addTable("invitations", (t) => {
-  return t
-    .addColumn("id", idColumn())
-    .addColumn("email", column("string"))
-    .createIndex("idx_inv_email", ["email"]);
-})
-.addReference("invitedUser", {
-  type: "one",
-  from: { table: "invitations", column: "email" },
-  to: { table: "users", column: "email" },
-  foreignKey: false,
-})
-```
-
-Join-only relations do not generate foreign key migrations or schema relations for Prisma/Drizzle.
-When a join-only relation uses a table's `id` column, Fragno coerces it to `_internalId` so you can
-define inverse relations without `_internalId` casts:
-
-```typescript
-.addReference("memberships", {
-  type: "many",
-  from: { table: "users", column: "id" }, // coerced to _internalId
-  to: { table: "memberships", column: "userId" },
-  foreignKey: false,
-})
-```
 
 ## Schema Evolution
 
@@ -250,8 +194,8 @@ const mySchema = schema((s) => {
 // mySchema.version === 3        // Three operations = version 3
 ```
 
-Each operation (`.addTable()`, `.alterTable()`, `.addReference()`) increments the version by 1. The
-CLI uses this to generate migrations for users upgrading from older versions.
+Each operation (`.addTable()`, `.alterTable()`, `.noOp()`) increments the version by 1. The CLI uses
+this to generate migrations for users upgrading from older versions.
 
 ### Using alterTable()
 

--- a/apps/docs/content/docs/fragno/for-library-authors/database-integration/querying.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/database-integration/querying.mdx
@@ -169,17 +169,24 @@ const [users] = await this.handlerTx()
 
 ### Joins
 
-Load related data using joins:
+Load related data using explicit joins:
 
 ```typescript
 const [postsWithAuthor] = await this.handlerTx()
   .retrieve(({ forSchema }) =>
-    forSchema(mySchema).find("posts", (b) => b.whereIndex("primary").join((j) => j.author())),
+    forSchema(mySchema).find("posts", (b) =>
+      b
+        .whereIndex("primary")
+        .joinOne("author", "users", (author) =>
+          author.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).select(["name"]),
+        ),
+    ),
   )
   .execute();
 ```
 
-Note: We currently only support simple left joins.
+Use `joinOne(...)` for nullable child objects and `joinMany(...)` for child arrays. Missing children
+resolve to `null` / `[]`.
 
 ## Creating Records
 

--- a/apps/docs/content/docs/fragno/for-library-authors/rules-of-fragno.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/rules-of-fragno.mdx
@@ -18,15 +18,19 @@ Keep this rare and explicit.
 `handlerTx()` is two-phase: **schedule all reads in one `.retrieve(...)`**, then **schedule all
 writes in one `.mutate(...)`**, then `.execute()`.
 
-If you need related data, use `.join(...)` and multiple `.find...` calls inside the same
-`.retrieve(...)` instead of starting extra `handlerTx()` calls.
+If you need related data, use explicit joins such as `.joinOne(...)` / `.joinMany(...)` and multiple
+`.find...` calls inside the same `.retrieve(...)` instead of starting extra `handlerTx()` calls.
 
 ```ts
 const result = await this.handlerTx()
   .retrieve(({ forSchema }) =>
     forSchema(mySchema)
       .findFirst("order", (b) =>
-        b.whereIndex("primary", (eb) => eb("id", "=", orderId)).join((j) => j.customer()),
+        b
+          .whereIndex("primary", (eb) => eb("id", "=", orderId))
+          .joinOne("customer", "customer", (customer) =>
+            customer.onIndex("primary", (eb) => eb("id", "=", eb.parent("customerId"))),
+          ),
       )
       .find("order_item", (b) =>
         b.whereIndex("idx_order_item_orderId", (eb) => eb("orderId", "=", orderId)),

--- a/apps/docs/content/docs/fragno/for-library-authors/rules-of-fragno.mdx
+++ b/apps/docs/content/docs/fragno/for-library-authors/rules-of-fragno.mdx
@@ -103,8 +103,8 @@ execution model and retry behavior.
 doesn't have to — you can also let it auto-generate (CUID) values. Fragno automatically adds
 `_internalId` and `_version` under the hood, so you do not need extra columns to mirror either.
 
-References can point at `idColumn()` values. `referenceColumn()` accepts ID strings (or `FragnoId`
-objects) and the query layer resolves them for you.
+References can point at `idColumn()` values. `referenceColumn({ table: "..." })` accepts ID strings
+(or `FragnoId` objects) and the query layer resolves them for you.
 
 ```ts
 import { column, idColumn, referenceColumn, schema } from "@fragno-dev/db/schema";
@@ -115,14 +115,9 @@ export const mySchema = schema("example", (s) =>
     .addTable("note", (t) =>
       t
         .addColumn("id", idColumn())
-        .addColumn("userId", referenceColumn())
+        .addColumn("userId", referenceColumn({ table: "user" }))
         .addColumn("content", column("string")),
-    )
-    .addReference("author", {
-      type: "one",
-      from: { table: "note", column: "userId" },
-      to: { table: "user", column: "id" },
-    }),
+    ),
 );
 
 await this.handlerTx()
@@ -140,4 +135,4 @@ await this.handlerTx()
 ```
 
 See [Defining Schemas](/docs/fragno/for-library-authors/database-integration/defining-schemas) for
-more on `idColumn()` and `referenceColumn()`.
+more on `idColumn()` and `referenceColumn({ table: "..." })`.

--- a/example-apps/fragno-db-usage-drizzle/src/commands/relations.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/commands/relations.ts
@@ -4,27 +4,25 @@ import * as repo from "../repository";
 
 const testAuthRelationsCommand: Command = {
   name: "test-auth-relations",
-  description: "Test relational queries for auth sessions (using convenience aliases)",
+  description: "Test auth joins using explicit Drizzle queries",
   run: async () => {
-    console.log("Testing auth relations with convenience aliases...");
+    console.log("Testing auth joins with explicit queries...");
 
-    // Test 1: Fetch sessions with their owners (using convenience alias)
     const sessionsWithOwners = await repo.findAuthSessionsWithOwners();
-    console.log("\n=== Auth Sessions with Owners (using convenience alias) ===");
+    console.log("\n=== Auth Sessions with Owners (explicit join) ===");
     console.log(JSON.stringify(sessionsWithOwners, null, 2));
 
-    // Test 2: Fetch auth users with their sessions
     const authUsersWithSessions = await repo.findAuthUsersWithSessions();
     console.log("\n=== Auth Users with Sessions ===");
     console.log(JSON.stringify(authUsersWithSessions, null, 2));
 
-    console.log("\n✓ Auth relations working correctly with convenience aliases!");
+    console.log("\n✓ Auth joins working correctly with explicit queries!");
   },
 };
 
 const testCommentRelationsCommand: Command = {
   name: "test-comment-relations",
-  description: "Test self-referential relational queries for comments",
+  description: "Test self-referential comment lookups with explicit queries",
   args: {
     postReference: {
       type: "string" as const,
@@ -47,27 +45,23 @@ const testCommentRelationsCommand: Command = {
 
 const testAllRelationsCommand: Command = {
   name: "test-all",
-  description: "Test all Fragno relational queries",
+  description: "Test all explicit Fragno relation-style queries",
   run: async () => {
-    console.log("=== Testing All Fragno Relational Queries ===\n");
+    console.log("=== Testing All Fragno Relation-Style Queries ===\n");
 
-    // Test auth relations (KEY TEST - using convenience aliases)
     const sessionsWithOwners = await repo.findAuthSessionsWithOwners();
-    console.log(
-      `✓ Auth sessions with owners (convenience alias): ${sessionsWithOwners.length} found`,
-    );
+    console.log(`✓ Auth sessions with owners (explicit join): ${sessionsWithOwners.length} found`);
 
     const authUsersWithSessions = await repo.findAuthUsersWithSessions();
     console.log(`✓ Auth users with sessions: ${authUsersWithSessions.length} found`);
 
-    // Test comment relations (self-referential)
     const commentsWithReplies = await repo.findCommentsWithReplies("1");
     console.log(`✓ Comments with replies: ${commentsWithReplies.length} found`);
 
-    console.log("\n=== All Fragno Relational Queries Passed! ===");
+    console.log("\n=== All Fragno Relation-Style Queries Passed! ===");
     console.log("This confirms that:");
-    console.log("  - Fragment convenience aliases work with relations");
-    console.log("  - Self-referential relations work correctly");
+    console.log("  - Explicit joins still work for auth data");
+    console.log("  - Self-referential comment trees still work correctly");
   },
 };
 
@@ -85,9 +79,9 @@ export const relationsCommand: Command = {
     console.log("Usage: node --import tsx src/mod.ts relations <command> [options]");
     console.log("");
     console.log("Commands:");
-    console.log("  test-auth-relations     Test auth session relations (convenience aliases)");
-    console.log("  test-comment-relations  Test comment self-referential relations");
-    console.log("  test-all                Test all Fragno relational queries");
+    console.log("  test-auth-relations     Test auth joins with explicit queries");
+    console.log("  test-comment-relations  Test self-referential comment queries");
+    console.log("  test-all                Test all explicit Fragno relation-style queries");
     console.log("");
     console.log(
       "Run 'node --import tsx src/mod.ts relations <command> --help' for more information.",

--- a/example-apps/fragno-db-usage-drizzle/src/integration.test.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/integration.test.ts
@@ -230,23 +230,19 @@ describe("Fragno Database Drizzle", () => {
   });
 
   describe("Relations Commands", () => {
-    it("should test auth relations with convenience aliases", async () => {
+    it("should test auth joins with explicit queries", async () => {
       const { relationsCommand, relationsSubCommands } = await import("./commands/relations");
       await cli(["test-auth-relations"], relationsCommand, {
         subCommands: relationsSubCommands,
       });
 
-      expect(logs).toContain("Testing auth relations with convenience aliases...");
+      expect(logs).toContain("Testing auth joins with explicit queries...");
       expect(
-        logs.some((log) =>
-          log.includes("=== Auth Sessions with Owners (using convenience alias) ==="),
-        ),
+        logs.some((log) => log.includes("=== Auth Sessions with Owners (explicit join) ===")),
       ).toBe(true);
       expect(logs.some((log) => log.includes("=== Auth Users with Sessions ==="))).toBe(true);
       expect(
-        logs.some((log) =>
-          log.includes("✓ Auth relations working correctly with convenience aliases!"),
-        ),
+        logs.some((log) => log.includes("✓ Auth joins working correctly with explicit queries!")),
       ).toBe(true);
     });
 
@@ -272,24 +268,24 @@ describe("Fragno Database Drizzle", () => {
       });
 
       expect(
-        logs.some((log) => log.includes("=== Testing All Fragno Relational Queries ===")),
+        logs.some((log) => log.includes("=== Testing All Fragno Relation-Style Queries ===")),
       ).toBe(true);
-      expect(
-        logs.some((log) => log.includes("✓ Auth sessions with owners (convenience alias):")),
-      ).toBe(true);
+      expect(logs.some((log) => log.includes("✓ Auth sessions with owners (explicit join):"))).toBe(
+        true,
+      );
       expect(logs.some((log) => log.includes("✓ Auth users with sessions:"))).toBe(true);
       expect(logs.some((log) => log.includes("✓ Comments with replies:"))).toBe(true);
       expect(
-        logs.some((log) => log.includes("=== All Fragno Relational Queries Passed! ===")),
+        logs.some((log) => log.includes("=== All Fragno Relation-Style Queries Passed! ===")),
       ).toBe(true);
 
       // Verify the key messages about what was tested
-      expect(
-        logs.some((log) => log.includes("Fragment convenience aliases work with relations")),
-      ).toBe(true);
-      expect(logs.some((log) => log.includes("Self-referential relations work correctly"))).toBe(
+      expect(logs.some((log) => log.includes("Explicit joins still work for auth data"))).toBe(
         true,
       );
+      expect(
+        logs.some((log) => log.includes("Self-referential comment trees still work correctly")),
+      ).toBe(true);
     });
   });
 });

--- a/example-apps/fragno-db-usage-drizzle/src/repository.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/repository.ts
@@ -2,14 +2,27 @@ import { eq, like, desc, and, sql, aliasedTable } from "drizzle-orm";
 
 import { getDrizzleDatabase } from "./database";
 import { appUser, blogPost } from "./schema/drizzle-schema";
-import { comment_schema, upvote_schema } from "./schema/fragno-schema";
+import { auth_schema, comment_schema, upvote_schema } from "./schema/fragno-schema";
 
+const { user: authUser, session: authSession } = auth_schema;
 const { comment } = comment_schema;
 const { upvote_total } = upvote_schema;
 
 type User = typeof appUser.$inferSelect;
 type NewUser = typeof appUser.$inferInsert;
 type NewBlogPost = typeof blogPost.$inferInsert;
+type AuthSession = typeof authSession.$inferSelect;
+type AuthUser = typeof authUser.$inferSelect;
+type CommentRow = typeof comment.$inferSelect;
+type SessionWithOwner = AuthSession & {
+  sessionOwner: Pick<AuthUser, "id" | "email" | "createdAt"> | null;
+};
+type UserWithSessions = AuthUser & { sessionList: AuthSession[] };
+type CommentWithReplies = CommentRow & { commentList: CommentWithReplies[] };
+type CommentWithParentAndReplies = CommentRow & {
+  parent: CommentRow | null;
+  commentList: CommentWithReplies[];
+};
 
 // User repository methods
 export async function findUserById(id: number) {
@@ -145,102 +158,170 @@ export async function searchBlogPostsByTitle(searchTerm: string) {
 }
 
 // ============================================================================
-// Complex Relational Queries (demonstrating Fragno relations work properly)
+// Explicit relational-style queries (without generated Drizzle relation metadata)
 // ============================================================================
 
-/**
- * Fetch auth sessions with their owner users using CONVENIENCE ALIASES.
- * This is the KEY TEST that demonstrates the fix for the relations bug.
- * We're using the 'session' convenience alias from simple_auth_db_schema.
- */
-export async function findAuthSessionsWithOwners() {
+function buildCommentReplyTree(comments: CommentRow[]): CommentWithReplies[] {
+  const commentsWithReplies = new Map<string, CommentWithReplies>();
+
+  for (const commentRow of comments) {
+    commentsWithReplies.set(commentRow.id, { ...commentRow, commentList: [] });
+  }
+
+  const rootComments: CommentWithReplies[] = [];
+
+  for (const commentRow of comments) {
+    const commentWithReplies = commentsWithReplies.get(commentRow.id);
+    if (!commentWithReplies) {
+      continue;
+    }
+
+    if (!commentRow.parentId) {
+      rootComments.push(commentWithReplies);
+      continue;
+    }
+
+    const parentComment = comments.find(
+      (candidate) => candidate._internalId === commentRow.parentId,
+    );
+    if (!parentComment) {
+      rootComments.push(commentWithReplies);
+      continue;
+    }
+
+    commentsWithReplies.get(parentComment.id)?.commentList.push(commentWithReplies);
+  }
+
+  const sortReplies = (commentWithReplies: CommentWithReplies) => {
+    commentWithReplies.commentList.sort(
+      (left, right) => left.createdAt.getTime() - right.createdAt.getTime(),
+    );
+    for (const reply of commentWithReplies.commentList) {
+      sortReplies(reply);
+    }
+  };
+
+  rootComments.sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
+  for (const rootComment of rootComments) {
+    sortReplies(rootComment);
+  }
+
+  return rootComments;
+}
+
+export async function findAuthSessionsWithOwners(): Promise<SessionWithOwner[]> {
   const db = await getDrizzleDatabase();
-  return await db.query.session.findMany({
-    with: {
+  const rows = await db
+    .select({
+      session: authSession,
       sessionOwner: {
-        columns: {
-          id: true,
-          email: true,
-          createdAt: true,
+        id: authUser.id,
+        email: authUser.email,
+        createdAt: authUser.createdAt,
+      },
+    })
+    .from(authSession)
+    .leftJoin(authUser, eq(authUser._internalId, authSession.userId))
+    .orderBy(desc(authSession.createdAt));
+
+  return rows.map(({ session, sessionOwner }) => ({
+    ...session,
+    sessionOwner: sessionOwner?.id ? sessionOwner : null,
+  }));
+}
+
+export async function findAuthSessionById(sessionId: string): Promise<SessionWithOwner | null> {
+  const db = await getDrizzleDatabase();
+  const row = (
+    await db
+      .select({
+        session: authSession,
+        sessionOwner: {
+          id: authUser.id,
+          email: authUser.email,
+          createdAt: authUser.createdAt,
         },
-      },
-    },
-    orderBy: (session, { desc }) => [desc(session.createdAt)],
-  });
+      })
+      .from(authSession)
+      .leftJoin(authUser, eq(authUser._internalId, authSession.userId))
+      .where(eq(authSession.id, sessionId))
+      .limit(1)
+  )[0];
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    ...row.session,
+    sessionOwner: row.sessionOwner?.id ? row.sessionOwner : null,
+  };
 }
 
-/**
- * Fetch a specific auth session with its owner using convenience aliases.
- * This demonstrates that joins work with the aliased tables.
- */
-export async function findAuthSessionById(sessionId: string) {
+export async function findAuthUsersWithSessions(): Promise<UserWithSessions[]> {
   const db = await getDrizzleDatabase();
-  return await db.query.session.findFirst({
-    where: (session, { eq }) => eq(session.id, sessionId),
-    with: {
-      sessionOwner: {
-        columns: {
-          id: true,
-          email: true,
-          createdAt: true,
-        },
-      },
-    },
-  });
+  const [users, sessions] = await Promise.all([
+    db.select().from(authUser).orderBy(desc(authUser.createdAt)),
+    db.select().from(authSession).orderBy(desc(authSession.createdAt)),
+  ]);
+
+  const sessionsByUserInternalId = new Map<number, AuthSession[]>();
+  for (const sessionRow of sessions) {
+    const existingSessions = sessionsByUserInternalId.get(sessionRow.userId) ?? [];
+    existingSessions.push(sessionRow);
+    sessionsByUserInternalId.set(sessionRow.userId, existingSessions);
+  }
+
+  return users.map((userRow) => ({
+    ...userRow,
+    sessionList: sessionsByUserInternalId.get(userRow._internalId) ?? [],
+  }));
 }
 
-/**
- * Fetch auth users with all their sessions using the convenience alias.
- */
-export async function findAuthUsersWithSessions() {
+export async function findCommentsWithReplies(
+  postReference: string,
+): Promise<CommentWithReplies[]> {
   const db = await getDrizzleDatabase();
-  return await db.query.user.findMany({
-    with: {
-      sessionList: {
-        orderBy: (session, { desc }) => [desc(session.createdAt)],
-      },
-    },
-  });
+  const comments = await db
+    .select()
+    .from(comment)
+    .where(eq(comment.postReference, postReference))
+    .orderBy(desc(comment.createdAt));
+
+  return buildCommentReplyTree(comments);
 }
 
-/**
- * Fetch comments with their nested replies (self-referential relation).
- * This demonstrates that self-referential relations work correctly.
- */
-export async function findCommentsWithReplies(postReference: string) {
+export async function findCommentWithParentAndReplies(
+  commentId: string,
+): Promise<CommentWithParentAndReplies | null> {
   const db = await getDrizzleDatabase();
-  return await db.query.comment.findMany({
-    where: (comment, { eq, isNull }) =>
-      and(eq(comment.postReference, postReference), isNull(comment.parentId)),
-    with: {
-      commentList: {
-        // Get first level of nested replies
-        orderBy: (comment, { asc }) => [asc(comment.createdAt)],
-        with: {
-          commentList: {
-            // Get second level of nested replies
-            orderBy: (comment, { asc }) => [asc(comment.createdAt)],
-          },
-        },
-      },
-    },
-    orderBy: (comment, { desc }) => [desc(comment.createdAt)],
-  });
-}
+  const currentComment = (
+    await db.select().from(comment).where(eq(comment.id, commentId)).limit(1)
+  )[0];
 
-/**
- * Fetch a single comment with its parent and replies.
- * This demonstrates bidirectional self-referential relations.
- */
-export async function findCommentWithParentAndReplies(commentId: string) {
-  const db = await getDrizzleDatabase();
-  return await db.query.comment.findFirst({
-    where: (comment, { eq }) => eq(comment.id, commentId),
-    with: {
-      parent: true,
-      commentList: {
-        orderBy: (comment, { asc }) => [asc(comment.createdAt)],
-      },
-    },
-  });
+  if (!currentComment) {
+    return null;
+  }
+
+  const [parentComment, commentsForPost] = await Promise.all([
+    currentComment.parentId
+      ? db
+          .select()
+          .from(comment)
+          .where(eq(comment._internalId, currentComment.parentId))
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+      : Promise.resolve(null),
+    db.select().from(comment).where(eq(comment.postReference, currentComment.postReference)),
+  ]);
+
+  const directReplies = buildCommentReplyTree(commentsForPost).find(
+    (candidate) => candidate.id === currentComment.id,
+  )?.commentList;
+
+  return {
+    ...currentComment,
+    parent: parentComment,
+    commentList: directReplies ?? [],
+  };
 }

--- a/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.mysql.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.mysql.ts
@@ -116,12 +116,12 @@ export const session_auth = mysqlTable("session_auth", {
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_session_user_sessionOwner_auth_7854da47"
+    name: "fk_session_user_session_userId_fk_auth_481a47e0"
   }),
   foreignKey({
     columns: [table.activeOrganizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_session_organization_sessionActiveOrganization_auth_c1d88689"
+    name: "fk_session_organization_session_activeOrganizationId_fkaa5effd7"
   }),
   index("idx_session_idx_session_user_auth_0748231c").on(table.userId),
   index("idx_session_idx_session_id_expiresAt_auth_2345cc9f").on(table.id, table.expiresAt)
@@ -143,7 +143,7 @@ export const organization_auth = mysqlTable("organization_auth", {
   foreignKey({
     columns: [table.createdBy],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organization_user_organizationCreator_auth_c99fc140"
+    name: "fk_organization_user_organization_createdBy_fk_auth_3a721c70"
   }),
   uniqueIndex("uidx_organization_idx_organization_slug_auth_9b82968a").on(table.slug),
   index("idx_organization_idx_organization_createdBy_auth_e893279c").on(table.createdBy)
@@ -161,12 +161,12 @@ export const organizationMember_auth = mysqlTable("organizationMember_auth", {
   foreignKey({
     columns: [table.organizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_organizationMember_organization_organizationMemberOr038a36fb"
+    name: "fk_organizationMember_organization_organizationMember_ofdd1098e"
   }),
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organizationMember_user_organizationMemberUser_auth_a00a7460"
+    name: "fk_organizationMember_user_organizationMember_userId_fkb413bdc4"
   }),
   uniqueIndex("uidx_organizationMember_idx_org_member_org_user_auth_abbf915f").on(table.organizationId, table.userId),
   index("idx_organizationMember_idx_org_member_user_auth_1cd12c0f").on(table.userId),
@@ -184,7 +184,7 @@ export const organizationMemberRole_auth = mysqlTable("organizationMemberRole_au
   foreignKey({
     columns: [table.memberId],
     foreignColumns: [organizationMember_auth._internalId],
-    name: "fk_organizationMemberRole_organizationMember_organizati5029ddce"
+    name: "fk_organizationMemberRole_organizationMember_organizatib4490866"
   }),
   uniqueIndex("uidx_organizationMemberRole_idx_org_member_role_member_e45d22f1").on(table.memberId, table.role),
   index("idx_organizationMemberRole_idx_org_member_role_member_a2a65acd6").on(table.memberId),
@@ -208,12 +208,12 @@ export const organizationInvitation_auth = mysqlTable("organizationInvitation_au
   foreignKey({
     columns: [table.organizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_organizationInvitation_organization_organizationInvida3865a6"
+    name: "fk_organizationInvitation_organization_organizationInvi963a4ee6"
   }),
   foreignKey({
     columns: [table.inviterId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organizationInvitation_user_organizationInvitationIn47cda46d"
+    name: "fk_organizationInvitation_user_organizationInvitation_icbf271d9"
   }),
   uniqueIndex("uidx_organizationInvitation_idx_org_invitation_token_au93b35818").on(table.token),
   index("idx_organizationInvitation_idx_org_invitation_org_statu68f8a9be").on(table.organizationId, table.status),
@@ -244,7 +244,7 @@ export const oauthAccount_auth = mysqlTable("oauthAccount_auth", {
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_oauthAccount_user_oauthAccountUser_auth_94d5cb9b"
+    name: "fk_oauthAccount_user_oauthAccount_userId_fk_auth_0ecc8c86"
   }),
   uniqueIndex("uidx_oauthAccount_idx_oauth_account_provider_account_au229618a4").on(table.provider, table.providerAccountId),
   index("idx_oauthAccount_idx_oauth_account_user_auth_98049852").on(table.userId),
@@ -268,7 +268,7 @@ export const oauthState_auth = mysqlTable("oauthState_auth", {
   foreignKey({
     columns: [table.linkUserId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_oauthState_user_oauthStateLinkUser_auth_2659bef7"
+    name: "fk_oauthState_user_oauthState_linkUserId_fk_auth_8d42d847"
   }),
   uniqueIndex("uidx_oauthState_idx_oauth_state_state_auth_f65e8ad2").on(table.state),
   index("idx_oauthState_idx_oauth_state_provider_auth_2c66010f").on(table.provider),
@@ -277,103 +277,103 @@ export const oauthState_auth = mysqlTable("oauthState_auth", {
 
 export const user_authRelations = relations(user_auth, ({ many }) => ({
   sessionList: many(session_auth, {
-    relationName: "session_user"
+    relationName: "session_userId"
   }),
   organizationList: many(organization_auth, {
-    relationName: "organization_user"
+    relationName: "organization_createdBy"
   }),
   organizationMemberList: many(organizationMember_auth, {
-    relationName: "organizationMember_user"
+    relationName: "organizationMember_userId"
   }),
   organizationInvitationList: many(organizationInvitation_auth, {
-    relationName: "organizationInvitation_user"
+    relationName: "organizationInvitation_inviterId"
   }),
   oauthAccountList: many(oauthAccount_auth, {
-    relationName: "oauthAccount_user"
+    relationName: "oauthAccount_userId"
   }),
   oauthStateList: many(oauthState_auth, {
-    relationName: "oauthState_user"
+    relationName: "oauthState_linkUserId"
   })
 }));
 
 export const session_authRelations = relations(session_auth, ({ one }) => ({
-  sessionOwner: one(user_auth, {
-    relationName: "session_user",
+  user: one(user_auth, {
+    relationName: "session_userId",
     fields: [session_auth.userId],
     references: [user_auth._internalId]
   }),
-  sessionActiveOrganization: one(organization_auth, {
-    relationName: "session_organization",
+  activeOrganization: one(organization_auth, {
+    relationName: "session_activeOrganizationId",
     fields: [session_auth.activeOrganizationId],
     references: [organization_auth._internalId]
   })
 }));
 
 export const organization_authRelations = relations(organization_auth, ({ one, many }) => ({
-  organizationCreator: one(user_auth, {
-    relationName: "organization_user",
+  createdBy: one(user_auth, {
+    relationName: "organization_createdBy",
     fields: [organization_auth.createdBy],
     references: [user_auth._internalId]
   }),
   sessionList: many(session_auth, {
-    relationName: "session_organization"
+    relationName: "session_activeOrganizationId"
   }),
   organizationMemberList: many(organizationMember_auth, {
-    relationName: "organizationMember_organization"
+    relationName: "organizationMember_organizationId"
   }),
   organizationInvitationList: many(organizationInvitation_auth, {
-    relationName: "organizationInvitation_organization"
+    relationName: "organizationInvitation_organizationId"
   })
 }));
 
 export const organizationMember_authRelations = relations(organizationMember_auth, ({ one, many }) => ({
-  organizationMemberOrganization: one(organization_auth, {
-    relationName: "organizationMember_organization",
+  organization: one(organization_auth, {
+    relationName: "organizationMember_organizationId",
     fields: [organizationMember_auth.organizationId],
     references: [organization_auth._internalId]
   }),
-  organizationMemberUser: one(user_auth, {
-    relationName: "organizationMember_user",
+  user: one(user_auth, {
+    relationName: "organizationMember_userId",
     fields: [organizationMember_auth.userId],
     references: [user_auth._internalId]
   }),
   organizationMemberRoleList: many(organizationMemberRole_auth, {
-    relationName: "organizationMemberRole_organizationMember"
+    relationName: "organizationMemberRole_memberId"
   })
 }));
 
 export const organizationMemberRole_authRelations = relations(organizationMemberRole_auth, ({ one }) => ({
-  organizationMemberRoleMember: one(organizationMember_auth, {
-    relationName: "organizationMemberRole_organizationMember",
+  member: one(organizationMember_auth, {
+    relationName: "organizationMemberRole_memberId",
     fields: [organizationMemberRole_auth.memberId],
     references: [organizationMember_auth._internalId]
   })
 }));
 
 export const organizationInvitation_authRelations = relations(organizationInvitation_auth, ({ one }) => ({
-  organizationInvitationOrganization: one(organization_auth, {
-    relationName: "organizationInvitation_organization",
+  organization: one(organization_auth, {
+    relationName: "organizationInvitation_organizationId",
     fields: [organizationInvitation_auth.organizationId],
     references: [organization_auth._internalId]
   }),
-  organizationInvitationInviter: one(user_auth, {
-    relationName: "organizationInvitation_user",
+  inviter: one(user_auth, {
+    relationName: "organizationInvitation_inviterId",
     fields: [organizationInvitation_auth.inviterId],
     references: [user_auth._internalId]
   })
 }));
 
 export const oauthAccount_authRelations = relations(oauthAccount_auth, ({ one }) => ({
-  oauthAccountUser: one(user_auth, {
-    relationName: "oauthAccount_user",
+  user: one(user_auth, {
+    relationName: "oauthAccount_userId",
     fields: [oauthAccount_auth.userId],
     references: [user_auth._internalId]
   })
 }));
 
 export const oauthState_authRelations = relations(oauthState_auth, ({ one }) => ({
-  oauthStateLinkUser: one(user_auth, {
-    relationName: "oauthState_user",
+  linkUser: one(user_auth, {
+    relationName: "oauthState_linkUserId",
     fields: [oauthState_auth.linkUserId],
     references: [user_auth._internalId]
   })
@@ -434,19 +434,19 @@ export const comment_comment = mysqlTable("comment_comment", {
   foreignKey({
     columns: [table.parentId],
     foreignColumns: [table._internalId],
-    name: "fk_comment_comment_parent_comment_e6560345"
+    name: "fk_comment_comment_comment_parentId_fk_comment_d0862848"
   }),
   index("idx_comment_idx_comment_post_comment_c75acad5").on(table.postReference)
 ])
 
 export const comment_commentRelations = relations(comment_comment, ({ one, many }) => ({
   parent: one(comment_comment, {
-    relationName: "comment_comment",
+    relationName: "comment_parentId",
     fields: [comment_comment.parentId],
     references: [comment_comment._internalId]
   }),
   commentList: many(comment_comment, {
-    relationName: "comment_comment"
+    relationName: "comment_parentId"
   })
 }));
 
@@ -542,7 +542,7 @@ export const workflow_step_workflows = mysqlTable("workflow_step_workflows", {
   foreignKey({
     columns: [table.instanceRef],
     foreignColumns: [workflow_instance_workflows._internalId],
-    name: "fk_workflow_step_workflow_instance_stepInstance_workflo01bdff32"
+    name: "fk_workflow_step_workflow_instance_workflow_step_instanf10e6a91"
   }),
   uniqueIndex("uidx_workflow_step_idx_workflow_step_instanceRef_runNum2a6b0b25").on(table.instanceRef, table.runNumber, table.stepKey),
   index("idx_workflow_step_idx_workflow_step_instanceRef_runNumbe91f4dec").on(table.instanceRef, table.runNumber, table.createdAt),
@@ -565,31 +565,31 @@ export const workflow_event_workflows = mysqlTable("workflow_event_workflows", {
   foreignKey({
     columns: [table.instanceRef],
     foreignColumns: [workflow_instance_workflows._internalId],
-    name: "fk_workflow_event_workflow_instance_eventInstance_workf9b5621c6"
+    name: "fk_workflow_event_workflow_instance_workflow_event_inst3029c2ed"
   }),
   index("idx_workflow_event_idx_workflow_event_instanceRef_runNu9d715b8f").on(table.instanceRef, table.runNumber, table.createdAt)
 ])
 
 export const workflow_instance_workflowsRelations = relations(workflow_instance_workflows, ({ many }) => ({
   workflow_stepList: many(workflow_step_workflows, {
-    relationName: "workflow_step_workflow_instance"
+    relationName: "workflow_step_instanceRef"
   }),
   workflow_eventList: many(workflow_event_workflows, {
-    relationName: "workflow_event_workflow_instance"
+    relationName: "workflow_event_instanceRef"
   })
 }));
 
 export const workflow_step_workflowsRelations = relations(workflow_step_workflows, ({ one }) => ({
-  stepInstance: one(workflow_instance_workflows, {
-    relationName: "workflow_step_workflow_instance",
+  instanceRef: one(workflow_instance_workflows, {
+    relationName: "workflow_step_instanceRef",
     fields: [workflow_step_workflows.instanceRef],
     references: [workflow_instance_workflows._internalId]
   })
 }));
 
 export const workflow_event_workflowsRelations = relations(workflow_event_workflows, ({ one }) => ({
-  eventInstance: one(workflow_instance_workflows, {
-    relationName: "workflow_event_workflow_instance",
+  instanceRef: one(workflow_instance_workflows, {
+    relationName: "workflow_event_instanceRef",
     fields: [workflow_event_workflows.instanceRef],
     references: [workflow_instance_workflows._internalId]
   })

--- a/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.sqlite.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.sqlite.ts
@@ -122,12 +122,12 @@ export const session_auth = sqliteTable("session_auth", {
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_session_user_sessionOwner_auth_7854da47"
+    name: "fk_session_user_session_userId_fk_auth_481a47e0"
   }),
   foreignKey({
     columns: [table.activeOrganizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_session_organization_sessionActiveOrganization_auth_c1d88689"
+    name: "fk_session_organization_session_activeOrganizationId_fkaa5effd7"
   }),
   index("idx_session_idx_session_user_auth_0748231c").on(table.userId),
   index("idx_session_idx_session_id_expiresAt_auth_2345cc9f").on(table.id, table.expiresAt),
@@ -150,7 +150,7 @@ export const organization_auth = sqliteTable("organization_auth", {
   foreignKey({
     columns: [table.createdBy],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organization_user_organizationCreator_auth_c99fc140"
+    name: "fk_organization_user_organization_createdBy_fk_auth_3a721c70"
   }),
   uniqueIndex("uidx_organization_idx_organization_slug_auth_9b82968a").on(table.slug),
   index("idx_organization_idx_organization_createdBy_auth_e893279c").on(table.createdBy),
@@ -169,12 +169,12 @@ export const organizationMember_auth = sqliteTable("organizationMember_auth", {
   foreignKey({
     columns: [table.organizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_organizationMember_organization_organizationMemberOr038a36fb"
+    name: "fk_organizationMember_organization_organizationMember_ofdd1098e"
   }),
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organizationMember_user_organizationMemberUser_auth_a00a7460"
+    name: "fk_organizationMember_user_organizationMember_userId_fkb413bdc4"
   }),
   uniqueIndex("uidx_organizationMember_idx_org_member_org_user_auth_abbf915f").on(table.organizationId, table.userId),
   index("idx_organizationMember_idx_org_member_user_auth_1cd12c0f").on(table.userId),
@@ -193,7 +193,7 @@ export const organizationMemberRole_auth = sqliteTable("organizationMemberRole_a
   foreignKey({
     columns: [table.memberId],
     foreignColumns: [organizationMember_auth._internalId],
-    name: "fk_organizationMemberRole_organizationMember_organizati5029ddce"
+    name: "fk_organizationMemberRole_organizationMember_organizatib4490866"
   }),
   uniqueIndex("uidx_organizationMemberRole_idx_org_member_role_member_e45d22f1").on(table.memberId, table.role),
   index("idx_organizationMemberRole_idx_org_member_role_member_a2a65acd6").on(table.memberId),
@@ -218,12 +218,12 @@ export const organizationInvitation_auth = sqliteTable("organizationInvitation_a
   foreignKey({
     columns: [table.organizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_organizationInvitation_organization_organizationInvida3865a6"
+    name: "fk_organizationInvitation_organization_organizationInvi963a4ee6"
   }),
   foreignKey({
     columns: [table.inviterId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organizationInvitation_user_organizationInvitationIn47cda46d"
+    name: "fk_organizationInvitation_user_organizationInvitation_icbf271d9"
   }),
   uniqueIndex("uidx_organizationInvitation_idx_org_invitation_token_au93b35818").on(table.token),
   index("idx_organizationInvitation_idx_org_invitation_org_statu68f8a9be").on(table.organizationId, table.status),
@@ -255,7 +255,7 @@ export const oauthAccount_auth = sqliteTable("oauthAccount_auth", {
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_oauthAccount_user_oauthAccountUser_auth_94d5cb9b"
+    name: "fk_oauthAccount_user_oauthAccount_userId_fk_auth_0ecc8c86"
   }),
   uniqueIndex("uidx_oauthAccount_idx_oauth_account_provider_account_au229618a4").on(table.provider, table.providerAccountId),
   index("idx_oauthAccount_idx_oauth_account_user_auth_98049852").on(table.userId),
@@ -280,7 +280,7 @@ export const oauthState_auth = sqliteTable("oauthState_auth", {
   foreignKey({
     columns: [table.linkUserId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_oauthState_user_oauthStateLinkUser_auth_2659bef7"
+    name: "fk_oauthState_user_oauthState_linkUserId_fk_auth_8d42d847"
   }),
   uniqueIndex("uidx_oauthState_idx_oauth_state_state_auth_f65e8ad2").on(table.state),
   index("idx_oauthState_idx_oauth_state_provider_auth_2c66010f").on(table.provider),
@@ -290,103 +290,103 @@ export const oauthState_auth = sqliteTable("oauthState_auth", {
 
 export const user_authRelations = relations(user_auth, ({ many }) => ({
   sessionList: many(session_auth, {
-    relationName: "session_user"
+    relationName: "session_userId"
   }),
   organizationList: many(organization_auth, {
-    relationName: "organization_user"
+    relationName: "organization_createdBy"
   }),
   organizationMemberList: many(organizationMember_auth, {
-    relationName: "organizationMember_user"
+    relationName: "organizationMember_userId"
   }),
   organizationInvitationList: many(organizationInvitation_auth, {
-    relationName: "organizationInvitation_user"
+    relationName: "organizationInvitation_inviterId"
   }),
   oauthAccountList: many(oauthAccount_auth, {
-    relationName: "oauthAccount_user"
+    relationName: "oauthAccount_userId"
   }),
   oauthStateList: many(oauthState_auth, {
-    relationName: "oauthState_user"
+    relationName: "oauthState_linkUserId"
   })
 }));
 
 export const session_authRelations = relations(session_auth, ({ one }) => ({
-  sessionOwner: one(user_auth, {
-    relationName: "session_user",
+  user: one(user_auth, {
+    relationName: "session_userId",
     fields: [session_auth.userId],
     references: [user_auth._internalId]
   }),
-  sessionActiveOrganization: one(organization_auth, {
-    relationName: "session_organization",
+  activeOrganization: one(organization_auth, {
+    relationName: "session_activeOrganizationId",
     fields: [session_auth.activeOrganizationId],
     references: [organization_auth._internalId]
   })
 }));
 
 export const organization_authRelations = relations(organization_auth, ({ one, many }) => ({
-  organizationCreator: one(user_auth, {
-    relationName: "organization_user",
+  createdBy: one(user_auth, {
+    relationName: "organization_createdBy",
     fields: [organization_auth.createdBy],
     references: [user_auth._internalId]
   }),
   sessionList: many(session_auth, {
-    relationName: "session_organization"
+    relationName: "session_activeOrganizationId"
   }),
   organizationMemberList: many(organizationMember_auth, {
-    relationName: "organizationMember_organization"
+    relationName: "organizationMember_organizationId"
   }),
   organizationInvitationList: many(organizationInvitation_auth, {
-    relationName: "organizationInvitation_organization"
+    relationName: "organizationInvitation_organizationId"
   })
 }));
 
 export const organizationMember_authRelations = relations(organizationMember_auth, ({ one, many }) => ({
-  organizationMemberOrganization: one(organization_auth, {
-    relationName: "organizationMember_organization",
+  organization: one(organization_auth, {
+    relationName: "organizationMember_organizationId",
     fields: [organizationMember_auth.organizationId],
     references: [organization_auth._internalId]
   }),
-  organizationMemberUser: one(user_auth, {
-    relationName: "organizationMember_user",
+  user: one(user_auth, {
+    relationName: "organizationMember_userId",
     fields: [organizationMember_auth.userId],
     references: [user_auth._internalId]
   }),
   organizationMemberRoleList: many(organizationMemberRole_auth, {
-    relationName: "organizationMemberRole_organizationMember"
+    relationName: "organizationMemberRole_memberId"
   })
 }));
 
 export const organizationMemberRole_authRelations = relations(organizationMemberRole_auth, ({ one }) => ({
-  organizationMemberRoleMember: one(organizationMember_auth, {
-    relationName: "organizationMemberRole_organizationMember",
+  member: one(organizationMember_auth, {
+    relationName: "organizationMemberRole_memberId",
     fields: [organizationMemberRole_auth.memberId],
     references: [organizationMember_auth._internalId]
   })
 }));
 
 export const organizationInvitation_authRelations = relations(organizationInvitation_auth, ({ one }) => ({
-  organizationInvitationOrganization: one(organization_auth, {
-    relationName: "organizationInvitation_organization",
+  organization: one(organization_auth, {
+    relationName: "organizationInvitation_organizationId",
     fields: [organizationInvitation_auth.organizationId],
     references: [organization_auth._internalId]
   }),
-  organizationInvitationInviter: one(user_auth, {
-    relationName: "organizationInvitation_user",
+  inviter: one(user_auth, {
+    relationName: "organizationInvitation_inviterId",
     fields: [organizationInvitation_auth.inviterId],
     references: [user_auth._internalId]
   })
 }));
 
 export const oauthAccount_authRelations = relations(oauthAccount_auth, ({ one }) => ({
-  oauthAccountUser: one(user_auth, {
-    relationName: "oauthAccount_user",
+  user: one(user_auth, {
+    relationName: "oauthAccount_userId",
     fields: [oauthAccount_auth.userId],
     references: [user_auth._internalId]
   })
 }));
 
 export const oauthState_authRelations = relations(oauthState_auth, ({ one }) => ({
-  oauthStateLinkUser: one(user_auth, {
-    relationName: "oauthState_user",
+  linkUser: one(user_auth, {
+    relationName: "oauthState_linkUserId",
     fields: [oauthState_auth.linkUserId],
     references: [user_auth._internalId]
   })
@@ -447,7 +447,7 @@ export const comment_comment = sqliteTable("comment_comment", {
   foreignKey({
     columns: [table.parentId],
     foreignColumns: [table._internalId],
-    name: "fk_comment_comment_parent_comment_e6560345"
+    name: "fk_comment_comment_comment_parentId_fk_comment_d0862848"
   }),
   index("idx_comment_idx_comment_post_comment_c75acad5").on(table.postReference),
   uniqueIndex("uidx_comment_idx_comment_external_id_comment_1579b6d0").on(table.id)
@@ -455,12 +455,12 @@ export const comment_comment = sqliteTable("comment_comment", {
 
 export const comment_commentRelations = relations(comment_comment, ({ one, many }) => ({
   parent: one(comment_comment, {
-    relationName: "comment_comment",
+    relationName: "comment_parentId",
     fields: [comment_comment.parentId],
     references: [comment_comment._internalId]
   }),
   commentList: many(comment_comment, {
-    relationName: "comment_comment"
+    relationName: "comment_parentId"
   })
 }));
 
@@ -559,7 +559,7 @@ export const workflow_step_workflows = sqliteTable("workflow_step_workflows", {
   foreignKey({
     columns: [table.instanceRef],
     foreignColumns: [workflow_instance_workflows._internalId],
-    name: "fk_workflow_step_workflow_instance_stepInstance_workflo01bdff32"
+    name: "fk_workflow_step_workflow_instance_workflow_step_instanf10e6a91"
   }),
   uniqueIndex("uidx_workflow_step_idx_workflow_step_instanceRef_runNum2a6b0b25").on(table.instanceRef, table.runNumber, table.stepKey),
   index("idx_workflow_step_idx_workflow_step_instanceRef_runNumbe91f4dec").on(table.instanceRef, table.runNumber, table.createdAt),
@@ -583,7 +583,7 @@ export const workflow_event_workflows = sqliteTable("workflow_event_workflows", 
   foreignKey({
     columns: [table.instanceRef],
     foreignColumns: [workflow_instance_workflows._internalId],
-    name: "fk_workflow_event_workflow_instance_eventInstance_workf9b5621c6"
+    name: "fk_workflow_event_workflow_instance_workflow_event_inst3029c2ed"
   }),
   index("idx_workflow_event_idx_workflow_event_instanceRef_runNu9d715b8f").on(table.instanceRef, table.runNumber, table.createdAt),
   uniqueIndex("uidx_workflow_event_idx_workflow_event_external_id_workd61ca377").on(table.id)
@@ -591,24 +591,24 @@ export const workflow_event_workflows = sqliteTable("workflow_event_workflows", 
 
 export const workflow_instance_workflowsRelations = relations(workflow_instance_workflows, ({ many }) => ({
   workflow_stepList: many(workflow_step_workflows, {
-    relationName: "workflow_step_workflow_instance"
+    relationName: "workflow_step_instanceRef"
   }),
   workflow_eventList: many(workflow_event_workflows, {
-    relationName: "workflow_event_workflow_instance"
+    relationName: "workflow_event_instanceRef"
   })
 }));
 
 export const workflow_step_workflowsRelations = relations(workflow_step_workflows, ({ one }) => ({
-  stepInstance: one(workflow_instance_workflows, {
-    relationName: "workflow_step_workflow_instance",
+  instanceRef: one(workflow_instance_workflows, {
+    relationName: "workflow_step_instanceRef",
     fields: [workflow_step_workflows.instanceRef],
     references: [workflow_instance_workflows._internalId]
   })
 }));
 
 export const workflow_event_workflowsRelations = relations(workflow_event_workflows, ({ one }) => ({
-  eventInstance: one(workflow_instance_workflows, {
-    relationName: "workflow_event_workflow_instance",
+  instanceRef: one(workflow_instance_workflows, {
+    relationName: "workflow_event_instanceRef",
     fields: [workflow_event_workflows.instanceRef],
     references: [workflow_instance_workflows._internalId]
   })

--- a/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.ts
+++ b/example-apps/fragno-db-usage-drizzle/src/schema/fragno-schema.ts
@@ -118,12 +118,12 @@ export const session_auth = schema_auth.table("session", {
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_session_user_sessionOwner"
+    name: "fk_session_user_session_userId_fk"
   }),
   foreignKey({
     columns: [table.activeOrganizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_session_organization_sessionActiveOrganization"
+    name: "fk_session_organization_session_activeOrganizationId_fk"
   }),
   index("idx_session_user").on(table.userId),
   index("idx_session_id_expiresAt").on(table.id, table.expiresAt)
@@ -145,7 +145,7 @@ export const organization_auth = schema_auth.table("organization", {
   foreignKey({
     columns: [table.createdBy],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organization_user_organizationCreator"
+    name: "fk_organization_user_organization_createdBy_fk"
   }),
   uniqueIndex("idx_organization_slug").on(table.slug),
   index("idx_organization_createdBy").on(table.createdBy)
@@ -163,12 +163,12 @@ export const organizationMember_auth = schema_auth.table("organizationMember", {
   foreignKey({
     columns: [table.organizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_organizationMember_organization_organizationMemberOrb0ebc659"
+    name: "fk_organizationMember_organization_organizationMember_o606388be"
   }),
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organizationMember_user_organizationMemberUser"
+    name: "fk_organizationMember_user_organizationMember_userId_fk"
   }),
   uniqueIndex("idx_org_member_org_user").on(table.organizationId, table.userId),
   index("idx_org_member_user").on(table.userId),
@@ -186,7 +186,7 @@ export const organizationMemberRole_auth = schema_auth.table("organizationMember
   foreignKey({
     columns: [table.memberId],
     foreignColumns: [organizationMember_auth._internalId],
-    name: "fk_organizationMemberRole_organizationMember_organizati1834c67a"
+    name: "fk_organizationMemberRole_organizationMember_organizati180d7eb6"
   }),
   uniqueIndex("idx_org_member_role_member_role").on(table.memberId, table.role),
   index("idx_org_member_role_member").on(table.memberId),
@@ -210,12 +210,12 @@ export const organizationInvitation_auth = schema_auth.table("organizationInvita
   foreignKey({
     columns: [table.organizationId],
     foreignColumns: [organization_auth._internalId],
-    name: "fk_organizationInvitation_organization_organizationInvi7f8b4d7d"
+    name: "fk_organizationInvitation_organization_organizationInvib469906c"
   }),
   foreignKey({
     columns: [table.inviterId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_organizationInvitation_user_organizationInvitationInviter"
+    name: "fk_organizationInvitation_user_organizationInvitation_i5d603a64"
   }),
   uniqueIndex("idx_org_invitation_token").on(table.token),
   index("idx_org_invitation_org_status").on(table.organizationId, table.status),
@@ -246,7 +246,7 @@ export const oauthAccount_auth = schema_auth.table("oauthAccount", {
   foreignKey({
     columns: [table.userId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_oauthAccount_user_oauthAccountUser"
+    name: "fk_oauthAccount_user_oauthAccount_userId_fk"
   }),
   uniqueIndex("idx_oauth_account_provider_account").on(table.provider, table.providerAccountId),
   index("idx_oauth_account_user").on(table.userId),
@@ -270,7 +270,7 @@ export const oauthState_auth = schema_auth.table("oauthState", {
   foreignKey({
     columns: [table.linkUserId],
     foreignColumns: [user_auth._internalId],
-    name: "fk_oauthState_user_oauthStateLinkUser"
+    name: "fk_oauthState_user_oauthState_linkUserId_fk"
   }),
   uniqueIndex("idx_oauth_state_state").on(table.state),
   index("idx_oauth_state_provider").on(table.provider),
@@ -279,103 +279,103 @@ export const oauthState_auth = schema_auth.table("oauthState", {
 
 export const user_authRelations = relations(user_auth, ({ many }) => ({
   sessionList: many(session_auth, {
-    relationName: "session_user"
+    relationName: "session_userId"
   }),
   organizationList: many(organization_auth, {
-    relationName: "organization_user"
+    relationName: "organization_createdBy"
   }),
   organizationMemberList: many(organizationMember_auth, {
-    relationName: "organizationMember_user"
+    relationName: "organizationMember_userId"
   }),
   organizationInvitationList: many(organizationInvitation_auth, {
-    relationName: "organizationInvitation_user"
+    relationName: "organizationInvitation_inviterId"
   }),
   oauthAccountList: many(oauthAccount_auth, {
-    relationName: "oauthAccount_user"
+    relationName: "oauthAccount_userId"
   }),
   oauthStateList: many(oauthState_auth, {
-    relationName: "oauthState_user"
+    relationName: "oauthState_linkUserId"
   })
 }));
 
 export const session_authRelations = relations(session_auth, ({ one }) => ({
-  sessionOwner: one(user_auth, {
-    relationName: "session_user",
+  user: one(user_auth, {
+    relationName: "session_userId",
     fields: [session_auth.userId],
     references: [user_auth._internalId]
   }),
-  sessionActiveOrganization: one(organization_auth, {
-    relationName: "session_organization",
+  activeOrganization: one(organization_auth, {
+    relationName: "session_activeOrganizationId",
     fields: [session_auth.activeOrganizationId],
     references: [organization_auth._internalId]
   })
 }));
 
 export const organization_authRelations = relations(organization_auth, ({ one, many }) => ({
-  organizationCreator: one(user_auth, {
-    relationName: "organization_user",
+  createdBy: one(user_auth, {
+    relationName: "organization_createdBy",
     fields: [organization_auth.createdBy],
     references: [user_auth._internalId]
   }),
   sessionList: many(session_auth, {
-    relationName: "session_organization"
+    relationName: "session_activeOrganizationId"
   }),
   organizationMemberList: many(organizationMember_auth, {
-    relationName: "organizationMember_organization"
+    relationName: "organizationMember_organizationId"
   }),
   organizationInvitationList: many(organizationInvitation_auth, {
-    relationName: "organizationInvitation_organization"
+    relationName: "organizationInvitation_organizationId"
   })
 }));
 
 export const organizationMember_authRelations = relations(organizationMember_auth, ({ one, many }) => ({
-  organizationMemberOrganization: one(organization_auth, {
-    relationName: "organizationMember_organization",
+  organization: one(organization_auth, {
+    relationName: "organizationMember_organizationId",
     fields: [organizationMember_auth.organizationId],
     references: [organization_auth._internalId]
   }),
-  organizationMemberUser: one(user_auth, {
-    relationName: "organizationMember_user",
+  user: one(user_auth, {
+    relationName: "organizationMember_userId",
     fields: [organizationMember_auth.userId],
     references: [user_auth._internalId]
   }),
   organizationMemberRoleList: many(organizationMemberRole_auth, {
-    relationName: "organizationMemberRole_organizationMember"
+    relationName: "organizationMemberRole_memberId"
   })
 }));
 
 export const organizationMemberRole_authRelations = relations(organizationMemberRole_auth, ({ one }) => ({
-  organizationMemberRoleMember: one(organizationMember_auth, {
-    relationName: "organizationMemberRole_organizationMember",
+  member: one(organizationMember_auth, {
+    relationName: "organizationMemberRole_memberId",
     fields: [organizationMemberRole_auth.memberId],
     references: [organizationMember_auth._internalId]
   })
 }));
 
 export const organizationInvitation_authRelations = relations(organizationInvitation_auth, ({ one }) => ({
-  organizationInvitationOrganization: one(organization_auth, {
-    relationName: "organizationInvitation_organization",
+  organization: one(organization_auth, {
+    relationName: "organizationInvitation_organizationId",
     fields: [organizationInvitation_auth.organizationId],
     references: [organization_auth._internalId]
   }),
-  organizationInvitationInviter: one(user_auth, {
-    relationName: "organizationInvitation_user",
+  inviter: one(user_auth, {
+    relationName: "organizationInvitation_inviterId",
     fields: [organizationInvitation_auth.inviterId],
     references: [user_auth._internalId]
   })
 }));
 
 export const oauthAccount_authRelations = relations(oauthAccount_auth, ({ one }) => ({
-  oauthAccountUser: one(user_auth, {
-    relationName: "oauthAccount_user",
+  user: one(user_auth, {
+    relationName: "oauthAccount_userId",
     fields: [oauthAccount_auth.userId],
     references: [user_auth._internalId]
   })
 }));
 
 export const oauthState_authRelations = relations(oauthState_auth, ({ one }) => ({
-  oauthStateLinkUser: one(user_auth, {
-    relationName: "oauthState_user",
+  linkUser: one(user_auth, {
+    relationName: "oauthState_linkUserId",
     fields: [oauthState_auth.linkUserId],
     references: [user_auth._internalId]
   })
@@ -438,19 +438,19 @@ export const comment_comment = schema_comment.table("comment", {
   foreignKey({
     columns: [table.parentId],
     foreignColumns: [table._internalId],
-    name: "fk_comment_comment_parent"
+    name: "fk_comment_comment_comment_parentId_fk"
   }),
   index("idx_comment_post").on(table.postReference)
 ])
 
 export const comment_commentRelations = relations(comment_comment, ({ one, many }) => ({
   parent: one(comment_comment, {
-    relationName: "comment_comment",
+    relationName: "comment_parentId",
     fields: [comment_comment.parentId],
     references: [comment_comment._internalId]
   }),
   commentList: many(comment_comment, {
-    relationName: "comment_comment"
+    relationName: "comment_parentId"
   })
 }));
 
@@ -550,7 +550,7 @@ export const workflow_step_workflows = schema_workflows.table("workflow_step", {
   foreignKey({
     columns: [table.instanceRef],
     foreignColumns: [workflow_instance_workflows._internalId],
-    name: "fk_workflow_step_workflow_instance_stepInstance"
+    name: "fk_workflow_step_workflow_instance_workflow_step_instanceRef_fk"
   }),
   uniqueIndex("idx_workflow_step_instanceRef_runNumber_stepKey").on(table.instanceRef, table.runNumber, table.stepKey),
   index("idx_workflow_step_instanceRef_runNumber_createdAt").on(table.instanceRef, table.runNumber, table.createdAt),
@@ -573,31 +573,31 @@ export const workflow_event_workflows = schema_workflows.table("workflow_event",
   foreignKey({
     columns: [table.instanceRef],
     foreignColumns: [workflow_instance_workflows._internalId],
-    name: "fk_workflow_event_workflow_instance_eventInstance"
+    name: "fk_workflow_event_workflow_instance_workflow_event_inst7a7e6da9"
   }),
   index("idx_workflow_event_instanceRef_runNumber_createdAt").on(table.instanceRef, table.runNumber, table.createdAt)
 ])
 
 export const workflow_instance_workflowsRelations = relations(workflow_instance_workflows, ({ many }) => ({
   workflow_stepList: many(workflow_step_workflows, {
-    relationName: "workflow_step_workflow_instance"
+    relationName: "workflow_step_instanceRef"
   }),
   workflow_eventList: many(workflow_event_workflows, {
-    relationName: "workflow_event_workflow_instance"
+    relationName: "workflow_event_instanceRef"
   })
 }));
 
 export const workflow_step_workflowsRelations = relations(workflow_step_workflows, ({ one }) => ({
-  stepInstance: one(workflow_instance_workflows, {
-    relationName: "workflow_step_workflow_instance",
+  instanceRef: one(workflow_instance_workflows, {
+    relationName: "workflow_step_instanceRef",
     fields: [workflow_step_workflows.instanceRef],
     references: [workflow_instance_workflows._internalId]
   })
 }));
 
 export const workflow_event_workflowsRelations = relations(workflow_event_workflows, ({ one }) => ({
-  eventInstance: one(workflow_instance_workflows, {
-    relationName: "workflow_event_workflow_instance",
+  instanceRef: one(workflow_instance_workflows, {
+    relationName: "workflow_event_instanceRef",
     fields: [workflow_event_workflows.instanceRef],
     references: [workflow_instance_workflows._internalId]
   })

--- a/example-apps/fragno-db-usage-drizzle/turbo.json
+++ b/example-apps/fragno-db-usage-drizzle/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/example-apps/fragno-db-usage-kysely/turbo.json
+++ b/example-apps/fragno-db-usage-kysely/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/example-apps/fragno-db-usage-prisma/turbo.json
+++ b/example-apps/fragno-db-usage-prisma/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/example-apps/react-spa-local-first/src/App.tsx
+++ b/example-apps/react-spa-local-first/src/App.tsx
@@ -715,7 +715,7 @@ export default function App() {
         for (const schema of selectedGroup.schemas) {
           const query = runtime.adapter.createQueryEngine(schema);
           for (const tableName of Object.keys(schema.tables)) {
-            const data = await query.find(tableName as never);
+            const data = await query.find(tableName as never, (b) => b);
             nextCounts[`${schema.name}.${tableName}`] = data.length;
           }
         }
@@ -792,7 +792,7 @@ export default function App() {
       setTableError(null);
       try {
         const query = runtime.adapter.createQueryEngine(schema);
-        const data = await query.find(selectedTable.tableName as never);
+        const data = await query.find(selectedTable.tableName as never, (b) => b);
         if (cancelled) {
           return;
         }

--- a/example-apps/stripe-webshop/turbo.json
+++ b/example-apps/stripe-webshop/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/example-fragments/fragno-db-library/src/schema/comment.ts
+++ b/example-fragments/fragno-db-library/src/schema/comment.ts
@@ -13,14 +13,10 @@ export const commentSchema = schema("comment", (s) => {
         )
         .addColumn("postReference", column("string")) // FIXME: Support external references
         .addColumn("userReference", column("string"))
-        .addColumn("parentId", referenceColumn().nullable())
+        .addColumn("parentId", referenceColumn({ table: "comment" }).nullable())
         .createIndex("idx_comment_post", ["postReference"]);
     })
-    .addReference("parent", {
-      type: "one",
-      from: { table: "comment", column: "parentId" },
-      to: { table: "comment", column: "id" },
-    })
+    .noOp("removed obsolete comment.parent addReference history")
     .alterTable("comment", (t) => {
       return t.addColumn("rating", column("integer").defaultTo(0));
     });

--- a/packages/auth/src/index.test.ts
+++ b/packages/auth/src/index.test.ts
@@ -20,16 +20,30 @@ import { userActionsRoutesFactory } from "./user/user-actions";
 import { userOverviewRoutesFactory } from "./user/user-overview";
 
 const preOrganizationSchemaVersion = (() => {
-  const index = authSchema.operations.findIndex(
+  const sessionActiveOrganizationIndex = authSchema.operations.findIndex(
+    (operation) =>
+      operation.type === "alter-table" &&
+      operation.tableName === "session" &&
+      operation.operations.some(
+        (tableOperation) =>
+          tableOperation.type === "add-column" &&
+          tableOperation.columnName === "activeOrganizationId",
+      ),
+  );
+  const organizationTableIndex = authSchema.operations.findIndex(
     (operation) => operation.type === "add-table" && operation.tableName === "organization",
   );
-  if (index === -1) {
-    throw new Error("Expected auth schema to include organization table operations.");
+
+  if (sessionActiveOrganizationIndex === -1 || organizationTableIndex === -1) {
+    throw new Error(
+      "Expected auth schema to include session and organization bootstrap operations.",
+    );
   }
-  if (index < 2) {
-    throw new Error("Expected organization table to be added after user and session tables.");
+  if (organizationTableIndex <= sessionActiveOrganizationIndex) {
+    throw new Error("Expected organization table to be added after session.activeOrganizationId.");
   }
-  return index;
+
+  return organizationTableIndex + 1;
 })();
 
 class MemoryStorage implements Pick<Storage, "getItem" | "setItem" | "removeItem"> {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -200,10 +200,12 @@ export const authFragmentDefinition = defineFragment<AuthConfig>("auth")
             forSchema(authSchema).findFirst("organizationInvitation", (b) =>
               b
                 .whereIndex("primary", (eb) => eb("id", "=", payload.invitationId))
-                .join((j) =>
-                  j.organizationInvitationOrganization((org) =>
-                    org.join((j) => j.organizationCreator()),
-                  ),
+                .joinOne("organizationInvitationOrganization", "organization", (organization) =>
+                  organization
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                    .joinOne("organizationCreator", "user", (creator) =>
+                      creator.onIndex("primary", (eb) => eb("id", "=", eb.parent("createdBy"))),
+                    ),
                 ),
             ),
           )

--- a/packages/auth/src/oauth/oauth-services.ts
+++ b/packages/auth/src/oauth/oauth-services.ts
@@ -285,22 +285,20 @@ export function createOAuthServices(options: {
             .find("oauthState", (b) =>
               b
                 .whereIndex("idx_oauth_state_state", (eb) => eb("state", "=", input.state))
-                .join((j) =>
-                  j.oauthStateLinkUser((b) =>
-                    b
-                      .select(["id", "email", "role", "bannedAt"])
-                      .join((j) =>
-                        j["userOrganizationMembers"]((member) =>
-                          member
-                            .select(["createdAt"])
-                            .join((j) =>
-                              j["organizationMemberOrganization"]((organization) =>
-                                organization.select(["id", "deletedAt"]),
-                              ),
-                            ),
+                .joinOne("oauthStateLinkUser", "user", (user) =>
+                  user
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("linkUserId")))
+                    .select(["id", "email", "role", "bannedAt"])
+                    .joinMany("userOrganizationMembers", "organizationMember", (member) =>
+                      member
+                        .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("id")))
+                        .select(["createdAt"])
+                        .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                          organization
+                            .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                            .select(["id", "deletedAt"]),
                         ),
-                      ),
-                  ),
+                    ),
                 ),
             )
             .find("oauthAccount", (b) =>
@@ -311,37 +309,34 @@ export function createOAuthServices(options: {
                     eb("providerAccountId", "=", providerAccountId),
                   ),
                 )
-                .join((j) =>
-                  j.oauthAccountUser((b) =>
-                    b
-                      .select(["id", "email", "role", "bannedAt"])
-                      .join((j) =>
-                        j["userOrganizationMembers"]((member) =>
-                          member
-                            .select(["createdAt"])
-                            .join((j) =>
-                              j["organizationMemberOrganization"]((organization) =>
-                                organization.select(["id", "deletedAt"]),
-                              ),
-                            ),
+                .joinOne("oauthAccountUser", "user", (user) =>
+                  user
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"])
+                    .joinMany("userOrganizationMembers", "organizationMember", (member) =>
+                      member
+                        .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("id")))
+                        .select(["createdAt"])
+                        .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                          organization
+                            .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                            .select(["id", "deletedAt"]),
                         ),
-                      ),
-                  ),
+                    ),
                 ),
             )
             .find("user", (b) =>
               b
                 .whereIndex("idx_user_email", (eb) => eb("email", "=", email))
-                .join((j) =>
-                  j["userOrganizationMembers"]((member) =>
-                    member
-                      .select(["createdAt"])
-                      .join((j) =>
-                        j["organizationMemberOrganization"]((organization) =>
-                          organization.select(["id", "deletedAt"]),
-                        ),
-                      ),
-                  ),
+                .joinMany("userOrganizationMembers", "organizationMember", (member) =>
+                  member
+                    .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("id")))
+                    .select(["createdAt"])
+                    .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                      organization
+                        .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                        .select(["id", "deletedAt"]),
+                    ),
                 ),
             ),
         )

--- a/packages/auth/src/organization/active-organization.ts
+++ b/packages/auth/src/organization/active-organization.ts
@@ -63,7 +63,11 @@ export function createActiveOrganizationServices() {
           uow.findFirst("session", (b) =>
             b
               .whereIndex("primary", (eb) => eb("id", "=", sessionId))
-              .join((j) => j.sessionActiveOrganization()),
+              .joinOne("sessionActiveOrganization", "organization", (organization) =>
+                organization.onIndex("primary", (eb) =>
+                  eb("id", "=", eb.parent("activeOrganizationId")),
+                ),
+              ),
           ),
         )
         .transformRetrieve(([session]) => {

--- a/packages/auth/src/organization/invitation-services.ts
+++ b/packages/auth/src/organization/invitation-services.ts
@@ -222,7 +222,9 @@ export function createOrganizationInvitationServices(
           uow.findFirst("organizationInvitation", (b) =>
             b
               .whereIndex("primary", (eb) => eb("id", "=", invitationId))
-              .join((j) => j.organizationInvitationOrganization()),
+              .joinOne("organizationInvitationOrganization", "organization", (organization) =>
+                organization.onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId"))),
+              ),
           ),
         )
         .transformRetrieve(([invitation]) =>
@@ -276,7 +278,11 @@ export function createOrganizationInvitationServices(
                     eb("userId", "=", input.actor.userId),
                   ),
                 )
-                .join((j) => j.organizationMemberOrganization()),
+                .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("organizationId")),
+                  ),
+                ),
             )
             .find("organizationMemberRole", (b) => {
               const scoped = actorMemberId
@@ -284,7 +290,11 @@ export function createOrganizationInvitationServices(
                     eb("memberId", "=", actorMemberId),
                   )
                 : b.whereIndex("primary");
-              return scoped.join((j) => j.organizationMemberRoleMember());
+              return scoped.joinOne(
+                "organizationMemberRoleMember",
+                "organizationMember",
+                (member) => member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+              );
             })
             .find("organizationInvitation", (b) =>
               b.whereIndex("idx_org_invitation_org_status", (eb) =>
@@ -477,10 +487,12 @@ export function createOrganizationInvitationServices(
                   eb.and(eb("email", "=", email), eb("status", "=", status)),
                 )
               : b.whereIndex("idx_org_invitation_email", (eb) => eb("email", "=", email))
-            ).join((j) =>
-              j.organizationInvitationOrganization((org) =>
-                org.join((j) => j.organizationCreator()),
-              ),
+            ).joinOne("organizationInvitationOrganization", "organization", (organization) =>
+              organization
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                .joinOne("organizationCreator", "user", (creator) =>
+                  creator.onIndex("primary", (eb) => eb("id", "=", eb.parent("createdBy"))),
+                ),
             ),
           ),
         )
@@ -537,7 +549,11 @@ export function createOrganizationInvitationServices(
             .findFirst("organizationInvitation", (b) =>
               b
                 .whereIndex("primary", (eb) => eb("id", "=", input.invitationId))
-                .join((j) => j.organizationInvitationOrganization()),
+                .joinOne("organizationInvitationOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("organizationId")),
+                  ),
+                ),
             )
             .findFirst("organizationMember", (b) =>
               b.whereIndex("idx_org_member_org_user", (eb) =>
@@ -553,14 +569,20 @@ export function createOrganizationInvitationServices(
                     eb("memberId", "=", actorMemberId),
                   )
                 : b.whereIndex("primary");
-              return scoped.join((j) => j.organizationMemberRoleMember());
+              return scoped.joinOne(
+                "organizationMemberRoleMember",
+                "organizationMember",
+                (member) => member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+              );
             })
             .find("organizationMember", (b) =>
               b
                 .whereIndex("idx_org_member_org", (eb) =>
                   eb("organizationId", "=", input.organizationId ?? ""),
                 )
-                .join((j) => j.organizationMemberUser()),
+                .joinOne("organizationMemberUser", "user", (user) =>
+                  user.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
+                ),
             )
             .findFirst("user", (b) =>
               b.whereIndex("primary", (eb) => eb("id", "=", input.actor.userId)),
@@ -788,14 +810,21 @@ export function createOrganizationInvitationServices(
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((jb) =>
-                  jb.sessionOwner((ub) =>
-                    ub
-                      .select(["id", "email", "role", "bannedAt"])
-                      .join((jb2) =>
-                        jb2["invitations"]((ib) => ib.join((jb3) => jb3["organization"]())),
-                      ),
-                  ),
+                .joinOne("sessionOwner", "user", (user) =>
+                  user
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"])
+                    .joinMany("invitations", "organizationInvitation", (invitation) =>
+                      invitation
+                        .onIndex("idx_org_invitation_email", (eb) =>
+                          eb("email", "=", eb.parent("email")),
+                        )
+                        .joinOne("organization", "organization", (organization) =>
+                          organization.onIndex("primary", (eb) =>
+                            eb("id", "=", eb.parent("organizationId")),
+                          ),
+                        ),
+                    ),
                 ),
             )
             .findFirst("session", (b) =>
@@ -874,10 +903,19 @@ export function createOrganizationInvitationServices(
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) =>
-                  j
-                    .sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))
-                    .sessionMembers((mb) => mb.join((jb) => jb["organizationMemberRoles"]())),
+                .joinOne("sessionOwner", "user", (user) =>
+                  user
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                )
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member
+                    .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("userId")))
+                    .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                      role.onIndex("idx_org_member_role_member", (eb) =>
+                        eb("memberId", "=", eb.parent("id")),
+                      ),
+                    ),
                 ),
             )
             .findFirst("session", (b) =>
@@ -888,10 +926,14 @@ export function createOrganizationInvitationServices(
             .find("organizationInvitation", (b) =>
               b
                 .whereIndex("primary", (eb) => eb("id", "=", params.invitationId))
-                .join((j) =>
-                  j.organizationInvitationOrganization((ob) =>
-                    ob.join((jb) => jb["organizationMembers"]()),
-                  ),
+                .joinOne("organizationInvitationOrganization", "organization", (organization) =>
+                  organization
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                    .joinMany("organizationMembers", "organizationMember", (member) =>
+                      member.onIndex("idx_org_member_org", (eb) =>
+                        eb("organizationId", "=", eb.parent("id")),
+                      ),
+                    ),
                 ),
             ),
         )
@@ -1140,7 +1182,11 @@ export function createOrganizationInvitationServices(
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) => j.sessionMembers()),
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member.onIndex("idx_org_member_user", (eb) =>
+                    eb("userId", "=", eb.parent("userId")),
+                  ),
+                ),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -1201,10 +1247,19 @@ export function createOrganizationInvitationServices(
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) =>
-                  j
-                    .sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))
-                    .sessionMembers((mb) => mb.join((jb) => jb["organizationMemberRoles"]())),
+                .joinOne("sessionOwner", "user", (user) =>
+                  user
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                )
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member
+                    .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("userId")))
+                    .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                      role.onIndex("idx_org_member_role_member", (eb) =>
+                        eb("memberId", "=", eb.parent("id")),
+                      ),
+                    ),
                 ),
             )
             .findFirst("session", (b) =>

--- a/packages/auth/src/organization/member-services.ts
+++ b/packages/auth/src/organization/member-services.ts
@@ -288,11 +288,19 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                     eb("userId", "=", input.actor.userId),
                   ),
                 )
-                .join((j) => j.organizationMemberOrganization()),
+                .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("organizationId")),
+                  ),
+                ),
             )
             // NOTE: actorMember is resolved in the same retrieve phase, so we filter in memory.
             .find("organizationMemberRole", (b) =>
-              b.whereIndex("primary").join((j) => j.organizationMemberRoleMember()),
+              b
+                .whereIndex("primary")
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .find("organizationMember", (b) =>
               b.whereIndex("idx_org_member_org", (eb) =>
@@ -413,11 +421,19 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                     eb("userId", "=", params.actor.userId),
                   ),
                 )
-                .join((j) => j.organizationMemberOrganization()),
+                .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("organizationId")),
+                  ),
+                ),
             )
             // NOTE: actorMember is resolved in the same retrieve phase, so we filter in memory.
             .find("organizationMemberRole", (b) =>
-              b.whereIndex("primary").join((j) => j.organizationMemberRoleMember()),
+              b
+                .whereIndex("primary")
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .findFirst("user", (b) =>
               b.whereIndex("primary", (eb) => eb("id", "=", params.actor.userId)),
@@ -549,16 +565,26 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                     eb("userId", "=", params.actor.userId),
                   ),
                 )
-                .join((j) => j.organizationMemberOrganization()),
+                .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("organizationId")),
+                  ),
+                ),
             )
             // NOTE: actorMember is resolved in the same retrieve phase, so we filter in memory.
             .find("organizationMemberRole", (b) =>
-              b.whereIndex("primary").join((j) => j.organizationMemberRoleMember()),
+              b
+                .whereIndex("primary")
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .find("organizationMemberRole", (b) =>
               b
                 .whereIndex("idx_org_member_role_role", (eb) => eb("role", "=", OWNER_ROLE))
-                .join((j) => j.organizationMemberRoleMember()),
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .findFirst("user", (b) =>
               b.whereIndex("primary", (eb) => eb("id", "=", params.actor.userId)),
@@ -675,16 +701,26 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                     eb("userId", "=", params.actor.userId),
                   ),
                 )
-                .join((j) => j.organizationMemberOrganization()),
+                .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("organizationId")),
+                  ),
+                ),
             )
             // NOTE: actorMember is resolved in the same retrieve phase, so we filter in memory.
             .find("organizationMemberRole", (b) =>
-              b.whereIndex("primary").join((j) => j.organizationMemberRoleMember()),
+              b
+                .whereIndex("primary")
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .find("organizationMemberRole", (b) =>
               b
                 .whereIndex("idx_org_member_role_role", (eb) => eb("role", "=", OWNER_ROLE))
-                .join((j) => j.organizationMemberRoleMember()),
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .findFirst("user", (b) =>
               b.whereIndex("primary", (eb) => eb("id", "=", params.actor.userId)),
@@ -799,16 +835,26 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                     eb("userId", "=", params.actor.userId),
                   ),
                 )
-                .join((j) => j.organizationMemberOrganization()),
+                .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("organizationId")),
+                  ),
+                ),
             )
             // NOTE: actorMember is resolved in the same retrieve phase, so we filter in memory.
             .find("organizationMemberRole", (b) =>
-              b.whereIndex("primary").join((j) => j.organizationMemberRoleMember()),
+              b
+                .whereIndex("primary")
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .find("organizationMemberRole", (b) =>
               b
                 .whereIndex("idx_org_member_role_role", (eb) => eb("role", "=", OWNER_ROLE))
-                .join((j) => j.organizationMemberRoleMember()),
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .findFirst("user", (b) =>
               b.whereIndex("primary", (eb) => eb("id", "=", params.actor.userId)),
@@ -903,7 +949,12 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
               .whereIndex("idx_org_member_org", (eb) => eb("organizationId", "=", organizationId))
               .orderByIndex("idx_org_member_org", effectiveSortOrder)
               .pageSize(effectivePageSize)
-              .join((j) => j.organizationMemberOrganization().organizationMemberUser());
+              .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                organization.onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId"))),
+              )
+              .joinOne("organizationMemberUser", "user", (user) =>
+                user.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
+              );
 
             return cursor ? query.after(cursor) : query;
           }),
@@ -977,7 +1028,9 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                   ? eb("memberId", "=", memberIds[0])
                   : eb.or(...memberIds.map((memberId) => eb("memberId", "=", memberId))),
               )
-              .join((j) => j.organizationMemberRoleMember()),
+              .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+              ),
           ),
         )
         .transformRetrieve(([roles]) => {
@@ -1016,7 +1069,11 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) => j.sessionMembers()),
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member.onIndex("idx_org_member_user", (eb) =>
+                    eb("userId", "=", eb.parent("userId")),
+                  ),
+                ),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -1031,19 +1088,26 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                 .whereIndex("idx_org_member_org", (eb) => eb("organizationId", "=", organizationId))
                 .orderByIndex("idx_org_member_org", effectiveSortOrder)
                 .pageSize(effectivePageSize)
-                .join((j) => j.organizationMemberOrganization().organizationMemberUser());
+                .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("organizationId")),
+                  ),
+                )
+                .joinOne("organizationMemberUser", "user", (user) =>
+                  user.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
+                );
 
               return cursor ? query.after(cursor) : query;
             })
             .find("organizationMemberRole", (b) =>
               b
                 .whereIndex("idx_org_member_role_member")
-                .join((j) =>
-                  j.organizationMemberRoleMember((mb) =>
-                    mb.whereIndex("idx_org_member_org", (eb) =>
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId")))
+                    .whereIndex("idx_org_member_org", (eb) =>
                       eb("organizationId", "=", organizationId),
                     ),
-                  ),
                 ),
             ),
         )
@@ -1133,10 +1197,19 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) =>
-                  j
-                    .sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))
-                    .sessionMembers((mb) => mb.join((jb) => jb["organizationMemberRoles"]())),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                )
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member
+                    .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("userId")))
+                    .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                      role.onIndex("idx_org_member_role_member", (eb) =>
+                        eb("memberId", "=", eb.parent("id")),
+                      ),
+                    ),
                 ),
             )
             .findFirst("session", (b) =>
@@ -1287,12 +1360,22 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) =>
-                  j
-                    .sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))
-                    .sessionMembers((mb) =>
-                      mb.join((jb) =>
-                        jb.organizationMemberOrganization()["organizationMemberRoles"](),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                )
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member
+                    .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("userId")))
+                    .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                      organization.onIndex("primary", (eb) =>
+                        eb("id", "=", eb.parent("organizationId")),
+                      ),
+                    )
+                    .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                      role.onIndex("idx_org_member_role_member", (eb) =>
+                        eb("memberId", "=", eb.parent("id")),
                       ),
                     ),
                 ),
@@ -1313,7 +1396,9 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
             .find("organizationMemberRole", (b) =>
               b
                 .whereIndex("idx_org_member_role_role", (eb) => eb("role", "=", OWNER_ROLE))
-                .join((j) => j.organizationMemberRoleMember()),
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             ),
         )
         .mutate(
@@ -1482,12 +1567,22 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) =>
-                  j
-                    .sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))
-                    .sessionMembers((mb) =>
-                      mb.join((jb) =>
-                        jb.organizationMemberOrganization()["organizationMemberRoles"](),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                )
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member
+                    .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("userId")))
+                    .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                      organization.onIndex("primary", (eb) =>
+                        eb("id", "=", eb.parent("organizationId")),
+                      ),
+                    )
+                    .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                      role.onIndex("idx_org_member_role_member", (eb) =>
+                        eb("memberId", "=", eb.parent("id")),
                       ),
                     ),
                 ),
@@ -1508,7 +1603,9 @@ export function createOrganizationMemberServices(options: OrganizationMemberServ
             .find("organizationMemberRole", (b) =>
               b
                 .whereIndex("idx_org_member_role_role", (eb) => eb("role", "=", OWNER_ROLE))
-                .join((j) => j.organizationMemberRoleMember()),
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             ),
         )
         .mutate(({ uow, retrieveResult: [session, expiredSession, member, roles, ownerRoles] }) => {

--- a/packages/auth/src/organization/organization-services.ts
+++ b/packages/auth/src/organization/organization-services.ts
@@ -339,7 +339,9 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
           uow.findFirst("organization", (b) =>
             b
               .whereIndex("primary", (eb) => eb("id", "=", organizationId))
-              .join((j) => j.organizationCreator()),
+              .joinOne("organizationCreator", "user", (creator) =>
+                creator.onIndex("primary", (eb) => eb("id", "=", eb.parent("createdBy"))),
+              ),
           ),
         )
         .transformRetrieve(([organization]) =>
@@ -379,7 +381,9 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
           uow.findFirst("organization", (b) =>
             b
               .whereIndex("idx_organization_slug", (eb) => eb("slug", "=", normalizedSlug))
-              .join((j) => j.organizationCreator()),
+              .joinOne("organizationCreator", "user", (creator) =>
+                creator.onIndex("primary", (eb) => eb("id", "=", eb.parent("createdBy"))),
+              ),
           ),
         )
         .transformRetrieve(([organization]) =>
@@ -435,7 +439,9 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
             .findFirst("organization", (b) =>
               b
                 .whereIndex("primary", (eb) => eb("id", "=", organizationId))
-                .join((j) => j.organizationCreator()),
+                .joinOne("organizationCreator", "user", (creator) =>
+                  creator.onIndex("primary", (eb) => eb("id", "=", eb.parent("createdBy"))),
+                ),
             )
             .findFirst("organization", (b) =>
               b.whereIndex("idx_organization_slug", (eb) => eb("slug", "=", nextSlug ?? "")),
@@ -447,7 +453,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
             )
             // NOTE: actorMember is resolved in the same retrieve phase, so we filter in memory.
             .find("organizationMemberRole", (b) =>
-              b.whereIndex("primary").join((j) => j.organizationMemberRoleMember()),
+              b
+                .whereIndex("primary")
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .findFirst("user", (b) => b.whereIndex("primary", (eb) => eb("id", "=", actor.userId))),
         )
@@ -545,7 +555,9 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
             .findFirst("organization", (b) =>
               b
                 .whereIndex("primary", (eb) => eb("id", "=", organizationId))
-                .join((j) => j.organizationCreator()),
+                .joinOne("organizationCreator", "user", (creator) =>
+                  creator.onIndex("primary", (eb) => eb("id", "=", eb.parent("createdBy"))),
+                ),
             )
             .findFirst("organizationMember", (b) =>
               b.whereIndex("idx_org_member_org_user", (eb) =>
@@ -554,7 +566,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
             )
             // NOTE: actorMember is resolved in the same retrieve phase, so we filter in memory.
             .find("organizationMemberRole", (b) =>
-              b.whereIndex("primary").join((j) => j.organizationMemberRoleMember()),
+              b
+                .whereIndex("primary")
+                .joinOne("organizationMemberRoleMember", "organizationMember", (member) =>
+                  member.onIndex("primary", (eb) => eb("id", "=", eb.parent("memberId"))),
+                ),
             )
             .find("organizationInvitation", (b) =>
               b.whereIndex("idx_org_invitation_org_status", (eb) =>
@@ -644,10 +660,15 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
               .whereIndex("idx_org_member_user", (eb) => eb("userId", "=", userId))
               .orderByIndex("idx_org_member_user", effectiveSortOrder)
               .pageSize(effectivePageSize)
-              .join((j) =>
-                j
-                  .organizationMemberOrganization((org) => org.join((j) => j.organizationCreator()))
-                  .organizationMemberUser(),
+              .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                organization
+                  .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                  .joinOne("organizationCreator", "user", (creator) =>
+                    creator.onIndex("primary", (eb) => eb("id", "=", eb.parent("createdBy"))),
+                  ),
+              )
+              .joinOne("organizationMemberUser", "user", (user) =>
+                user.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
               );
 
             return cursor ? query.after(cursor) : query;
@@ -723,10 +744,15 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) =>
-                  j
-                    .sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))
-                    .sessionMembers(),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                )
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member.onIndex("idx_org_member_user", (eb) =>
+                    eb("userId", "=", eb.parent("userId")),
+                  ),
                 ),
             )
             .findFirst("session", (b) =>
@@ -902,24 +928,37 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) =>
-                  j
-                    .sessionOwner((b) => b.select(["id"]))
-                    .sessionMembers((mb) => {
-                      let memberQuery = mb
-                        .orderByIndex("primary", effectiveSortOrder)
-                        .pageSize(effectivePageSize + 1)
-                        .join((jb) => jb["organization"]()["roles"]((rb) => rb.select(["role"])));
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id"]),
+                )
+                .joinMany("sessionMembers", "organizationMember", (member) => {
+                  let memberQuery = member
+                    .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("userId")))
+                    .orderByIndex("primary", effectiveSortOrder)
+                    .pageSize(effectivePageSize + 1)
+                    .joinOne("organization", "organization", (organization) =>
+                      organization.onIndex("primary", (eb) =>
+                        eb("id", "=", eb.parent("organizationId")),
+                      ),
+                    )
+                    .joinMany("roles", "organizationMemberRole", (role) =>
+                      role
+                        .onIndex("idx_org_member_role_member", (eb) =>
+                          eb("memberId", "=", eb.parent("id")),
+                        )
+                        .select(["role"]),
+                    );
 
-                      if (cursorId) {
-                        memberQuery = memberQuery.whereIndex("primary", (eb) =>
-                          eb("id", effectiveSortOrder === "asc" ? ">" : "<", cursorId),
-                        );
-                      }
+                  if (cursorId) {
+                    memberQuery = memberQuery.whereIndex("primary", (eb) =>
+                      eb("id", effectiveSortOrder === "asc" ? ">" : "<", cursorId),
+                    );
+                  }
 
-                      return memberQuery;
-                    }),
-                ),
+                  return memberQuery;
+                }),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -1075,11 +1114,24 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) =>
-                  j
-                    .sessionOwner((b) => b.select(["id"]))
-                    .sessionActiveOrganization()
-                    .sessionMembers((mb) => mb.join((jb) => jb["organizationMemberRoles"]())),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id"]),
+                )
+                .joinOne("sessionActiveOrganization", "organization", (organization) =>
+                  organization.onIndex("primary", (eb) =>
+                    eb("id", "=", eb.parent("activeOrganizationId")),
+                  ),
+                )
+                .joinMany("sessionMembers", "organizationMember", (member) =>
+                  member
+                    .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("userId")))
+                    .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                      role.onIndex("idx_org_member_role_member", (eb) =>
+                        eb("memberId", "=", eb.parent("id")),
+                      ),
+                    ),
                 ),
             )
             .findFirst("session", (b) =>
@@ -1177,7 +1229,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) => j.sessionOwner((b) => b.select(["id"]))),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id"]),
+                ),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -1192,7 +1248,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_org_member_org", (eb) =>
                   eb("organizationId", "=", params.organizationId),
                 )
-                .join((j) => j["organizationMemberRoles"]()),
+                .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                  role.onIndex("idx_org_member_role_member", (eb) =>
+                    eb("memberId", "=", eb.parent("id")),
+                  ),
+                ),
             ),
         )
         .mutate(({ uow, retrieveResult: [session, expiredSession, organization, members] }) => {
@@ -1277,7 +1337,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) => j.sessionOwner((b) => b.select(["id", "email", "role"]))),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role"]),
+                ),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -1292,7 +1356,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_org_member_org", (eb) =>
                   eb("organizationId", "=", params.organizationId),
                 )
-                .join((j) => j["organizationMemberRoles"]()),
+                .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                  role.onIndex("idx_org_member_role_member", (eb) =>
+                    eb("memberId", "=", eb.parent("id")),
+                  ),
+                ),
             ),
         )
         .mutate(({ uow, retrieveResult: [session, expiredSession, organization, members] }) => {
@@ -1383,7 +1451,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) => j.sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                ),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -1401,7 +1473,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_org_member_org", (eb) =>
                   eb("organizationId", "=", params.organizationId),
                 )
-                .join((j) => j["organizationMemberRoles"]()),
+                .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                  role.onIndex("idx_org_member_role_member", (eb) =>
+                    eb("memberId", "=", eb.parent("id")),
+                  ),
+                ),
             ),
         )
         .mutate(
@@ -1533,7 +1609,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", params.sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) => j.sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                ),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -1556,7 +1636,11 @@ export function createOrganizationServices(options: OrganizationServiceOptions =
                 .whereIndex("idx_org_member_org", (eb) =>
                   eb("organizationId", "=", params.organizationId),
                 )
-                .join((j) => j["organizationMemberRoles"]()),
+                .joinMany("organizationMemberRoles", "organizationMemberRole", (role) =>
+                  role.onIndex("idx_org_member_role_member", (eb) =>
+                    eb("memberId", "=", eb.parent("id")),
+                  ),
+                ),
             ),
         )
         .mutate(

--- a/packages/auth/src/schema.ts
+++ b/packages/auth/src/schema.ts
@@ -18,7 +18,7 @@ export const authSchema = schema("auth", (s) => {
     .addTable("session", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("userId", referenceColumn())
+        .addColumn("userId", referenceColumn({ table: "user" }))
         .addColumn("expiresAt", column("timestamp"))
         .addColumn(
           "createdAt",
@@ -32,7 +32,10 @@ export const authSchema = schema("auth", (s) => {
         .createIndex("idx_user_createdAt", ["createdAt"]);
     })
     .alterTable("session", (t) => {
-      return t.addColumn("activeOrganizationId", referenceColumn().nullable());
+      return t.addColumn(
+        "activeOrganizationId",
+        referenceColumn({ table: "organization" }).nullable(),
+      );
     })
     .addTable("organization", (t) => {
       return t
@@ -41,7 +44,7 @@ export const authSchema = schema("auth", (s) => {
         .addColumn("slug", column("string"))
         .addColumn("logoUrl", column("string").nullable())
         .addColumn("metadata", column("json").nullable())
-        .addColumn("createdBy", referenceColumn())
+        .addColumn("createdBy", referenceColumn({ table: "user" }))
         .addColumn(
           "createdAt",
           column("timestamp").defaultTo((b) => b.now()),
@@ -57,8 +60,8 @@ export const authSchema = schema("auth", (s) => {
     .addTable("organizationMember", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("organizationId", referenceColumn())
-        .addColumn("userId", referenceColumn())
+        .addColumn("organizationId", referenceColumn({ table: "organization" }))
+        .addColumn("userId", referenceColumn({ table: "user" }))
         .addColumn(
           "createdAt",
           column("timestamp").defaultTo((b) => b.now()),
@@ -76,7 +79,7 @@ export const authSchema = schema("auth", (s) => {
     .addTable("organizationMemberRole", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("memberId", referenceColumn())
+        .addColumn("memberId", referenceColumn({ table: "organizationMember" }))
         .addColumn("role", column("string"))
         .addColumn(
           "createdAt",
@@ -91,12 +94,12 @@ export const authSchema = schema("auth", (s) => {
     .addTable("organizationInvitation", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("organizationId", referenceColumn())
+        .addColumn("organizationId", referenceColumn({ table: "organization" }))
         .addColumn("email", column("string"))
         .addColumn("roles", column("json"))
         .addColumn("status", column("string"))
         .addColumn("token", column("string"))
-        .addColumn("inviterId", referenceColumn())
+        .addColumn("inviterId", referenceColumn({ table: "user" }))
         .addColumn("expiresAt", column("timestamp"))
         .addColumn(
           "createdAt",
@@ -108,110 +111,19 @@ export const authSchema = schema("auth", (s) => {
         .createIndex("idx_org_invitation_email", ["email"])
         .createIndex("idx_org_invitation_email_status", ["email", "status"]);
     })
-    .addReference("sessionOwner", {
-      from: {
-        table: "session",
-        column: "userId",
-      },
-      to: {
-        table: "user",
-        column: "id",
-      },
-      type: "one",
-    })
-    .addReference("sessionActiveOrganization", {
-      from: {
-        table: "session",
-        column: "activeOrganizationId",
-      },
-      to: {
-        table: "organization",
-        column: "id",
-      },
-      type: "one",
-    })
-    .addReference("organizationCreator", {
-      from: {
-        table: "organization",
-        column: "createdBy",
-      },
-      to: {
-        table: "user",
-        column: "id",
-      },
-      type: "one",
-    })
-    .addReference("organizationMemberOrganization", {
-      from: {
-        table: "organizationMember",
-        column: "organizationId",
-      },
-      to: {
-        table: "organization",
-        column: "id",
-      },
-      type: "one",
-    })
-    .addReference("organizationMembers", {
-      from: {
-        table: "organization",
-        column: "id",
-      },
-      to: {
-        table: "organizationMember",
-        column: "organizationId",
-      },
-      type: "many",
-      foreignKey: false,
-    })
-    .addReference("organizationMemberUser", {
-      from: {
-        table: "organizationMember",
-        column: "userId",
-      },
-      to: {
-        table: "user",
-        column: "id",
-      },
-      type: "one",
-    })
-    .addReference("organizationMemberRoleMember", {
-      from: {
-        table: "organizationMemberRole",
-        column: "memberId",
-      },
-      to: {
-        table: "organizationMember",
-        column: "id",
-      },
-      type: "one",
-    })
-    .addReference("organizationInvitationOrganization", {
-      from: {
-        table: "organizationInvitation",
-        column: "organizationId",
-      },
-      to: {
-        table: "organization",
-        column: "id",
-      },
-      type: "one",
-    })
-    .addReference("organizationInvitationInviter", {
-      from: {
-        table: "organizationInvitation",
-        column: "inviterId",
-      },
-      to: {
-        table: "user",
-        column: "id",
-      },
-      type: "one",
-    })
+    .noOp("removed obsolete sessionOwner addReference history")
+    .noOp("removed obsolete sessionActiveOrganization addReference history")
+    .noOp("removed obsolete organizationCreator addReference history")
+    .noOp("removed obsolete organizationMemberOrganization addReference history")
+    .noOp("removed obsolete organizationMembers join-only relation history")
+    .noOp("removed obsolete organizationMemberUser addReference history")
+    .noOp("removed obsolete organizationMemberRoleMember addReference history")
+    .noOp("removed obsolete organizationInvitationOrganization addReference history")
+    .noOp("removed obsolete organizationInvitationInviter addReference history")
     .addTable("oauthAccount", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("userId", referenceColumn())
+        .addColumn("userId", referenceColumn({ table: "user" }))
         .addColumn("provider", column("string"))
         .addColumn("providerAccountId", column("string"))
         .addColumn("email", column("string").nullable())
@@ -246,7 +158,7 @@ export const authSchema = schema("auth", (s) => {
         .addColumn("codeVerifier", column("string").nullable())
         .addColumn("redirectUri", column("string").nullable())
         .addColumn("returnTo", column("string").nullable())
-        .addColumn("linkUserId", referenceColumn().nullable())
+        .addColumn("linkUserId", referenceColumn({ table: "user" }).nullable())
         .addColumn(
           "createdAt",
           column("timestamp").defaultTo((b) => b.now()),
@@ -256,144 +168,23 @@ export const authSchema = schema("auth", (s) => {
         .createIndex("idx_oauth_state_provider", ["provider"])
         .createIndex("idx_oauth_state_expiresAt", ["expiresAt"]);
     })
-    .addReference("oauthAccountUser", {
-      from: {
-        table: "oauthAccount",
-        column: "userId",
-      },
-      to: {
-        table: "user",
-        column: "id",
-      },
-      type: "one",
-    })
-    .addReference("oauthStateLinkUser", {
-      from: {
-        table: "oauthState",
-        column: "linkUserId",
-      },
-      to: {
-        table: "user",
-        column: "id",
-      },
-      type: "one",
-    })
+    .noOp("removed obsolete oauthAccountUser addReference history")
+    .noOp("removed obsolete oauthStateLinkUser addReference history")
     .alterTable("user", (t) => {
       return t.alterColumn("passwordHash").nullable();
     })
-    .addReference("sessionOrganizationMembers", {
-      type: "many",
-      from: {
-        table: "session",
-        column: "userId",
-      },
-      to: {
-        table: "organizationMember",
-        column: "userId",
-      },
-      foreignKey: false,
-    })
-    .addReference("sessionMembers", {
-      type: "many",
-      from: {
-        table: "session",
-        column: "userId",
-      },
-      to: {
-        table: "organizationMember",
-        column: "userId",
-      },
-      foreignKey: false,
-    })
-    .addReference("organizationMemberRoles", {
-      type: "many",
-      from: {
-        table: "organizationMember",
-        // Join-only relations coerce `id` to internal ID.
-        column: "id",
-      },
-      to: {
-        table: "organizationMemberRole",
-        column: "memberId",
-      },
-      foreignKey: false,
-    })
-    .addReference("roles", {
-      type: "many",
-      from: {
-        table: "organizationMember",
-        // Join-only relations coerce `id` to internal ID.
-        column: "id",
-      },
-      to: {
-        table: "organizationMemberRole",
-        column: "memberId",
-      },
-      foreignKey: false,
-    })
-    .addReference("organization", {
-      type: "one",
-      from: {
-        table: "organizationMember",
-        column: "organizationId",
-      },
-      to: {
-        table: "organization",
-        column: "id",
-      },
-      foreignKey: false,
-    })
-    .addReference("userOrganizationInvitations", {
-      type: "many",
-      from: {
-        table: "user",
-        column: "email",
-      },
-      to: {
-        table: "organizationInvitation",
-        column: "email",
-      },
-      foreignKey: false,
-    })
-    .addReference("invitations", {
-      type: "many",
-      from: {
-        table: "user",
-        column: "email",
-      },
-      to: {
-        table: "organizationInvitation",
-        column: "email",
-      },
-      foreignKey: false,
-    })
-    .addReference("organization", {
-      type: "one",
-      from: {
-        table: "organizationInvitation",
-        column: "organizationId",
-      },
-      to: {
-        table: "organization",
-        column: "id",
-      },
-      foreignKey: false,
-    })
+    .noOp("removed obsolete sessionOrganizationMembers join-only relation history")
+    .noOp("removed obsolete sessionMembers join-only relation history")
+    .noOp("removed obsolete organizationMemberRoles join-only relation history")
+    .noOp("removed obsolete roles join-only relation history")
+    .noOp("removed obsolete organizationMember.organization join-only relation history")
+    .noOp("removed obsolete userOrganizationInvitations join-only relation history")
+    .noOp("removed obsolete invitations join-only relation history")
+    .noOp("removed obsolete organizationInvitation.organization join-only relation history")
     .alterTable("session", (t) => {
       return t.createIndex("idx_session_id_expiresAt", ["id", "expiresAt"]);
     })
-    .addReference("userOrganizationMembers", {
-      type: "many",
-      from: {
-        table: "user",
-        column: "id",
-      },
-      to: {
-        table: "organizationMember",
-        column: "userId",
-      },
-      foreignKey: false,
-    })
+    .noOp("removed obsolete userOrganizationMembers join-only relation history")
     .alterTable("oauthState", (t) => {
       return t.addColumn("sessionSeed", column("json").nullable());
     });

--- a/packages/auth/src/session/session.ts
+++ b/packages/auth/src/session/session.ts
@@ -304,10 +304,10 @@ export function createSessionServices(cookieOptions?: CookieOptions) {
           uow.find("organizationMember", (b) =>
             b
               .whereIndex("idx_org_member_user", (eb) => eb("userId", "=", userId))
-              .join((j) =>
-                j.organizationMemberOrganization((ob) =>
-                  ob.select(["id", "deletedAt", "createdAt"]),
-                ),
+              .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                organization
+                  .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                  .select(["id", "deletedAt", "createdAt"]),
               ),
           ),
         )
@@ -395,7 +395,11 @@ export function createSessionServices(cookieOptions?: CookieOptions) {
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", sessionId), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) => j.sessionOwner((b) => b.select(["id", "email", "role"]))),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role"]),
+                ),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -435,7 +439,11 @@ export function createSessionServices(cookieOptions?: CookieOptions) {
           uow.findFirst("session", (b) =>
             b
               .whereIndex("primary", (eb) => eb("id", "=", sessionId))
-              .join((j) => j.sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))),
+              .joinOne("sessionOwner", "user", (owner) =>
+                owner
+                  .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                  .select(["id", "email", "role", "bannedAt"]),
+              ),
           ),
         )
         .mutate(({ uow, retrieveResult: [session] }) => {
@@ -481,7 +489,11 @@ export function createSessionServices(cookieOptions?: CookieOptions) {
                 .whereIndex("idx_session_id_expiresAt", (eb) =>
                   eb.and(eb("id", "=", sessionId ?? ""), eb("expiresAt", ">", eb.now())),
                 )
-                .join((j) => j.sessionOwner((b) => b.select(["id", "email", "role"]))),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role"]),
+                ),
             )
             .findFirst("session", (b) =>
               b.whereIndex("idx_session_id_expiresAt", (eb) =>
@@ -625,7 +637,11 @@ export const sessionRoutesFactory = defineRoutes<typeof authFragmentDefinition>(
                     .whereIndex("idx_session_id_expiresAt", (eb) =>
                       eb.and(eb("id", "=", sessionId), eb("expiresAt", ">", eb.now())),
                     )
-                    .join((jb) => jb.sessionOwner((ub) => ub.select(["id", "email", "role"]))),
+                    .joinOne("sessionOwner", "user", (owner) =>
+                      owner
+                        .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                        .select(["id", "email", "role"]),
+                    ),
                 );
                 scheduleExpiredLookup();
                 return uow;
@@ -636,16 +652,32 @@ export const sessionRoutesFactory = defineRoutes<typeof authFragmentDefinition>(
                   .whereIndex("idx_session_id_expiresAt", (eb) =>
                     eb.and(eb("id", "=", sessionId), eb("expiresAt", ">", eb.now())),
                   )
-                  .join((jb) =>
-                    jb
-                      .sessionOwner((ub) => ub.select(["id", "email", "role"]))
-                      .sessionActiveOrganization((ob) => ob.select(["id"]))
-                      .sessionMembers((mb) =>
-                        mb.join((jb2) =>
-                          jb2["organization"]((ob) => ob.select(organizationSelect))["roles"](
-                            (rb) => rb.select(["role"]),
-                          ),
-                        ),
+                  .joinOne("sessionOwner", "user", (owner) =>
+                    owner
+                      .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                      .select(["id", "email", "role"]),
+                  )
+                  .joinOne("sessionActiveOrganization", "organization", (organization) =>
+                    organization
+                      .onIndex("primary", (eb) => eb("id", "=", eb.parent("activeOrganizationId")))
+                      .select(["id"]),
+                  )
+                  .joinMany("sessionMembers", "organizationMember", (member) =>
+                    member
+                      .onIndex("idx_org_member_user", (eb) =>
+                        eb("userId", "=", eb.parent("userId")),
+                      )
+                      .joinOne("organization", "organization", (organization) =>
+                        organization
+                          .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                          .select(organizationSelect),
+                      )
+                      .joinMany("roles", "organizationMemberRole", (role) =>
+                        role
+                          .onIndex("idx_org_member_role_member", (eb) =>
+                            eb("memberId", "=", eb.parent("id")),
+                          )
+                          .select(["role"]),
                       ),
                   ),
               );
@@ -655,18 +687,23 @@ export const sessionRoutesFactory = defineRoutes<typeof authFragmentDefinition>(
                   .whereIndex("idx_session_id_expiresAt", (eb) =>
                     eb.and(eb("id", "=", sessionId), eb("expiresAt", ">", eb.now())),
                   )
-                  .join((jb) =>
-                    jb.sessionOwner((ub) =>
-                      ub
-                        .select(["id", "email", "role"])
-                        .join((jb2) =>
-                          jb2["invitations"]((ib) =>
-                            ib.join((jb3) =>
-                              jb3["organization"]((ob) => ob.select(organizationSelect)),
-                            ),
+                  .joinOne("sessionOwner", "user", (owner) =>
+                    owner
+                      .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                      .select(["id", "email", "role"])
+                      .joinMany("invitations", "organizationInvitation", (invitation) =>
+                        invitation
+                          .onIndex("idx_org_invitation_email", (eb) =>
+                            eb("email", "=", eb.parent("email")),
+                          )
+                          .joinOne("organization", "organization", (organization) =>
+                            organization
+                              .onIndex("primary", (eb) =>
+                                eb("id", "=", eb.parent("organizationId")),
+                              )
+                              .select(organizationSelect),
                           ),
-                        ),
-                    ),
+                      ),
                   ),
               );
 

--- a/packages/auth/src/user/user-actions.ts
+++ b/packages/auth/src/user/user-actions.ts
@@ -289,7 +289,11 @@ export function createUserServices(
             .findFirst("session", (b) =>
               b
                 .whereIndex("primary", (eb) => eb("id", "=", sessionId))
-                .join((j) => j.sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))),
+                .joinOne("sessionOwner", "user", (owner) =>
+                  owner
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                    .select(["id", "email", "role", "bannedAt"]),
+                ),
             )
             .findFirst("user", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
         )
@@ -344,7 +348,11 @@ export function createUserServices(
           uow.findFirst("session", (b) =>
             b
               .whereIndex("primary", (eb) => eb("id", "=", sessionId))
-              .join((j) => j.sessionOwner((b) => b.select(["id", "email", "role", "bannedAt"]))),
+              .joinOne("sessionOwner", "user", (owner) =>
+                owner
+                  .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                  .select(["id", "email", "role", "bannedAt"]),
+              ),
           ),
         )
         .mutate(({ uow, retrieveResult: [session] }) => {
@@ -529,16 +537,15 @@ export const userActionsRoutesFactory = defineRoutes<typeof authFragmentDefiniti
               forSchema(authSchema).find("user", (b) =>
                 b
                   .whereIndex("idx_user_email", (eb) => eb("email", "=", email))
-                  .join((j) =>
-                    j["userOrganizationMembers"]((member) =>
-                      member
-                        .select(["createdAt"])
-                        .join((j) =>
-                          j["organizationMemberOrganization"]((organization) =>
-                            organization.select(["id", "deletedAt"]),
-                          ),
-                        ),
-                    ),
+                  .joinMany("userOrganizationMembers", "organizationMember", (member) =>
+                    member
+                      .onIndex("idx_org_member_user", (eb) => eb("userId", "=", eb.parent("id")))
+                      .select(["createdAt"])
+                      .joinOne("organizationMemberOrganization", "organization", (organization) =>
+                        organization
+                          .onIndex("primary", (eb) => eb("id", "=", eb.parent("organizationId")))
+                          .select(["id", "deletedAt"]),
+                      ),
                   ),
               ),
             )

--- a/packages/cloudflare-fragment/src/definition.ts
+++ b/packages/cloudflare-fragment/src/definition.ts
@@ -331,7 +331,9 @@ export const cloudflareFragmentDefinition = defineFragment<CloudflareFragmentCon
             forSchema(cloudflareSchema).findFirst("deployment", (b) =>
               b
                 .whereIndex("primary", (eb) => eb("id", "=", input.deploymentId))
-                .join((j) => j.app()),
+                .joinOne("app", "app", (app) =>
+                  app.onIndex("primary", (eb) => eb("id", "=", eb.parent("appId"))),
+                ),
             ),
           )
           .mutate(({ forSchema, retrieveResult: [deployment] }) => {
@@ -438,7 +440,9 @@ export const cloudflareFragmentDefinition = defineFragment<CloudflareFragmentCon
                   .findFirst("deployment", (b) =>
                     b
                       .whereIndex("primary", (eb) => eb("id", "=", input.deploymentId))
-                      .join((j) => j.app()),
+                      .joinOne("app", "app", (app) =>
+                        app.onIndex("primary", (eb) => eb("id", "=", eb.parent("appId"))),
+                      ),
                   )
                   .findFirst("deployment", (b) =>
                     b.whereIndex("primary", (eb) => eb("id", "=", remoteDeploymentId)),
@@ -453,7 +457,9 @@ export const cloudflareFragmentDefinition = defineFragment<CloudflareFragmentCon
                 forSchema(cloudflareSchema).findFirst("deployment", (b) =>
                   b
                     .whereIndex("primary", (eb) => eb("id", "=", input.deploymentId))
-                    .join((j) => j.app()),
+                    .joinOne("app", "app", (app) =>
+                      app.onIndex("primary", (eb) => eb("id", "=", eb.parent("appId"))),
+                    ),
                 ),
               )
               .transformRetrieve(([deployment]) => ({
@@ -765,7 +771,11 @@ export const cloudflareFragmentDefinition = defineFragment<CloudflareFragmentCon
         return this.serviceTx(cloudflareSchema)
           .retrieve((uow) =>
             uow.findFirst("deployment", (b) =>
-              b.whereIndex("primary", (eb) => eb("id", "=", deploymentId)).join((j) => j.app()),
+              b
+                .whereIndex("primary", (eb) => eb("id", "=", deploymentId))
+                .joinOne("app", "app", (app) =>
+                  app.onIndex("primary", (eb) => eb("id", "=", eb.parent("appId"))),
+                ),
             ),
           )
           .transformRetrieve(([deployment]) => {
@@ -802,7 +812,13 @@ export const cloudflareFragmentDefinition = defineFragment<CloudflareFragmentCon
           .retrieve((uow) =>
             uow
               .find("app", (b) => b.whereIndex("primary"))
-              .find("deployment", (b) => b.whereIndex("primary").join((j) => j.app())),
+              .find("deployment", (b) =>
+                b
+                  .whereIndex("primary")
+                  .joinOne("app", "app", (app) =>
+                    app.onIndex("primary", (eb) => eb("id", "=", eb.parent("appId"))),
+                  ),
+              ),
           )
           .transformRetrieve(([apps, deployments]) => {
             const latestDeploymentsByAppId = new Map<string, (typeof deployments)[number]>();

--- a/packages/cloudflare-fragment/src/schema.ts
+++ b/packages/cloudflare-fragment/src/schema.ts
@@ -22,7 +22,7 @@ export const cloudflareSchema = schema("cloudflare-fragment", (s) => {
     .addTable("deployment", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("appId", referenceColumn())
+        .addColumn("appId", referenceColumn({ table: "app" }))
         .addColumn("status", column("string"))
         .addColumn("format", column("string"))
         .addColumn("entrypoint", column("string"))
@@ -50,9 +50,5 @@ export const cloudflareSchema = schema("cloudflare-fragment", (s) => {
         .createIndex("idx_deployment_app_createdAt", ["appId", "createdAt"])
         .createIndex("idx_deployment_status_createdAt", ["status", "createdAt"]);
     })
-    .addReference("app", {
-      type: "one",
-      from: { table: "deployment", column: "appId" },
-      to: { table: "app", column: "id" },
-    });
+    .noOp("removed obsolete deployment -> app addReference history");
 });

--- a/packages/create/src/integration.test.ts
+++ b/packages/create/src/integration.test.ts
@@ -4,11 +4,20 @@ import { exec } from "node:child_process";
 import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import { create } from ".";
 
 const execAsync = promisify(exec);
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const linkedFragnoPackages: Record<string, string> = {
+  "@fragno-dev/core": path.join(repoRoot, "packages/fragno"),
+  "@fragno-dev/db": path.join(repoRoot, "packages/fragno-db"),
+  "@fragno-dev/cli": path.join(repoRoot, "apps/fragno-cli"),
+  "@fragno-dev/unplugin-fragno": path.join(repoRoot, "packages/unplugin-fragno"),
+};
 
 async function createTempDir(name: string): Promise<string> {
   const dir = path.join(tmpdir(), `${name}-${Date.now()}`);
@@ -22,6 +31,29 @@ async function createTempDir(name: string): Promise<string> {
 }
 
 type BuildTool = "tsdown" | "esbuild" | "vite" | "rollup" | "webpack" | "rspack";
+
+async function linkLocalFragnoPackages(targetPath: string) {
+  const packageJsonPath = path.join(targetPath, "package.json");
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as Record<
+    string,
+    unknown
+  >;
+
+  for (const sectionName of ["dependencies", "devDependencies"] as const) {
+    const section = packageJson[sectionName];
+    if (!section || typeof section !== "object") {
+      continue;
+    }
+
+    for (const [packageName, localPath] of Object.entries(linkedFragnoPackages)) {
+      if (packageName in (section as Record<string, string>)) {
+        (section as Record<string, string>)[packageName] = `link:${localPath}`;
+      }
+    }
+  }
+
+  await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
+}
 
 function createFragmentTestSuite(buildTool: BuildTool, withDatabase: boolean) {
   return () => {
@@ -38,6 +70,7 @@ function createFragmentTestSuite(buildTool: BuildTool, withDatabase: boolean) {
       tempDir = await createTempDir(`fragment-test-${buildTool}-${suffix}`);
       console.log("temp", tempDir);
       create({ ...testConfig, path: tempDir, withDatabase });
+      await linkLocalFragnoPackages(tempDir);
     });
 
     afterAll(async () => {

--- a/packages/create/src/package-json.ts
+++ b/packages/create/src/package-json.ts
@@ -1,9 +1,9 @@
 import type { BuildTools } from "./index";
 
-const fragnoCoreVersion = "0.2.0";
-const fragnoDbVersion = "0.3.0";
-const unpluginFragnoVersion = "0.0.8";
-const fragnoCliVersion = "0.2.0";
+const fragnoCoreVersion = "0.2.2";
+const fragnoDbVersion = "0.4.1";
+const unpluginFragnoVersion = "0.0.9";
+const fragnoCliVersion = "0.2.3";
 
 export const basePkg: Record<string, unknown> = {
   dependencies: {

--- a/packages/create/templates/optional/agent/AGENTS.md
+++ b/packages/create/templates/optional/agent/AGENTS.md
@@ -142,21 +142,11 @@ export const noteSchema = schema("example-fragment", (s) => {
       return t
         .addColumn("id", idColumn()) // Auto-generated ID
         .addColumn("content", column("string"))
-        .addColumn("userId", referenceColumn())
-        .addColumn("createdAt", column("timestamp").defaultTo$("now"))
+        .addColumn("userId", referenceColumn({ table: "user" }))
+        .addColumn("createdAt", column("timestamp").defaultTo((b) => b.now())
         .createIndex("idx_note_user", ["userId"]);
     })
-    .addReference("author", {
-      from: {
-        table: "note",
-        column: "userId",
-      },
-      to: {
-        table: "user",
-        column: "id",
-      },
-      type: "one",
-    });
+    .noOp("removed obsolete note -> user addReference history");
 });
 ```
 

--- a/packages/create/templates/optional/database/index.ts
+++ b/packages/create/templates/optional/database/index.ts
@@ -73,7 +73,13 @@ const exampleFragmentDefinition = defineFragment<ExampleConfig>("example-fragmen
       getNotes: function () {
         return this.serviceTx(noteSchema)
           .retrieve((uow) =>
-            uow.find("note", (b) => b.whereIndex("primary").join((j) => j.author())),
+            uow.find("note", (b) =>
+              b
+                .whereIndex("primary")
+                .joinOne("author", "user", (author) =>
+                  author.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
+                ),
+            ),
           )
           .transformRetrieve(([notes]) => {
             return notes;
@@ -87,7 +93,13 @@ const exampleFragmentDefinition = defineFragment<ExampleConfig>("example-fragmen
               .findFirst("user", (b) =>
                 b.whereIndex("idx_user_email", (eb) => eb("email", "=", userEmail)),
               )
-              .find("note", (b) => b.whereIndex("primary").join((j) => j.author())),
+              .find("note", (b) =>
+                b
+                  .whereIndex("primary")
+                  .joinOne("author", "user", (author) =>
+                    author.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
+                  ),
+              ),
           )
           .transformRetrieve(([user, allNotes]) => {
             if (!user) {
@@ -102,7 +114,11 @@ const exampleFragmentDefinition = defineFragment<ExampleConfig>("example-fragmen
         return this.serviceTx(noteSchema)
           .retrieve((uow) =>
             uow.findFirst("note", (b) =>
-              b.whereIndex("primary", (eb) => eb("id", "=", noteId)).join((j) => j.author()),
+              b
+                .whereIndex("primary", (eb) => eb("id", "=", noteId))
+                .joinOne("author", "user", (author) =>
+                  author.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
+                ),
             ),
           )
           .mutate(({ uow, retrieveResult: [note] }) => {

--- a/packages/create/templates/optional/database/schema.ts
+++ b/packages/create/templates/optional/database/schema.ts
@@ -13,16 +13,12 @@ export const noteSchema = schema("example-fragment", (s) => {
       return t
         .addColumn("id", idColumn())
         .addColumn("content", column("string"))
-        .addColumn("userId", referenceColumn())
+        .addColumn("userId", referenceColumn({ table: "user" }))
         .addColumn(
           "createdAt",
           column("timestamp").defaultTo((b) => b.now()),
         )
         .createIndex("idx_note_user", ["userId"]);
     })
-    .addReference("author", {
-      type: "one",
-      from: { table: "note", column: "userId" },
-      to: { table: "user", column: "id" },
-    });
+    .noOp("removed obsolete note -> user addReference history");
 });

--- a/packages/create/turbo.json
+++ b/packages/create/turbo.json
@@ -1,0 +1,15 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": [
+        "$TURBO_EXTENDS$",
+        "@fragno-dev/core#build",
+        "@fragno-dev/db#build",
+        "@fragno-dev/cli#build",
+        "@fragno-dev/unplugin-fragno#build"
+      ],
+      "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
+    }
+  }
+}

--- a/packages/forms/turbo.json
+++ b/packages/forms/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/fragment-mailing-list/turbo.json
+++ b/packages/fragment-mailing-list/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/fragment-upload/src/schema.ts
+++ b/packages/fragment-upload/src/schema.ts
@@ -85,7 +85,7 @@ export const uploadSchema = schema("upload", (s) => {
     .addTable("upload_part", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("uploadId", referenceColumn())
+        .addColumn("uploadId", referenceColumn({ table: "upload" }))
         .addColumn("partNumber", column("integer"))
         .addColumn("etag", column("string"))
         .addColumn("sizeBytes", column("bigint"))
@@ -98,9 +98,5 @@ export const uploadSchema = schema("upload", (s) => {
           unique: true,
         });
     })
-    .addReference("upload", {
-      type: "one",
-      from: { table: "upload_part", column: "uploadId" },
-      to: { table: "upload", column: "id" },
-    });
+    .noOp("removed obsolete upload_part -> upload addReference history");
 });

--- a/packages/fragment-upload/turbo.json
+++ b/packages/fragment-upload/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/fragment-workflows/src/schema.ts
+++ b/packages/fragment-workflows/src/schema.ts
@@ -56,7 +56,7 @@ export const workflowsSchema = schema("workflows", (s) => {
             // Internal step row id.
             .addColumn("id", idColumn())
             // Reference to workflow_instance (internal id).
-            .addColumn("instanceRef", referenceColumn())
+            .addColumn("instanceRef", referenceColumn({ table: "workflow_instance" }))
             // Run number (ties steps to the instance run).
             .addColumn("runNumber", column("integer"))
             // Deterministic step key (type:name) for replay/idempotency.
@@ -119,7 +119,7 @@ export const workflowsSchema = schema("workflows", (s) => {
             // Internal event row id.
             .addColumn("id", idColumn())
             // Reference to workflow_instance (internal id).
-            .addColumn("instanceRef", referenceColumn())
+            .addColumn("instanceRef", referenceColumn({ table: "workflow_instance" }))
             // Run number (ties events to the instance run).
             .addColumn("runNumber", column("integer"))
             // Actor describes who emitted the event; typical values are "user" and "system".
@@ -144,15 +144,7 @@ export const workflowsSchema = schema("workflows", (s) => {
             ])
         );
       })
-      .addReference("stepInstance", {
-        type: "one",
-        from: { table: "workflow_step", column: "instanceRef" },
-        to: { table: "workflow_instance", column: "id" },
-      })
-      .addReference("eventInstance", {
-        type: "one",
-        from: { table: "workflow_event", column: "instanceRef" },
-        to: { table: "workflow_instance", column: "id" },
-      })
+      .noOp("removed obsolete workflow_step -> workflow_instance addReference history")
+      .noOp("removed obsolete workflow_event -> workflow_instance addReference history")
   );
 });

--- a/packages/fragment-workflows/turbo.json
+++ b/packages/fragment-workflows/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/fragno-db/src/adapters/drizzle/migrate-drizzle.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/migrate-drizzle.test.ts
@@ -40,7 +40,7 @@ describe("generateSchema and migrate", () => {
           .addColumn("slug", column("varchar(255)"))
           .addColumn("content", column("string"))
           .addColumn("excerpt", column("string").nullable())
-          .addColumn("userId", referenceColumn())
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .addColumn("viewCount", column("integer").defaultTo(0))
           .addColumn("likeCount", column("bigint").defaultTo(9999999999999999n))
           .addColumn("isPublished", column("bool").defaultTo(false))
@@ -61,9 +61,9 @@ describe("generateSchema and migrate", () => {
         return t
           .addColumn("id", idColumn())
           .addColumn("content", column("string"))
-          .addColumn("postId", referenceColumn())
-          .addColumn("userId", referenceColumn())
-          .addColumn("parentId", referenceColumn().nullable())
+          .addColumn("postId", referenceColumn({ table: "posts" }))
+          .addColumn("userId", referenceColumn({ table: "users" }))
+          .addColumn("parentId", referenceColumn({ table: "comments" }).nullable())
           .addColumn(
             "createdAt",
             column("timestamp").defaultTo((b) => b.now()),
@@ -88,8 +88,8 @@ describe("generateSchema and migrate", () => {
       .addTable("postTags", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("postId", referenceColumn())
-          .addColumn("tagId", referenceColumn())
+          .addColumn("postId", referenceColumn({ table: "posts" }))
+          .addColumn("tagId", referenceColumn({ table: "tags" }))
           .addColumn("order", column("integer").defaultTo(0))
           .addColumn(
             "createdAt",
@@ -97,36 +97,6 @@ describe("generateSchema and migrate", () => {
           )
           .createIndex("idx_postTags_post_tag", ["postId", "tagId"], { unique: true })
           .createIndex("idx_postTags_tag", ["tagId"]);
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "userId" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "comments", column: "postId" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "comments", column: "userId" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("parent", {
-        type: "one",
-        from: { table: "comments", column: "parentId" },
-        to: { table: "comments", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "postTags", column: "postId" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("tag", {
-        type: "one",
-        from: { table: "postTags", column: "tagId" },
-        to: { table: "tags", column: "id" },
       });
   });
 
@@ -291,12 +261,12 @@ describe("generateSchema and migrate", () => {
       	CONSTRAINT "postTags_id_unique" UNIQUE("id")
       );
 
-      ALTER TABLE "test"."posts" ADD CONSTRAINT "fk_posts_users_author" FOREIGN KEY ("userId") REFERENCES "test"."users"("_internalId") ON DELETE no action ON UPDATE no action;
-      ALTER TABLE "test"."comments" ADD CONSTRAINT "fk_comments_posts_post" FOREIGN KEY ("postId") REFERENCES "test"."posts"("_internalId") ON DELETE no action ON UPDATE no action;
-      ALTER TABLE "test"."comments" ADD CONSTRAINT "fk_comments_users_author" FOREIGN KEY ("userId") REFERENCES "test"."users"("_internalId") ON DELETE no action ON UPDATE no action;
-      ALTER TABLE "test"."comments" ADD CONSTRAINT "fk_comments_comments_parent" FOREIGN KEY ("parentId") REFERENCES "test"."comments"("_internalId") ON DELETE no action ON UPDATE no action;
-      ALTER TABLE "test"."postTags" ADD CONSTRAINT "fk_postTags_posts_post" FOREIGN KEY ("postId") REFERENCES "test"."posts"("_internalId") ON DELETE no action ON UPDATE no action;
-      ALTER TABLE "test"."postTags" ADD CONSTRAINT "fk_postTags_tags_tag" FOREIGN KEY ("tagId") REFERENCES "test"."tags"("_internalId") ON DELETE no action ON UPDATE no action;
+      ALTER TABLE "test"."posts" ADD CONSTRAINT "fk_posts_users_posts_userId_fk" FOREIGN KEY ("userId") REFERENCES "test"."users"("_internalId") ON DELETE no action ON UPDATE no action;
+      ALTER TABLE "test"."comments" ADD CONSTRAINT "fk_comments_posts_comments_postId_fk" FOREIGN KEY ("postId") REFERENCES "test"."posts"("_internalId") ON DELETE no action ON UPDATE no action;
+      ALTER TABLE "test"."comments" ADD CONSTRAINT "fk_comments_users_comments_userId_fk" FOREIGN KEY ("userId") REFERENCES "test"."users"("_internalId") ON DELETE no action ON UPDATE no action;
+      ALTER TABLE "test"."comments" ADD CONSTRAINT "fk_comments_comments_comments_parentId_fk" FOREIGN KEY ("parentId") REFERENCES "test"."comments"("_internalId") ON DELETE no action ON UPDATE no action;
+      ALTER TABLE "test"."postTags" ADD CONSTRAINT "fk_postTags_posts_postTags_postId_fk" FOREIGN KEY ("postId") REFERENCES "test"."posts"("_internalId") ON DELETE no action ON UPDATE no action;
+      ALTER TABLE "test"."postTags" ADD CONSTRAINT "fk_postTags_tags_postTags_tagId_fk" FOREIGN KEY ("tagId") REFERENCES "test"."tags"("_internalId") ON DELETE no action ON UPDATE no action;
       CREATE UNIQUE INDEX "unique_key" ON "fragno_db_settings" USING btree ("key");
       CREATE INDEX "idx_namespace_status_retry" ON "fragno_hooks" USING btree ("namespace","status","nextRetryAt");
       CREATE INDEX "idx_nonce" ON "fragno_hooks" USING btree ("nonce");

--- a/packages/fragno-db/src/adapters/drizzle/migration-parity-drizzle-kit.test.ts
+++ b/packages/fragno-db/src/adapters/drizzle/migration-parity-drizzle-kit.test.ts
@@ -52,7 +52,7 @@ const paritySchema = schema("parity", (s) => {
         .addColumn("body", column("string"))
         .addColumn("published", column("bool").defaultTo(false))
         .addColumn("publishedAt", column("timestamp").nullable())
-        .addColumn("authorId", referenceColumn())
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .addColumn("metadata", column("json").nullable())
         .addColumn("rating", column("decimal").nullable())
         .addColumn("contentHash", column("binary").nullable())
@@ -70,8 +70,8 @@ const paritySchema = schema("parity", (s) => {
     .addTable("postTags", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("postId", referenceColumn())
-        .addColumn("tagId", referenceColumn())
+        .addColumn("postId", referenceColumn({ table: "posts" }))
+        .addColumn("tagId", referenceColumn({ table: "tags" }))
         .addColumn(
           "addedAt",
           column("timestamp").defaultTo((b) => b.now()),
@@ -84,28 +84,8 @@ const paritySchema = schema("parity", (s) => {
       return t
         .addColumn("id", idColumn())
         .addColumn("name", column("string"))
-        .addColumn("parentId", referenceColumn().nullable())
+        .addColumn("parentId", referenceColumn({ table: "categories" }).nullable())
         .createIndex("categories_parent_idx", ["parentId"]);
-    })
-    .addReference("posts_author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("post_tags_post", {
-      type: "one",
-      from: { table: "postTags", column: "postId" },
-      to: { table: "posts", column: "id" },
-    })
-    .addReference("post_tags_tag", {
-      type: "one",
-      from: { table: "postTags", column: "tagId" },
-      to: { table: "tags", column: "id" },
-    })
-    .addReference("categories_parent", {
-      type: "one",
-      from: { table: "categories", column: "parentId" },
-      to: { table: "categories", column: "id" },
     });
 });
 

--- a/packages/fragno-db/src/adapters/generic-sql/generic-sql-adapter.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/generic-sql-adapter.test.ts
@@ -50,7 +50,7 @@ describe("SqlAdapter", () => {
     const product = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("products", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "test")));
+        .findFirst("products", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "test")));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();

--- a/packages/fragno-db/src/adapters/generic-sql/generic-sql-adapter.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/generic-sql-adapter.test.ts
@@ -50,7 +50,7 @@ describe("SqlAdapter", () => {
     const product = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("products", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "test")));
+        .findFirstNew("products", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "test")));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();

--- a/packages/fragno-db/src/adapters/generic-sql/migration/adapter-migration-parity.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/adapter-migration-parity.test.ts
@@ -37,15 +37,10 @@ const paritySchema = schema("parity", (s) => {
     .addTable("posts", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("authorId", referenceColumn())
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .addColumn("title", column("string"))
         .addColumn("isPublished", column("bool").defaultTo(false))
         .createIndex("posts_author_idx", ["authorId"]);
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
     });
 });
 

--- a/packages/fragno-db/src/adapters/generic-sql/migration/dialect/mysql.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/dialect/mysql.test.ts
@@ -798,10 +798,10 @@ describe("MySQLSQLGenerator", () => {
         `"create table \`posts\` (\`id\` integer not null unique, \`user_id\` integer not null, \`title\` text not null, \`content\` text not null)"`,
       );
       expect(statements[4].sql).toMatchInlineSnapshot(
-        `"alter table \`posts\` add constraint \`posts_user_id_fk\` foreign key (\`user_id\`) references \`users\` (\`id\`) on delete restrict on update restrict"`,
+        `"alter table \`posts\` add column \`published\` boolean default false not null"`,
       );
       expect(statements[5].sql).toMatchInlineSnapshot(
-        `"alter table \`posts\` add column \`published\` boolean default false not null"`,
+        `"alter table \`posts\` add constraint \`posts_user_id_fk\` foreign key (\`user_id\`) references \`users\` (\`id\`) on delete restrict on update restrict"`,
       );
       expect(statements[6].sql).toBe("SET FOREIGN_KEY_CHECKS = 1");
     });
@@ -979,6 +979,39 @@ describe("MySQLSQLGenerator", () => {
       expect(preprocessed[0]).toEqual({ type: "custom", sql: "SET FOREIGN_KEY_CHECKS = 0" });
       expect(preprocessed[1]).toEqual(operations[0]);
       expect(preprocessed[2]).toEqual({ type: "custom", sql: "SET FOREIGN_KEY_CHECKS = 1" });
+    });
+
+    it("hoists foreign keys inside the wrapped batch for forward references", () => {
+      const operations: MigrationOperation[] = [
+        {
+          type: "create-table",
+          name: "sessions",
+          columns: [{ name: "id", type: "string", isNullable: false, role: "external-id" }],
+        },
+        {
+          type: "add-foreign-key",
+          table: "sessions",
+          value: {
+            name: "sessions_org_fk",
+            columns: ["organizationId"],
+            referencedTable: "organizations",
+            referencedColumns: ["_internalId"],
+          },
+        },
+        {
+          type: "create-table",
+          name: "organizations",
+          columns: [{ name: "id", type: "string", isNullable: false, role: "external-id" }],
+        },
+      ];
+
+      expect(generator.preprocess(operations)).toEqual([
+        { type: "custom", sql: "SET FOREIGN_KEY_CHECKS = 0" },
+        operations[0],
+        operations[2],
+        operations[1],
+        { type: "custom", sql: "SET FOREIGN_KEY_CHECKS = 1" },
+      ]);
     });
 
     it("should return empty array for empty operations", () => {

--- a/packages/fragno-db/src/adapters/generic-sql/migration/dialect/mysql.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/dialect/mysql.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../../../migration-engine/shared";
 import { isUpdated } from "../../../../migration-engine/shared";
 import type { NamingResolver } from "../../../../naming/sql-naming";
-import { SQLGenerator } from "../sql-generator";
+import { reorderAddForeignKeysForExecution, SQLGenerator } from "../sql-generator";
 
 const errors = {
   IdColumnUpdate:
@@ -20,7 +20,8 @@ const errors = {
  */
 export class MySQLSQLGenerator extends SQLGenerator {
   /**
-   * MySQL preprocessing: wrap operations with SET FOREIGN_KEY_CHECKS = 0/1.
+   * MySQL disables FK checks for the batch and still hoists FK creation to the end,
+   * so forward references can be created after the referenced tables exist.
    */
   override preprocess(operations: MigrationOperation[]): MigrationOperation[] {
     if (operations.length === 0) {
@@ -29,7 +30,7 @@ export class MySQLSQLGenerator extends SQLGenerator {
 
     return [
       { type: "custom", sql: "SET FOREIGN_KEY_CHECKS = 0" },
-      ...operations,
+      ...reorderAddForeignKeysForExecution(operations),
       { type: "custom", sql: "SET FOREIGN_KEY_CHECKS = 1" },
     ];
   }

--- a/packages/fragno-db/src/adapters/generic-sql/migration/dialect/postgres.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/dialect/postgres.test.ts
@@ -801,10 +801,10 @@ describe("PostgresSQLGenerator", () => {
         `"create table "posts" ("id" integer not null unique, "user_id" integer not null, "title" text not null, "content" text not null)"`,
       );
       expect(statements[3].sql).toMatchInlineSnapshot(
-        `"alter table "posts" add constraint "posts_user_id_fk" foreign key ("user_id") references "users" ("id") on delete restrict on update restrict"`,
+        `"alter table "posts" add column "published" boolean default false not null"`,
       );
       expect(statements[4].sql).toMatchInlineSnapshot(
-        `"alter table "posts" add column "published" boolean default false not null"`,
+        `"alter table "posts" add constraint "posts_user_id_fk" foreign key ("user_id") references "users" ("id") on delete restrict on update restrict"`,
       );
     });
 
@@ -962,7 +962,7 @@ describe("PostgresSQLGenerator", () => {
   });
 
   describe("preprocessing", () => {
-    it("should not modify operations (PostgreSQL doesn't need preprocessing)", () => {
+    it("should leave batches without foreign keys unchanged", () => {
       const operations: MigrationOperation[] = [
         {
           type: "create-table",
@@ -973,6 +973,37 @@ describe("PostgresSQLGenerator", () => {
 
       const preprocessed = generator.preprocess(operations);
       expect(preprocessed).toEqual(operations);
+    });
+
+    it("hoists foreign keys to the end of the batch for forward references", () => {
+      const operations: MigrationOperation[] = [
+        {
+          type: "create-table",
+          name: "sessions",
+          columns: [{ name: "id", type: "string", isNullable: false, role: "external-id" }],
+        },
+        {
+          type: "add-foreign-key",
+          table: "sessions",
+          value: {
+            name: "sessions_org_fk",
+            columns: ["organizationId"],
+            referencedTable: "organizations",
+            referencedColumns: ["_internalId"],
+          },
+        },
+        {
+          type: "create-table",
+          name: "organizations",
+          columns: [{ name: "id", type: "string", isNullable: false, role: "external-id" }],
+        },
+      ];
+
+      expect(generator.preprocess(operations)).toEqual([
+        operations[0],
+        operations[2],
+        operations[1],
+      ]);
     });
   });
 

--- a/packages/fragno-db/src/adapters/generic-sql/migration/dialect/postgres.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/dialect/postgres.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../../../migration-engine/shared";
 import { isUpdated } from "../../../../migration-engine/shared";
 import type { NamingResolver } from "../../../../naming/sql-naming";
-import { SQLGenerator } from "../sql-generator";
+import { reorderAddForeignKeysForExecution, SQLGenerator } from "../sql-generator";
 
 const errors = {
   IdColumnUpdate:
@@ -20,10 +20,11 @@ const errors = {
  */
 export class PostgresSQLGenerator extends SQLGenerator {
   /**
-   * PostgreSQL doesn't need preprocessing - it handles FKs normally.
+   * PostgreSQL can add foreign keys after the referenced tables exist,
+   * so we hoist FK operations to the end of the batch for forward references.
    */
   override preprocess(operations: MigrationOperation[]): MigrationOperation[] {
-    return operations;
+    return reorderAddForeignKeysForExecution(operations);
   }
 
   /**

--- a/packages/fragno-db/src/adapters/generic-sql/migration/prepared-migrations.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/prepared-migrations.test.ts
@@ -28,12 +28,7 @@ const testSchema = schema("test", (s) => {
       return t
         .addColumn("id", idColumn())
         .addColumn("title", column("string"))
-        .addColumn("authorId", referenceColumn());
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
+        .addColumn("authorId", referenceColumn({ table: "users" }));
     });
 });
 
@@ -55,15 +50,10 @@ const fkLaterSchema = schema("fk_later", (s) => {
       return t.addColumn("id", idColumn()).addColumn("name", column("string"));
     })
     .addTable("posts", (t) => {
-      return t
-        .addColumn("id", idColumn())
-        .addColumn("title", column("string"))
-        .addColumn("authorId", referenceColumn());
+      return t.addColumn("id", idColumn()).addColumn("title", column("string"));
     })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
+    .alterTable("posts", (t) => {
+      return t.addColumn("authorId", referenceColumn({ table: "users" }));
     });
 });
 
@@ -631,7 +621,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
     `);
   });
 
-  test("PostgreSQL: migration 0 -> 4 (full schema with posts and FK)", () => {
+  test("PostgreSQL: migration 0 -> 3 (full schema with posts and FK)", () => {
     const prepared = createPreparedMigrations({
       schema: testSchema,
       namespace: "test",
@@ -639,7 +629,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
       resolver,
     });
 
-    const sql = prepared.getSQL(0, 4, { updateVersionInMigration: true });
+    const sql = prepared.getSQL(0, 3, { updateVersionInMigration: true });
     expect(sql).toMatchInlineSnapshot(`
       "create table "users_test" ("id" varchar(128) not null unique, "name" text not null, "_internalId" bigserial not null primary key, "_version" integer default 0 not null);
 
@@ -651,9 +641,9 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
 
       create table "posts_test" ("id" varchar(128) not null unique, "title" text not null, "authorId" bigint not null, "_internalId" bigserial not null primary key, "_version" integer default 0 not null);
 
-      alter table "posts_test" add constraint "fk_posts_users_author_test_8d48035c" foreign key ("authorId") references "users_test" ("_internalId") on delete restrict on update restrict;
+      alter table "posts_test" add constraint "fk_posts_users_posts_authorId_fk_test_96f92407" foreign key ("authorId") references "users_test" ("_internalId") on delete restrict on update restrict;
 
-      insert into "fragno_db_settings" ("id", "key", "value") values ('BflimUWc1NbCMMDD9SM3gQ', 'test.schema_version', '4');"
+      insert into "fragno_db_settings" ("id", "key", "value") values ('BflimUWc1NbCMMDD9SM3gQ', 'test.schema_version', '3');"
     `);
   });
 
@@ -689,11 +679,13 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
     expect(sql).toMatchInlineSnapshot(`
       "create table "posts_test" ("id" varchar(128) not null unique, "title" text not null, "authorId" bigint not null, "_internalId" bigserial not null primary key, "_version" integer default 0 not null);
 
+      alter table "posts_test" add constraint "fk_posts_users_posts_authorId_fk_test_96f92407" foreign key ("authorId") references "users_test" ("_internalId") on delete restrict on update restrict;
+
       update "fragno_db_settings" set "value" = '3' where "key" = 'test.schema_version';"
     `);
   });
 
-  test("SQLite: migration 0 -> 4 with FK merging", () => {
+  test("SQLite: migration 0 -> 3 with FK merging", () => {
     const prepared = createPreparedMigrations({
       schema: testSchema,
       namespace: "test",
@@ -701,7 +693,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
       resolver,
     });
 
-    const sql = prepared.getSQL(0, 4, { updateVersionInMigration: true });
+    const sql = prepared.getSQL(0, 3, { updateVersionInMigration: true });
     expect(sql).toMatchInlineSnapshot(`
       "PRAGMA defer_foreign_keys = ON;
 
@@ -715,7 +707,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
 
       create table "posts_test" ("id" text not null unique, "title" text not null, "authorId" integer not null, "_internalId" integer not null primary key autoincrement, "_version" integer default 0 not null, foreign key ("authorId") references "users_test" ("_internalId") on delete restrict on update restrict);
 
-      insert into "fragno_db_settings" ("id", "key", "value") values ('BflimUWc1NbCMMDD9SM3gQ', 'test.schema_version', '4');"
+      insert into "fragno_db_settings" ("id", "key", "value") values ('BflimUWc1NbCMMDD9SM3gQ', 'test.schema_version', '3');"
     `);
   });
 
@@ -733,7 +725,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
     ).toThrow("SQLite doesn't support modifying foreign keys");
   });
 
-  test("MySQL: migration 0 -> 4 with FK checks disabled", () => {
+  test("MySQL: migration 0 -> 3 with FK checks disabled", () => {
     const prepared = createPreparedMigrations({
       schema: testSchema,
       namespace: "test",
@@ -741,7 +733,7 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
       resolver,
     });
 
-    const sql = prepared.getSQL(0, 4, { updateVersionInMigration: true });
+    const sql = prepared.getSQL(0, 3, { updateVersionInMigration: true });
     expect(sql).toMatchInlineSnapshot(`
       "SET FOREIGN_KEY_CHECKS = 0;
 
@@ -755,11 +747,11 @@ describe("PreparedMigrations - Multi-step Migration Scenarios", () => {
 
       create table \`posts_test\` (\`id\` varchar(128) not null unique, \`title\` text not null, \`authorId\` bigint not null, \`_internalId\` bigint not null  auto_increment, \`_version\` integer default 0 not null, constraint \`posts_test__internalId\` primary key (\`_internalId\`));
 
-      alter table \`posts_test\` add constraint \`fk_posts_users_author_test_8d48035c\` foreign key (\`authorId\`) references \`users_test\` (\`_internalId\`) on delete restrict on update restrict;
+      alter table \`posts_test\` add constraint \`fk_posts_users_posts_authorId_fk_test_96f92407\` foreign key (\`authorId\`) references \`users_test\` (\`_internalId\`) on delete restrict on update restrict;
 
       SET FOREIGN_KEY_CHECKS = 1;
 
-      insert into \`fragno_db_settings\` (\`id\`, \`key\`, \`value\`) values ('BflimUWc1NbCMMDD9SM3gQ', 'test.schema_version', '4');"
+      insert into \`fragno_db_settings\` (\`id\`, \`key\`, \`value\`) values ('BflimUWc1NbCMMDD9SM3gQ', 'test.schema_version', '3');"
     `);
   });
 

--- a/packages/fragno-db/src/adapters/generic-sql/migration/sql-generator.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/migration/sql-generator.ts
@@ -33,6 +33,23 @@ export interface CompilableQuery {
   compile(): CompiledQuery;
 }
 
+export function reorderAddForeignKeysForExecution(
+  operations: MigrationOperation[],
+): MigrationOperation[] {
+  const addForeignKeys: MigrationOperation[] = [];
+  const otherOperations: MigrationOperation[] = [];
+
+  for (const operation of operations) {
+    if (operation.type === "add-foreign-key") {
+      addForeignKeys.push(operation);
+    } else {
+      otherOperations.push(operation);
+    }
+  }
+
+  return [...otherOperations, ...addForeignKeys];
+}
+
 /**
  * Abstract base class for SQL generation from migration operations.
  * Each database dialect extends this class and implements the abstract methods.

--- a/packages/fragno-db/src/adapters/generic-sql/query/generic-sql-uow-operation-compiler.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/query/generic-sql-uow-operation-compiler.test.ts
@@ -1,9 +1,25 @@
 import { describe, test, expect } from "vitest";
 
 import { Cursor } from "../../../query/cursor";
-import { schema, column, idColumn, referenceColumn, FragnoId } from "../../../schema/create";
+import {
+  schema,
+  column,
+  idColumn,
+  referenceColumn,
+  FragnoId,
+  getTableRelations,
+  type Relation,
+} from "../../../schema/create";
 import { BetterSQLite3DriverConfig, NodePostgresDriverConfig } from "../driver-config";
 import { GenericSQLUOWOperationCompiler } from "./generic-sql-uow-operation-compiler";
+
+function renameRelation(relation: Relation, name: string): Relation {
+  return {
+    ...relation,
+    id: `${relation.referencer.name}.${name}`,
+    name,
+  };
+}
 
 // Test schema with indexes
 const testSchema = schema("test", (s) => {
@@ -16,7 +32,7 @@ const testSchema = schema("test", (s) => {
         .addColumn("age", column("integer").nullable())
         .addColumn("isActive", column("bool"))
         .addColumn("createdAt", column("timestamp"))
-        .addColumn("invitedBy", referenceColumn().nullable())
+        .addColumn("invitedBy", referenceColumn({ table: "users" }).nullable())
         .createIndex("idx_email", ["email"], { unique: true })
         .createIndex("idx_users_name", ["name"])
         .createIndex("idx_age", ["age"])
@@ -27,7 +43,7 @@ const testSchema = schema("test", (s) => {
         .addColumn("id", idColumn())
         .addColumn("title", column("string"))
         .addColumn("content", column("string"))
-        .addColumn("userId", referenceColumn())
+        .addColumn("userId", referenceColumn({ table: "users" }))
         .addColumn("viewCount", column("integer").defaultTo(0))
         .addColumn("publishedAt", column("timestamp").nullable())
         .createIndex("idx_title", ["title"])
@@ -37,8 +53,8 @@ const testSchema = schema("test", (s) => {
       return t
         .addColumn("id", idColumn())
         .addColumn("content", column("string"))
-        .addColumn("postId", referenceColumn())
-        .addColumn("authorId", referenceColumn())
+        .addColumn("postId", referenceColumn({ table: "posts" }))
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .createIndex("idx_comments_post", ["postId"])
         .createIndex("idx_author", ["authorId"]);
     })
@@ -51,42 +67,21 @@ const testSchema = schema("test", (s) => {
     .addTable("post_tags", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("postId", referenceColumn())
-        .addColumn("tagId", referenceColumn())
+        .addColumn("postId", referenceColumn({ table: "posts" }))
+        .addColumn("tagId", referenceColumn({ table: "tags" }))
         .createIndex("idx_post_tags_post", ["postId"])
         .createIndex("idx_tag", ["tagId"]);
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "userId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("inviter", {
-      type: "one",
-      from: { table: "users", column: "invitedBy" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("post", {
-      type: "one",
-      from: { table: "comments", column: "postId" },
-      to: { table: "posts", column: "id" },
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "comments", column: "authorId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("post", {
-      type: "one",
-      from: { table: "post_tags", column: "postId" },
-      to: { table: "posts", column: "id" },
-    })
-    .addReference("tag", {
-      type: "one",
-      from: { table: "post_tags", column: "tagId" },
-      to: { table: "tags", column: "id" },
     });
 });
+
+const testSchemaRelations = {
+  postsAuthor: renameRelation(getTableRelations(testSchema.tables.posts)["user"], "author"),
+  usersInviter: renameRelation(getTableRelations(testSchema.tables.users)["invitedBy"], "inviter"),
+  commentsPost: getTableRelations(testSchema.tables.comments)["post"],
+  commentsAuthor: getTableRelations(testSchema.tables.comments)["author"],
+  postTagsPost: getTableRelations(testSchema.tables.post_tags)["post"],
+  postTagsTag: getTableRelations(testSchema.tables.post_tags)["tag"],
+};
 
 // Schema with custom-named id columns
 const customIdSchema = schema("customid", (s) => {
@@ -101,7 +96,7 @@ const customIdSchema = schema("customid", (s) => {
     .addTable("orders", (t) => {
       return t
         .addColumn("orderId", idColumn())
-        .addColumn("productRef", referenceColumn())
+        .addColumn("productRef", referenceColumn({ table: "products" }))
         .addColumn("quantity", column("integer"));
     })
     .addTable("categories", (t) => {
@@ -113,27 +108,23 @@ const customIdSchema = schema("customid", (s) => {
     .addTable("product_categories", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("prodRef", referenceColumn())
-        .addColumn("catRef", referenceColumn())
+        .addColumn("prodRef", referenceColumn({ table: "products" }))
+        .addColumn("catRef", referenceColumn({ table: "categories" }))
         .createIndex("idx_prod", ["prodRef"])
         .createIndex("idx_cat", ["catRef"]);
-    })
-    .addReference("product", {
-      type: "one",
-      from: { table: "orders", column: "productRef" },
-      to: { table: "products", column: "productId" },
-    })
-    .addReference("product", {
-      type: "one",
-      from: { table: "product_categories", column: "prodRef" },
-      to: { table: "products", column: "productId" },
-    })
-    .addReference("category", {
-      type: "one",
-      from: { table: "product_categories", column: "catRef" },
-      to: { table: "categories", column: "categoryId" },
     });
 });
+
+const customIdSchemaRelations = {
+  productCategoriesProduct: renameRelation(
+    getTableRelations(customIdSchema.tables.product_categories)["prodRef"],
+    "product",
+  ),
+  productCategoriesCategory: renameRelation(
+    getTableRelations(customIdSchema.tables.product_categories)["catRef"],
+    "category",
+  ),
+};
 
 const joinOnlySchema = schema("joinonly", (s) => {
   return s
@@ -152,27 +143,31 @@ const joinOnlySchema = schema("joinonly", (s) => {
     .addTable("memberships", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("userId", referenceColumn())
+        .addColumn("userId", referenceColumn({ table: "users" }))
         .createIndex("idx_memberships_user", ["userId"]);
-    })
-    .addReference("invitedUser", {
-      type: "one",
-      from: { table: "invitations", column: "email" },
-      to: { table: "users", column: "email" },
-      foreignKey: false,
-    })
-    .addReference("membershipUser", {
-      type: "one",
-      from: { table: "memberships", column: "userId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("memberships", {
-      type: "many",
-      from: { table: "users", column: "id" },
-      to: { table: "memberships", column: "userId" },
-      foreignKey: false,
     });
 });
+
+const joinOnlyRelations = {
+  invitedUser: {
+    id: "invitations.invitedUser",
+    name: "invitedUser",
+    type: "one",
+    foreignKey: false,
+    table: joinOnlySchema.tables.users,
+    referencer: joinOnlySchema.tables.invitations,
+    on: [["email", "email"]],
+  } satisfies Relation,
+  memberships: {
+    id: "users.memberships",
+    name: "memberships",
+    type: "many",
+    foreignKey: false,
+    table: joinOnlySchema.tables.memberships,
+    referencer: joinOnlySchema.tables.users,
+    on: [["id", "userId"]],
+  } satisfies Relation<"many">,
+};
 
 describe("GenericSQLUOWOperationCompiler", () => {
   const driverConfig = new BetterSQLite3DriverConfig();
@@ -1164,7 +1159,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "title"],
           joins: [
             {
-              relation: testSchema.tables.posts.relations.author,
+              relation: testSchemaRelations.postsAuthor,
               options: {
                 select: ["name", "email"],
               },
@@ -1192,7 +1187,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id"],
           joins: [
             {
-              relation: joinOnlySchema.tables.invitations.relations.invitedUser,
+              relation: joinOnlyRelations.invitedUser,
               options: {
                 select: ["email"],
               },
@@ -1220,7 +1215,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id"],
           joins: [
             {
-              relation: joinOnlySchema.tables.users.relations.memberships,
+              relation: joinOnlyRelations.memberships,
               options: {
                 select: ["id"],
               },
@@ -1248,7 +1243,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "userId"],
           joins: [
             {
-              relation: testSchema.tables.posts.relations.author,
+              relation: testSchemaRelations.postsAuthor,
               options: {
                 select: true,
               },
@@ -1276,13 +1271,13 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "content"],
           joins: [
             {
-              relation: testSchema.tables.comments.relations.post,
+              relation: testSchemaRelations.commentsPost,
               options: {
                 select: ["title"],
               },
             },
             {
-              relation: testSchema.tables.comments.relations.author,
+              relation: testSchemaRelations.commentsAuthor,
               options: {
                 select: ["name"],
               },
@@ -1310,7 +1305,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "name"],
           joins: [
             {
-              relation: testSchema.tables.users.relations.inviter,
+              relation: testSchemaRelations.usersInviter,
               options: {
                 select: ["name", "email"],
               },
@@ -1339,7 +1334,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "title"],
           joins: [
             {
-              relation: testSchema.tables.posts.relations.author,
+              relation: testSchemaRelations.postsAuthor,
               options: {
                 select: ["name"],
                 where: {
@@ -1375,7 +1370,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "title"],
           joins: [
             {
-              relation: testSchema.tables.posts.relations.author,
+              relation: testSchemaRelations.postsAuthor,
               options: {
                 select: ["name"],
                 where: {
@@ -1420,7 +1415,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "title"],
           joins: [
             {
-              relation: testSchema.tables.posts.relations.author,
+              relation: testSchemaRelations.postsAuthor,
               options: {
                 select: ["id", "name"],
               },
@@ -1448,7 +1443,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id"],
           joins: [
             {
-              relation: testSchema.tables.posts.relations.author,
+              relation: testSchemaRelations.postsAuthor,
               options: {
                 select: true,
               },
@@ -1477,7 +1472,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "title"],
           joins: [
             {
-              relation: testSchema.tables.posts.relations.author,
+              relation: testSchemaRelations.postsAuthor,
               options: {
                 select: ["id", "name"],
                 where: {
@@ -1512,13 +1507,13 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id", "content"],
           joins: [
             {
-              relation: testSchema.tables.comments.relations.post,
+              relation: testSchemaRelations.commentsPost,
               options: {
                 select: ["id", "title"],
               },
             },
             {
-              relation: testSchema.tables.comments.relations.author,
+              relation: testSchemaRelations.commentsAuthor,
               options: {
                 select: ["name"],
               },
@@ -1546,13 +1541,13 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id"],
           joins: [
             {
-              relation: testSchema.tables.post_tags.relations.post,
+              relation: testSchemaRelations.postTagsPost,
               options: {
                 select: ["title"],
               },
             },
             {
-              relation: testSchema.tables.post_tags.relations.tag,
+              relation: testSchemaRelations.postTagsTag,
               options: {
                 select: ["name"],
               },
@@ -1582,13 +1577,13 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id"],
           joins: [
             {
-              relation: customIdSchema.tables.product_categories.relations.product,
+              relation: customIdSchemaRelations.productCategoriesProduct,
               options: {
                 select: ["productId", "name"],
               },
             },
             {
-              relation: customIdSchema.tables.product_categories.relations.category,
+              relation: customIdSchemaRelations.productCategoriesCategory,
               options: {
                 select: ["categoryId", "categoryName"],
               },
@@ -1617,7 +1612,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id"],
           joins: [
             {
-              relation: customIdSchema.tables.product_categories.relations.product,
+              relation: customIdSchemaRelations.productCategoriesProduct,
               options: {
                 select: ["productId", "name"],
                 where: {
@@ -1652,7 +1647,7 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id"],
           joins: [
             {
-              relation: customIdSchema.tables.product_categories.relations.product,
+              relation: customIdSchemaRelations.productCategoriesProduct,
               options: {
                 select: true,
               },
@@ -1680,13 +1675,13 @@ describe("GenericSQLUOWOperationCompiler", () => {
           select: ["id"],
           joins: [
             {
-              relation: customIdSchema.tables.product_categories.relations.product,
+              relation: customIdSchemaRelations.productCategoriesProduct,
               options: {
                 select: ["productId"],
               },
             },
             {
-              relation: customIdSchema.tables.product_categories.relations.category,
+              relation: customIdSchemaRelations.productCategoriesCategory,
               options: {
                 select: ["categoryId"],
               },

--- a/packages/fragno-db/src/adapters/generic-sql/query/generic-sql-uow-operation-compiler.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/query/generic-sql-uow-operation-compiler.ts
@@ -17,6 +17,7 @@ import { createColdKysely } from "../migration/cold-kysely";
 import type { SQLiteStorageMode } from "../sqlite-storage";
 import { createSQLQueryCompiler } from "./create-sql-query-compiler";
 import { buildCursorCondition } from "./cursor-utils";
+import { QueryTreeSQLCompiler } from "./query-tree-sql-compiler";
 import { SQLQueryCompiler } from "./sql-query-compiler";
 
 /**
@@ -56,6 +57,22 @@ export class GenericSQLUOWOperationCompiler extends UOWOperationCompiler<Compile
     );
   }
 
+  private getQueryTreeCompiler(
+    schema: AnySchema,
+    namespace: string | null | undefined,
+  ): QueryTreeSQLCompiler {
+    const resolver = this.getNamingResolver(schema, namespace ?? null);
+    const kysely = createColdKysely(this.driverConfig.databaseType);
+    const schemaName = resolver.getSchemaName();
+    const scopedKysely = schemaName ? kysely.withSchema(schemaName) : kysely;
+    return new QueryTreeSQLCompiler(
+      scopedKysely,
+      this.driverConfig,
+      this.sqliteStorageMode,
+      resolver,
+    );
+  }
+
   override compileCount(
     op: RetrievalOperation<AnySchema> & { type: "count" },
   ): CompiledQuery | null {
@@ -84,11 +101,20 @@ export class GenericSQLUOWOperationCompiler extends UOWOperationCompiler<Compile
       useIndex: _useIndex,
       orderByIndex,
       joins: join,
+      queryTree,
       after,
       before,
       pageSize,
       ...findManyOptions
     } = op.options;
+
+    if (queryTree) {
+      const queryTreeCompiler = this.getQueryTreeCompiler(op.schema, op.namespace);
+      return queryTreeCompiler.compile(queryTree, {
+        readTracking: op.readTracking,
+        withCursor: op.withCursor,
+      });
+    }
 
     // Get index columns for ordering and cursor pagination
     let indexColumns: AnyColumn[] = [];

--- a/packages/fragno-db/src/adapters/generic-sql/query/query-tree-sql-compiler.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/query/query-tree-sql-compiler.ts
@@ -1,0 +1,347 @@
+import type { CompiledQuery, SelectQueryBuilder, Kysely } from "kysely";
+import { sql } from "kysely";
+
+import type { NamingResolver } from "../../../naming/sql-naming";
+import type { Condition } from "../../../query/condition-builder";
+import type {
+  CompiledQueryTreeChildNode,
+  CompiledQueryTreeRootNode,
+} from "../../../query/unit-of-work/query-tree";
+import { getQueryTreeSelectedColumnNames } from "../../../query/unit-of-work/query-tree";
+import type { AnyColumn, AnyTable } from "../../../schema/create";
+import type { DriverConfig } from "../driver-config";
+import type { SQLiteStorageMode } from "../sqlite-storage";
+import { buildCursorCondition } from "./cursor-utils";
+import { buildQueryTreeWhere } from "./query-tree-where-builder";
+import { buildWhere } from "./where-builder";
+
+// oxlint-disable-next-line no-explicit-any
+export type AnyKysely = Kysely<any>;
+// oxlint-disable-next-line no-explicit-any
+export type AnySelectQueryBuilder<O = any> = SelectQueryBuilder<any, any, O>;
+
+const CHILD_JSON_COLUMN_ALIAS = "_fragno_item";
+
+export class QueryTreeSQLCompiler {
+  readonly #db: AnyKysely;
+  readonly #driverConfig: DriverConfig;
+  readonly #sqliteStorageMode?: SQLiteStorageMode;
+  readonly #resolver?: NamingResolver;
+
+  constructor(
+    db: AnyKysely,
+    driverConfig: DriverConfig,
+    sqliteStorageMode?: SQLiteStorageMode,
+    resolver?: NamingResolver,
+  ) {
+    this.#db = db;
+    this.#driverConfig = driverConfig;
+    this.#sqliteStorageMode = sqliteStorageMode;
+    this.#resolver = resolver;
+  }
+
+  compile(
+    root: CompiledQueryTreeRootNode,
+    options?: { readTracking?: boolean; withCursor?: boolean },
+  ): CompiledQuery {
+    const readTracking = options?.readTracking ?? false;
+    const orderByIndex =
+      root.orderByIndex ??
+      (root.after || root.before
+        ? { indexName: root.useIndex, direction: "asc" as const }
+        : undefined);
+    const cursorColumns = orderByIndex
+      ? this.#resolveOrderByColumns(root.table, orderByIndex.indexName)
+      : [];
+    const cursorCondition = buildCursorCondition(
+      root.after || root.before,
+      cursorColumns,
+      orderByIndex?.direction ?? "asc",
+      !!root.after,
+      this.#driverConfig,
+      this.#sqliteStorageMode,
+    );
+    const combinedWhere = this.#combineConditions(root.where, cursorCondition);
+
+    const rootAlias = "_fragno_root";
+    let query = this.#db.selectFrom(`${this.#getTableName(root.table)} as ${rootAlias}`);
+
+    if (combinedWhere) {
+      query = query.where((eb) =>
+        buildWhere(
+          combinedWhere,
+          eb,
+          this.#driverConfig,
+          this.#sqliteStorageMode,
+          this.#resolver,
+          root.table,
+          rootAlias,
+        ),
+      );
+    }
+
+    query = this.#applyOrderByIndex(query, root.table, orderByIndex, rootAlias);
+
+    const effectivePageSize =
+      options?.withCursor && root.pageSize !== undefined ? root.pageSize + 1 : root.pageSize;
+    if (effectivePageSize !== undefined) {
+      query = query.limit(effectivePageSize);
+    }
+
+    const selectedColumnNames = getQueryTreeSelectedColumnNames(
+      root.table,
+      root.select,
+      readTracking ? [root.table.getIdColumn().name] : [],
+    );
+
+    const selections = selectedColumnNames.map((columnName) => {
+      const column = root.table.columns[columnName];
+      const physicalName = this.#getColumnName(root.table, column.name);
+      return sql.ref(`${rootAlias}.${physicalName}`).as(columnName);
+    });
+
+    for (const child of root.children) {
+      selections.push(
+        this.#buildChildExpression(child, root.table, rootAlias, child.alias, 0, readTracking),
+      );
+    }
+
+    return query.select(selections).compile();
+  }
+
+  #buildChildExpression(
+    child: CompiledQueryTreeChildNode,
+    parentTable: AnyTable,
+    parentAlias: string,
+    path: string,
+    depth: number,
+    readTracking: boolean,
+  ) {
+    return this.#buildChildValueExpression(
+      child,
+      parentTable,
+      parentAlias,
+      path,
+      depth,
+      readTracking,
+    ).as(child.alias);
+  }
+
+  #buildChildValueExpression(
+    child: CompiledQueryTreeChildNode,
+    parentTable: AnyTable,
+    parentAlias: string,
+    path: string,
+    depth: number,
+    readTracking: boolean,
+  ) {
+    const childAlias = `_fragno_${path.replace(/[^a-zA-Z0-9_]/g, "_")}_${depth}`;
+    const jsonObject = this.#buildJsonObjectExpression(
+      child,
+      childAlias,
+      path,
+      depth,
+      readTracking,
+    );
+
+    let childQuery = this.#db
+      .selectFrom(`${this.#getTableName(child.table)} as ${childAlias}`)
+      .select(jsonObject.as(CHILD_JSON_COLUMN_ALIAS));
+
+    const onIndex = child.onIndex;
+    if (onIndex) {
+      childQuery = childQuery.where((eb) =>
+        buildQueryTreeWhere(
+          onIndex,
+          eb,
+          this.#driverConfig,
+          this.#sqliteStorageMode,
+          this.#resolver,
+          child.table,
+          childAlias,
+          parentTable,
+          parentAlias,
+        ),
+      );
+    }
+
+    const childWhere = child.where;
+    if (childWhere) {
+      childQuery = childQuery.where((eb) =>
+        buildWhere(
+          childWhere,
+          eb,
+          this.#driverConfig,
+          this.#sqliteStorageMode,
+          this.#resolver,
+          child.table,
+          childAlias,
+        ),
+      );
+    }
+
+    childQuery = this.#applyOrderByIndex(childQuery, child.table, child.orderByIndex, childAlias);
+
+    if (child.pageSize !== undefined) {
+      childQuery = childQuery.limit(child.pageSize);
+    }
+
+    if (child.cardinality === "one") {
+      return sql`(${childQuery.limit(1)})`;
+    }
+
+    return this.#wrapJsonArrayAggValue(childQuery);
+  }
+
+  #buildJsonObjectExpression(
+    node: CompiledQueryTreeRootNode | CompiledQueryTreeChildNode,
+    rowAlias: string,
+    path: string,
+    depth: number,
+    readTracking: boolean,
+  ) {
+    const items: Array<{ key: string; expr: unknown }> = [];
+
+    for (const columnName of getQueryTreeSelectedColumnNames(
+      node.table,
+      node.select,
+      readTracking ? [node.table.getIdColumn().name] : [],
+    )) {
+      const column = node.table.columns[columnName];
+      const physicalName = this.#getColumnName(node.table, column.name);
+      items.push({ key: columnName, expr: sql.ref(`${rowAlias}.${physicalName}`) });
+    }
+
+    for (const child of node.children) {
+      const childValueExpr = this.#buildChildValueExpression(
+        child,
+        node.table,
+        rowAlias,
+        `${path}_${child.alias}`,
+        depth + 1,
+        readTracking,
+      );
+      items.push({
+        key: child.alias,
+        expr:
+          this.#driverConfig.databaseType === "sqlite"
+            ? sql`json(${childValueExpr})`
+            : childValueExpr,
+      });
+    }
+
+    return this.#jsonObject(items);
+  }
+
+  #jsonObject(items: Array<{ key: string; expr: unknown }>) {
+    const args: unknown[] = [];
+    for (const item of items) {
+      args.push(sql.lit(item.key));
+      args.push(item.expr);
+    }
+
+    switch (this.#driverConfig.databaseType) {
+      case "sqlite":
+      case "mysql":
+        return sql`json_object(${sql.join(args)})`;
+      case "postgresql":
+        return sql`json_build_object(${sql.join(args)})`;
+      default: {
+        const exhaustiveCheck: never = this.#driverConfig.databaseType;
+        throw new Error(`Unsupported database type: ${exhaustiveCheck}`);
+      }
+    }
+  }
+
+  #wrapJsonArrayAggValue(query: AnySelectQueryBuilder) {
+    switch (this.#driverConfig.databaseType) {
+      case "sqlite":
+        return sql`
+          coalesce(
+            (
+              select json_group_array(json(${sql.ref(`_fragno_agg.${CHILD_JSON_COLUMN_ALIAS}`)}))
+              from (${query}) as _fragno_agg
+            ),
+            json('[]')
+          )
+        `;
+      case "postgresql":
+        return sql`
+          coalesce(
+            (
+              select json_agg(${sql.ref(`_fragno_agg.${CHILD_JSON_COLUMN_ALIAS}`)})
+              from (${query}) as _fragno_agg
+            ),
+            '[]'::json
+          )
+        `;
+      case "mysql":
+        return sql`
+          coalesce(
+            (
+              select json_arrayagg(${sql.ref(`_fragno_agg.${CHILD_JSON_COLUMN_ALIAS}`)})
+              from (${query}) as _fragno_agg
+            ),
+            json_array()
+          )
+        `;
+      default: {
+        const exhaustiveCheck: never = this.#driverConfig.databaseType;
+        throw new Error(`Unsupported database type: ${exhaustiveCheck}`);
+      }
+    }
+  }
+
+  #combineConditions(left: Condition | undefined, right: Condition | undefined) {
+    if (left && right) {
+      return {
+        type: "and" as const,
+        items: [left, right],
+      };
+    }
+
+    return left ?? right;
+  }
+
+  #applyOrderByIndex<T extends { orderBy(column: string, direction: "asc" | "desc"): T }>(
+    query: T,
+    table: AnyTable,
+    orderByIndex: { indexName: string; direction: "asc" | "desc" } | undefined,
+    alias: string,
+  ): T {
+    if (!orderByIndex) {
+      return query;
+    }
+
+    let orderedQuery = query;
+    for (const column of this.#resolveOrderByColumns(table, orderByIndex.indexName)) {
+      orderedQuery = orderedQuery.orderBy(
+        `${alias}.${this.#getColumnName(table, column.name)}`,
+        orderByIndex.direction,
+      );
+    }
+
+    return orderedQuery;
+  }
+
+  #resolveOrderByColumns(table: AnyTable, indexName: string): AnyColumn[] {
+    if (indexName === "_primary") {
+      return [table.getIdColumn()];
+    }
+
+    const index = table.indexes[indexName];
+    if (!index) {
+      throw new Error(`Index "${indexName}" not found on table "${table.name}".`);
+    }
+
+    return index.columns;
+  }
+
+  #getTableName(table: AnyTable): string {
+    return this.#resolver ? this.#resolver.getTableName(table.name) : table.name;
+  }
+
+  #getColumnName(table: AnyTable, columnName: string): string {
+    return this.#resolver ? this.#resolver.getColumnName(table.name, columnName) : columnName;
+  }
+}

--- a/packages/fragno-db/src/adapters/generic-sql/query/query-tree-where-builder.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/query/query-tree-where-builder.ts
@@ -1,0 +1,215 @@
+import { sql, type BinaryOperator } from "kysely";
+
+import type { NamingResolver } from "../../../naming/sql-naming";
+import type { Condition } from "../../../query/condition-builder";
+import { getDbNowOffsetMs, isDbNow } from "../../../query/db-now";
+import { createSQLSerializer } from "../../../query/serialize/create-sql-serializer";
+import { isParentColumnRef } from "../../../query/unit-of-work/query-tree";
+import { resolveFragnoIdValue } from "../../../query/value-encoding";
+import type { AnyColumn, AnyTable } from "../../../schema/create";
+import { Column, FragnoId, FragnoReference } from "../../../schema/create";
+import type { DriverConfig } from "../driver-config";
+import type { SQLiteStorageMode } from "../sqlite-storage";
+import { buildDbNowSql } from "./db-now-sql";
+import type { AnyExpressionBuilder, AnyExpressionWrapper } from "./sql-query-compiler";
+import { fullSQLName } from "./where-builder";
+
+function getColumnSqlName(
+  column: AnyColumn,
+  resolver?: NamingResolver,
+  table?: AnyTable,
+  tableAlias?: string,
+): string {
+  if (table && tableAlias && column.tableName === table.name) {
+    const columnName = resolver
+      ? resolver.getColumnName(column.tableName, column.name)
+      : column.name;
+    return `${tableAlias}.${columnName}`;
+  }
+
+  return fullSQLName(column, resolver);
+}
+
+function getComparableColumn(column: AnyColumn, table: AnyTable): AnyColumn {
+  if (column.role === "external-id") {
+    return table.getInternalIdColumn();
+  }
+  return column;
+}
+
+function getComparableParentColumn(column: AnyColumn, table: AnyTable): AnyColumn {
+  if (column.role === "external-id") {
+    return table.getInternalIdColumn();
+  }
+  return column;
+}
+
+export function buildQueryTreeWhere(
+  condition: Condition,
+  eb: AnyExpressionBuilder,
+  driverConfig: DriverConfig,
+  sqliteStorageMode: SQLiteStorageMode | undefined,
+  resolver: NamingResolver | undefined,
+  childTable: AnyTable,
+  childAlias: string,
+  parentTable?: AnyTable,
+  parentAlias?: string,
+): AnyExpressionWrapper {
+  const serializer = createSQLSerializer(driverConfig, sqliteStorageMode);
+
+  if (condition.type === "compare") {
+    let left = condition.a;
+    let rightValue = condition.b;
+
+    if (isParentColumnRef(rightValue)) {
+      if (!parentTable || !parentAlias) {
+        throw new Error(
+          "Parent column references can only be used inside correlated query-tree joins.",
+        );
+      }
+
+      let parentColumn = rightValue.column;
+      if (left.role === "external-id" && parentColumn.role !== "external-id") {
+        left = getComparableColumn(left, childTable);
+      }
+      if (parentColumn.role === "external-id" && left.role !== "external-id") {
+        parentColumn = getComparableParentColumn(parentColumn, parentTable);
+      }
+
+      return eb(
+        getColumnSqlName(left, resolver, childTable, childAlias),
+        condition.operator as BinaryOperator,
+        eb.ref(getColumnSqlName(parentColumn, resolver, parentTable, parentAlias)),
+      );
+    }
+
+    if (!(rightValue instanceof Column)) {
+      if (isDbNow(rightValue)) {
+        rightValue = buildDbNowSql({
+          driverConfig,
+          columnType: left.type,
+          offsetMs: getDbNowOffsetMs(rightValue),
+          sqliteStorageMode,
+        });
+      } else if (left.role === "reference") {
+        if (rightValue instanceof FragnoId && rightValue.internalId !== undefined) {
+          rightValue = rightValue.internalId;
+        } else if (rightValue instanceof FragnoReference) {
+          rightValue = rightValue.internalId;
+        } else if (rightValue instanceof FragnoId && rightValue.internalId === undefined) {
+          rightValue = rightValue.externalId;
+        } else {
+          rightValue = serializer.serialize(resolveFragnoIdValue(rightValue, left), left);
+        }
+      } else {
+        rightValue = serializer.serialize(resolveFragnoIdValue(rightValue, left), left);
+      }
+    }
+
+    let operator: BinaryOperator;
+    let rhs: unknown;
+
+    switch (condition.operator) {
+      case "contains":
+        operator = "like";
+        rhs =
+          rightValue instanceof Column
+            ? sql`concat('%', ${eb.ref(getColumnSqlName(rightValue, resolver))}, '%')`
+            : `%${rightValue}%`;
+        break;
+      case "not contains":
+        operator = "not like";
+        rhs =
+          rightValue instanceof Column
+            ? sql`concat('%', ${eb.ref(getColumnSqlName(rightValue, resolver))}, '%')`
+            : `%${rightValue}%`;
+        break;
+      case "starts with":
+        operator = "like";
+        rhs =
+          rightValue instanceof Column
+            ? sql`concat(${eb.ref(getColumnSqlName(rightValue, resolver))}, '%')`
+            : `${rightValue}%`;
+        break;
+      case "not starts with":
+        operator = "not like";
+        rhs =
+          rightValue instanceof Column
+            ? sql`concat(${eb.ref(getColumnSqlName(rightValue, resolver))}, '%')`
+            : `${rightValue}%`;
+        break;
+      case "ends with":
+        operator = "like";
+        rhs =
+          rightValue instanceof Column
+            ? sql`concat('%', ${eb.ref(getColumnSqlName(rightValue, resolver))})`
+            : `%${rightValue}`;
+        break;
+      case "not ends with":
+        operator = "not like";
+        rhs =
+          rightValue instanceof Column
+            ? sql`concat('%', ${eb.ref(getColumnSqlName(rightValue, resolver))})`
+            : `%${rightValue}`;
+        break;
+      default:
+        operator = condition.operator as BinaryOperator;
+        rhs =
+          rightValue instanceof Column
+            ? eb.ref(getColumnSqlName(rightValue, resolver))
+            : rightValue;
+    }
+
+    return eb(getColumnSqlName(left, resolver, childTable, childAlias), operator, rhs);
+  }
+
+  if (condition.type === "and") {
+    return eb.and(
+      condition.items.map((item) =>
+        buildQueryTreeWhere(
+          item,
+          eb,
+          driverConfig,
+          sqliteStorageMode,
+          resolver,
+          childTable,
+          childAlias,
+          parentTable,
+          parentAlias,
+        ),
+      ),
+    );
+  }
+
+  if (condition.type === "not") {
+    return eb.not(
+      buildQueryTreeWhere(
+        condition.item,
+        eb,
+        driverConfig,
+        sqliteStorageMode,
+        resolver,
+        childTable,
+        childAlias,
+        parentTable,
+        parentAlias,
+      ),
+    );
+  }
+
+  return eb.or(
+    condition.items.map((item) =>
+      buildQueryTreeWhere(
+        item,
+        eb,
+        driverConfig,
+        sqliteStorageMode,
+        resolver,
+        childTable,
+        childAlias,
+        parentTable,
+        parentAlias,
+      ),
+    ),
+  );
+}

--- a/packages/fragno-db/src/adapters/generic-sql/query/select-builder.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/query/select-builder.test.ts
@@ -20,14 +20,9 @@ describe("select-builder", () => {
           .addColumn("id", idColumn())
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
-          .addColumn("userId", referenceColumn())
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .addColumn("viewCount", column("integer").defaultTo(0))
           .addColumn("publishedAt", column("timestamp").nullable());
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "userId" },
-        to: { table: "users", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/adapters/generic-sql/query/sql-query-compiler.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/query/sql-query-compiler.test.ts
@@ -29,7 +29,7 @@ const testSchema = schema("test", (s) => {
         .addColumn("id", idColumn())
         .addColumn("title", column("string"))
         .addColumn("content", column("string"))
-        .addColumn("userId", referenceColumn());
+        .addColumn("userId", referenceColumn({ table: "users" }));
     });
 });
 

--- a/packages/fragno-db/src/adapters/generic-sql/query/where-builder.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/query/where-builder.test.ts
@@ -27,14 +27,9 @@ describe("where-builder", () => {
           .addColumn("id", idColumn())
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
-          .addColumn("userId", referenceColumn())
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .addColumn("viewCount", column("integer").defaultTo(0))
           .addColumn("publishedAt", column("timestamp").nullable());
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "userId" },
-        to: { table: "users", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/adapters/generic-sql/query/where-builder.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/query/where-builder.ts
@@ -11,6 +11,7 @@ import {
   Column,
   FragnoId,
   FragnoReference,
+  getTableForeignKey,
 } from "../../../schema/create";
 import type { DriverConfig } from "../driver-config";
 import type { SQLiteStorageMode } from "../sqlite-storage";
@@ -89,11 +90,9 @@ export function buildWhere(
         // Handle reference columns specially
         if (typeof val === "string") {
           // String external ID - create subquery to lookup internal ID
-          const relation = Object.values(table.relations).find((rel) =>
-            rel.on.some(([localCol]) => localCol === left.name),
-          );
-          if (relation) {
-            const refTable = relation.table;
+          const foreignKey = getTableForeignKey(table, left.name);
+          if (foreignKey) {
+            const refTable = foreignKey.referencedTable;
             const internalIdCol = refTable.getInternalIdColumn();
             const idCol = refTable.getIdColumn();
             const physicalTableName = resolver
@@ -119,11 +118,9 @@ export function buildWhere(
           val = val.internalId;
         } else if (val instanceof FragnoId && val.internalId === undefined) {
           // FragnoId without internal ID - create subquery using external ID
-          const relation = Object.values(table.relations).find((rel) =>
-            rel.on.some(([localCol]) => localCol === left.name),
-          );
-          if (relation) {
-            const refTable = relation.table;
+          const foreignKey = getTableForeignKey(table, left.name);
+          if (foreignKey) {
+            const refTable = foreignKey.referencedTable;
             const internalIdCol = refTable.getInternalIdColumn();
             const idCol = refTable.getIdColumn();
             const physicalTableName = resolver

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-migrations.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-migrations.test.ts
@@ -138,7 +138,7 @@ describe("SqlAdapter PGLite", () => {
     const getUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", userId)).select(["id", "name"]),
         );
       await uow.executeRetrieve();
@@ -205,7 +205,7 @@ describe("SqlAdapter PGLite", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -216,7 +216,13 @@ describe("SqlAdapter PGLite", () => {
     const emailsWithUsers = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .find("emails", (b) => b.whereIndex("primary").join((jb) => jb.user()));
+        .findNew("emails", (b) =>
+          b
+            .whereIndex("primary")
+            .joinOne("user", "users", (jb) =>
+              jb.onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id"))),
+            ),
+        );
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -246,8 +252,12 @@ describe("SqlAdapter PGLite", () => {
     const userEmails = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .find("emails", (b) =>
-          b.whereIndex("user_emails", (eb) => eb("user_id", "=", userId)).join((jb) => jb.user()),
+        .findNew("emails", (b) =>
+          b
+            .whereIndex("user_emails", (eb) => eb("user_id", "=", userId))
+            .joinOne("user", "users", (jb) =>
+              jb.onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id"))),
+            ),
         );
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
@@ -280,7 +290,7 @@ describe("SqlAdapter PGLite", () => {
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
       // Retrieval phase: find the user
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     // Execute retrieval and transition to mutation phase
     const [users] = await uow.executeRetrieve();
@@ -299,7 +309,9 @@ describe("SqlAdapter PGLite", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+        .findFirstNew("users", (b) =>
+          b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)),
+        );
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -327,7 +339,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the user was NOT updated
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -339,7 +351,7 @@ describe("SqlAdapter PGLite", () => {
 
     const uow3 = queryEngine
       .createUnitOfWork("get-all-emails")
-      .find("emails", (b) => b.whereIndex("primary").orderByIndex("unique_email", "desc"));
+      .findNew("emails", (b) => b.whereIndex("primary").orderByIndex("unique_email", "desc"));
     const [allEmails] = await uow3.executeRetrieve();
     const userNames = allEmails.map((email) => email.email);
     expect(userNames).toEqual(["john.doe@example.com", "john.doe.work@company.com"]);
@@ -351,7 +363,7 @@ describe("SqlAdapter PGLite", () => {
     // Count all users
     const uow = queryEngine
       .createUnitOfWork("count-users")
-      .find("users", (b) => b.whereIndex("primary").selectCount());
+      .findNew("users", (b) => b.whereIndex("primary").selectCount());
 
     const [count] = await uow.executeRetrieve();
 
@@ -362,7 +374,7 @@ describe("SqlAdapter PGLite", () => {
     // Count with where clause
     const uow2 = queryEngine
       .createUnitOfWork("count-young-users")
-      .find("users", (b) => b.whereIndex("age_idx", (eb) => eb("age", "<", 28)).selectCount());
+      .findNew("users", (b) => b.whereIndex("age_idx", (eb) => eb("age", "<", 28)).selectCount());
 
     const [youngCount] = await uow2.executeRetrieve();
     expect(youngCount).toBeGreaterThanOrEqual(1); // At least Alice (25)
@@ -395,7 +407,9 @@ describe("SqlAdapter PGLite", () => {
     // Test forward pagination with after cursor, ordered by name
     const page1 = queryEngine
       .createUnitOfWork("page-1")
-      .find("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2));
+      .findNew("users", (b) =>
+        b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2),
+      );
 
     const [page1Results] = await page1.executeRetrieve();
     // Note: Previous tests created "Alice" and "Jane Doe"
@@ -413,7 +427,7 @@ describe("SqlAdapter PGLite", () => {
     // Get page 2 using the cursor
     const page2 = queryEngine
       .createUnitOfWork("page-2")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").after(cursor).pageSize(2),
       );
 
@@ -566,13 +580,16 @@ describe("SqlAdapter PGLite", () => {
     })();
 
     // Query post_tags with joined post and tag data using UOW
-    const uow = queryEngine
-      .createUnitOfWork("get-post-tags")
-      .find("post_tags", (b) =>
-        b
-          .whereIndex("primary")
-          .join((jb) => jb.post((pb) => pb.select(["title"])).tag((tb) => tb.select(["name"]))),
-      );
+    const uow = queryEngine.createUnitOfWork("get-post-tags").findNew("post_tags", (b) =>
+      b
+        .whereIndex("primary")
+        .joinOne("post", "posts", (pb) =>
+          pb.onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id"))).select(["title"]),
+        )
+        .joinOne("tag", "tags", (tb) =>
+          tb.onIndex("primary", (eb) => eb("id", "=", eb.parent("tag_id"))).select(["name"]),
+        ),
+    );
 
     const [postTags] = await uow.executeRetrieve();
 
@@ -637,13 +654,16 @@ describe("SqlAdapter PGLite", () => {
     // Test nested many-to-many join: post_tags -> post -> author
     const uow2 = queryEngine
       .createUnitOfWork("get-post-tags-with-authors")
-      .find("post_tags", (b) =>
+      .findNew("post_tags", (b) =>
         b
           .whereIndex("pt_post", (eb) => eb("post_id", "=", post1Id))
-          .join((jb) =>
-            jb.post((pb) =>
-              pb.select(["title"]).join((jb2) => jb2["author"]((ab) => ab.select(["name"]))),
-            ),
+          .joinOne("post", "posts", (pb) =>
+            pb
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+              .select(["title"])
+              .joinOne("author", "users", (ab) =>
+                ab.onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id"))).select(["name"]),
+              ),
           ),
       );
 
@@ -730,23 +750,27 @@ describe("SqlAdapter PGLite", () => {
     })();
 
     // Now perform a complex nested join: comments -> post -> author, and comments -> commenter
-    const uow = queryEngine.createUnitOfWork("test-complex-joins").find("comments", (b) =>
-      b.whereIndex("primary").join((jb) =>
-        jb
-          .post((postBuilder) =>
-            postBuilder
-              .select(["id", "title", "content"])
-              .orderByIndex("primary", "desc")
-              .pageSize(1)
-              .join((jb2) =>
-                // Nested join to the post's author
-                jb2.author((authorBuilder) =>
-                  authorBuilder.select(["id", "name", "age"]).orderByIndex("name_idx", "asc"),
-                ),
-              ),
-          )
-          .commenter((commenterBuilder) => commenterBuilder.select(["id", "name"])),
-      ),
+    const uow = queryEngine.createUnitOfWork("test-complex-joins").findNew("comments", (b) =>
+      b
+        .whereIndex("primary")
+        .joinOne("post", "posts", (postBuilder) =>
+          postBuilder
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+            .select(["id", "title", "content"])
+            .orderByIndex("primary", "desc")
+            .pageSize(1)
+            .joinOne("author", "users", (authorBuilder) =>
+              authorBuilder
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+                .select(["id", "name", "age"])
+                .orderByIndex("name_idx", "asc"),
+            ),
+        )
+        .joinOne("commenter", "users", (commenterBuilder) =>
+          commenterBuilder
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+            .select(["id", "name"]),
+        ),
     );
 
     const [[comment]] = await uow.executeRetrieve();
@@ -822,7 +846,7 @@ describe("SqlAdapter PGLite", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -832,7 +856,7 @@ describe("SqlAdapter PGLite", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -842,7 +866,7 @@ describe("SqlAdapter PGLite", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -910,7 +934,7 @@ describe("SqlAdapter PGLite", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -960,7 +984,7 @@ describe("SqlAdapter PGLite", () => {
     const post = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postId)));
+        .findFirstNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1017,7 +1041,7 @@ describe("SqlAdapter PGLite", () => {
     const user = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1028,7 +1052,7 @@ describe("SqlAdapter PGLite", () => {
     const post = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("posts", (b) =>
+        .findFirstNew("posts", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", postId.externalId)),
         );
       await uow.executeRetrieve();
@@ -1067,7 +1091,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Fetch first page with cursor (pageSize=10, total=15 items)
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -1088,7 +1112,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Fetch second page using cursor (last page with 5 remaining items)
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -1118,7 +1142,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Test empty results
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NonExistentPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -1139,7 +1163,7 @@ describe("SqlAdapter PGLite", () => {
     const existingUsers = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .find("users", (b) => b.whereIndex("name_idx").pageSize(1));
+        .findNew("users", (b) => b.whereIndex("name_idx").pageSize(1));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1164,7 +1188,7 @@ describe("SqlAdapter PGLite", () => {
     // Use findWithCursor in UOW
     const uow = queryEngine
       .createUnitOfWork("cursor-test")
-      .findWithCursor("users", (b) =>
+      .findWithCursorNew("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(3),
       );
 
@@ -1223,7 +1247,9 @@ describe("SqlAdapter PGLite", () => {
     const posts = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", userId)));
+        .findNew("posts", (b) =>
+          b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", userId)),
+        );
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-migrations.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-migrations.test.ts
@@ -138,7 +138,7 @@ describe("SqlAdapter PGLite", () => {
     const getUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", userId)).select(["id", "name"]),
         );
       await uow.executeRetrieve();
@@ -205,7 +205,7 @@ describe("SqlAdapter PGLite", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -216,7 +216,7 @@ describe("SqlAdapter PGLite", () => {
     const emailsWithUsers = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findNew("emails", (b) =>
+        .find("emails", (b) =>
           b
             .whereIndex("primary")
             .joinOne("user", "users", (jb) =>
@@ -252,7 +252,7 @@ describe("SqlAdapter PGLite", () => {
     const userEmails = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findNew("emails", (b) =>
+        .find("emails", (b) =>
           b
             .whereIndex("user_emails", (eb) => eb("user_id", "=", userId))
             .joinOne("user", "users", (jb) =>
@@ -290,7 +290,7 @@ describe("SqlAdapter PGLite", () => {
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
       // Retrieval phase: find the user
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     // Execute retrieval and transition to mutation phase
     const [users] = await uow.executeRetrieve();
@@ -309,9 +309,7 @@ describe("SqlAdapter PGLite", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
-          b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)),
-        );
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -339,7 +337,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the user was NOT updated
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -351,7 +349,7 @@ describe("SqlAdapter PGLite", () => {
 
     const uow3 = queryEngine
       .createUnitOfWork("get-all-emails")
-      .findNew("emails", (b) => b.whereIndex("primary").orderByIndex("unique_email", "desc"));
+      .find("emails", (b) => b.whereIndex("primary").orderByIndex("unique_email", "desc"));
     const [allEmails] = await uow3.executeRetrieve();
     const userNames = allEmails.map((email) => email.email);
     expect(userNames).toEqual(["john.doe@example.com", "john.doe.work@company.com"]);
@@ -363,7 +361,7 @@ describe("SqlAdapter PGLite", () => {
     // Count all users
     const uow = queryEngine
       .createUnitOfWork("count-users")
-      .findNew("users", (b) => b.whereIndex("primary").selectCount());
+      .find("users", (b) => b.whereIndex("primary").selectCount());
 
     const [count] = await uow.executeRetrieve();
 
@@ -374,7 +372,7 @@ describe("SqlAdapter PGLite", () => {
     // Count with where clause
     const uow2 = queryEngine
       .createUnitOfWork("count-young-users")
-      .findNew("users", (b) => b.whereIndex("age_idx", (eb) => eb("age", "<", 28)).selectCount());
+      .find("users", (b) => b.whereIndex("age_idx", (eb) => eb("age", "<", 28)).selectCount());
 
     const [youngCount] = await uow2.executeRetrieve();
     expect(youngCount).toBeGreaterThanOrEqual(1); // At least Alice (25)
@@ -407,9 +405,7 @@ describe("SqlAdapter PGLite", () => {
     // Test forward pagination with after cursor, ordered by name
     const page1 = queryEngine
       .createUnitOfWork("page-1")
-      .findNew("users", (b) =>
-        b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2),
-      );
+      .find("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2));
 
     const [page1Results] = await page1.executeRetrieve();
     // Note: Previous tests created "Alice" and "Jane Doe"
@@ -427,7 +423,7 @@ describe("SqlAdapter PGLite", () => {
     // Get page 2 using the cursor
     const page2 = queryEngine
       .createUnitOfWork("page-2")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").after(cursor).pageSize(2),
       );
 
@@ -580,7 +576,7 @@ describe("SqlAdapter PGLite", () => {
     })();
 
     // Query post_tags with joined post and tag data using UOW
-    const uow = queryEngine.createUnitOfWork("get-post-tags").findNew("post_tags", (b) =>
+    const uow = queryEngine.createUnitOfWork("get-post-tags").find("post_tags", (b) =>
       b
         .whereIndex("primary")
         .joinOne("post", "posts", (pb) =>
@@ -652,20 +648,18 @@ describe("SqlAdapter PGLite", () => {
     ]);
 
     // Test nested many-to-many join: post_tags -> post -> author
-    const uow2 = queryEngine
-      .createUnitOfWork("get-post-tags-with-authors")
-      .findNew("post_tags", (b) =>
-        b
-          .whereIndex("pt_post", (eb) => eb("post_id", "=", post1Id))
-          .joinOne("post", "posts", (pb) =>
-            pb
-              .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
-              .select(["title"])
-              .joinOne("author", "users", (ab) =>
-                ab.onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id"))).select(["name"]),
-              ),
-          ),
-      );
+    const uow2 = queryEngine.createUnitOfWork("get-post-tags-with-authors").find("post_tags", (b) =>
+      b
+        .whereIndex("pt_post", (eb) => eb("post_id", "=", post1Id))
+        .joinOne("post", "posts", (pb) =>
+          pb
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+            .select(["title"])
+            .joinOne("author", "users", (ab) =>
+              ab.onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id"))).select(["name"]),
+            ),
+        ),
+    );
 
     const [postTagsWithAuthors] = await uow2.executeRetrieve();
 
@@ -750,7 +744,7 @@ describe("SqlAdapter PGLite", () => {
     })();
 
     // Now perform a complex nested join: comments -> post -> author, and comments -> commenter
-    const uow = queryEngine.createUnitOfWork("test-complex-joins").findNew("comments", (b) =>
+    const uow = queryEngine.createUnitOfWork("test-complex-joins").find("comments", (b) =>
       b
         .whereIndex("primary")
         .joinOne("post", "posts", (postBuilder) =>
@@ -846,7 +840,7 @@ describe("SqlAdapter PGLite", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -856,7 +850,7 @@ describe("SqlAdapter PGLite", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -866,7 +860,7 @@ describe("SqlAdapter PGLite", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -934,7 +928,7 @@ describe("SqlAdapter PGLite", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -984,7 +978,7 @@ describe("SqlAdapter PGLite", () => {
     const post = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postId)));
+        .findFirst("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1041,7 +1035,7 @@ describe("SqlAdapter PGLite", () => {
     const user = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1052,7 +1046,7 @@ describe("SqlAdapter PGLite", () => {
     const post = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("posts", (b) =>
+        .findFirst("posts", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", postId.externalId)),
         );
       await uow.executeRetrieve();
@@ -1091,7 +1085,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Fetch first page with cursor (pageSize=10, total=15 items)
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -1112,7 +1106,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Fetch second page using cursor (last page with 5 remaining items)
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -1142,7 +1136,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Test empty results
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NonExistentPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -1163,7 +1157,7 @@ describe("SqlAdapter PGLite", () => {
     const existingUsers = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findNew("users", (b) => b.whereIndex("name_idx").pageSize(1));
+        .find("users", (b) => b.whereIndex("name_idx").pageSize(1));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1188,7 +1182,7 @@ describe("SqlAdapter PGLite", () => {
     // Use findWithCursor in UOW
     const uow = queryEngine
       .createUnitOfWork("cursor-test")
-      .findWithCursorNew("users", (b) =>
+      .findWithCursor("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(3),
       );
 
@@ -1247,9 +1241,7 @@ describe("SqlAdapter PGLite", () => {
     const posts = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findNew("posts", (b) =>
-          b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", userId)),
-        );
+        .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", userId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-migrations.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-migrations.test.ts
@@ -22,7 +22,7 @@ describe("SqlAdapter PGLite", () => {
       .addTable("emails", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("email", column("string"))
           .addColumn("is_primary", column("bool").defaultTo(false))
           .createIndex("unique_email", ["email"], { unique: true })
@@ -31,7 +31,7 @@ describe("SqlAdapter PGLite", () => {
       .addTable("posts", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
           .createIndex("posts_user_idx", ["user_id"]);
@@ -45,49 +45,19 @@ describe("SqlAdapter PGLite", () => {
       .addTable("post_tags", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("post_id", referenceColumn())
-          .addColumn("tag_id", referenceColumn())
+          .addColumn("post_id", referenceColumn({ table: "posts" }))
+          .addColumn("tag_id", referenceColumn({ table: "tags" }))
           .createIndex("pt_post", ["post_id"])
           .createIndex("pt_tag", ["tag_id"]);
       })
       .addTable("comments", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("post_id", referenceColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("post_id", referenceColumn({ table: "posts" }))
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("text", column("string"))
           .createIndex("comments_post_idx", ["post_id"])
           .createIndex("comments_user_idx", ["user_id"]);
-      })
-      .addReference("user", {
-        type: "one",
-        from: { table: "emails", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "post_tags", column: "post_id" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("tag", {
-        type: "one",
-        from: { table: "post_tags", column: "tag_id" },
-        to: { table: "tags", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "comments", column: "post_id" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("commenter", {
-        type: "one",
-        from: { table: "comments", column: "user_id" },
-        to: { table: "users", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-pagination.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-pagination.test.ts
@@ -25,7 +25,7 @@ describe("SqlAdapter PGLite", () => {
       .addTable("emails", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("email", column("string"))
           .addColumn("is_primary", column("bool").defaultTo(false))
           .createIndex("unique_email", ["email"], { unique: true })
@@ -34,7 +34,7 @@ describe("SqlAdapter PGLite", () => {
       .addTable("posts", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
           .createIndex("posts_user_idx", ["user_id"]);
@@ -42,8 +42,8 @@ describe("SqlAdapter PGLite", () => {
       .addTable("comments", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("post_id", referenceColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("post_id", referenceColumn({ table: "posts" }))
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("text", column("string"))
           .createIndex("comments_post_idx", ["post_id"])
           .createIndex("comments_user_idx", ["user_id"]);
@@ -60,26 +60,6 @@ describe("SqlAdapter PGLite", () => {
           .addColumn("payload", column("json").nullable())
           .addColumn("big_score", column("bigint"))
           .createIndex("events_name_idx", ["name"]);
-      })
-      .addReference("user", {
-        type: "one",
-        from: { table: "emails", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "comments", column: "post_id" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("commenter", {
-        type: "one",
-        from: { table: "comments", column: "user_id" },
-        to: { table: "users", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-pagination.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-pagination.test.ts
@@ -140,7 +140,7 @@ describe("SqlAdapter PGLite", () => {
 
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     const [users] = await uow.executeRetrieve();
 
@@ -153,7 +153,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -172,7 +172,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -194,7 +194,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .find("users", (b) => b.whereIndex("primary").selectCount())
+      .findNew("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     expect(totalCount).toBeGreaterThanOrEqual(3);
@@ -216,7 +216,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -237,7 +237,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -270,7 +270,7 @@ describe("SqlAdapter PGLite", () => {
     }
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -285,7 +285,7 @@ describe("SqlAdapter PGLite", () => {
     expect(firstPage.cursor).toBeInstanceOf(Cursor);
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -301,7 +301,7 @@ describe("SqlAdapter PGLite", () => {
     expect(secondPage.cursor).toBeInstanceOf(Cursor);
 
     const thirdPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(secondPage.cursor!)
@@ -317,7 +317,7 @@ describe("SqlAdapter PGLite", () => {
     expect(thirdPage.cursor).toBeUndefined();
 
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NoMatchPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -345,7 +345,7 @@ describe("SqlAdapter PGLite", () => {
     const all = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .find("users", (b) =>
+        .findNew("users", (b) =>
           b
             .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
             .orderByIndex("name_id_idx", "asc"),
@@ -355,7 +355,7 @@ describe("SqlAdapter PGLite", () => {
     })();
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .orderByIndex("name_id_idx", "asc")
@@ -366,7 +366,7 @@ describe("SqlAdapter PGLite", () => {
     })();
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .after(firstPage.cursor!)
@@ -406,7 +406,7 @@ describe("SqlAdapter PGLite", () => {
       })();
     }
 
-    const uow = queryEngine.createUnitOfWork("cursor-test").findWithCursor("users", (b) =>
+    const uow = queryEngine.createUnitOfWork("cursor-test").findWithCursorNew("users", (b) =>
       b
         .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
         .orderByIndex("name_idx", "asc")
@@ -431,7 +431,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [usersResult] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "SqlAdapter PGLite Email User")),
       )
       .executeRetrieve();
@@ -450,17 +450,21 @@ describe("SqlAdapter PGLite", () => {
 
     const uow = queryEngine
       .createUnitOfWork("test-joins", { onQuery: (query) => queries.push(query) })
-      .find("emails", (b) =>
+      .findNew("emails", (b) =>
         b
           .whereIndex("user_emails", (eb) => eb("user_id", "=", createdUser.id))
-          .join((jb) => jb.user((builder) => builder.select(["name", "id", "age"]))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["name", "id", "age"]),
+          ),
       );
 
     const [[email]] = await uow.executeRetrieve();
 
     const [query] = queries;
     expect(query.sql).toMatchInlineSnapshot(
-      `"select "user"."name" as "user:name", "user"."id" as "user:id", "user"."age" as "user:age", "user"."_internalId" as "user:_internalId", "user"."_version" as "user:_version", "namespace"."emails"."id" as "id", "namespace"."emails"."user_id" as "user_id", "namespace"."emails"."email" as "email", "namespace"."emails"."is_primary" as "is_primary", "namespace"."emails"."_internalId" as "_internalId", "namespace"."emails"."_version" as "_version" from "namespace"."emails" left join "namespace"."users" as "user" on "namespace"."emails"."user_id" = "user"."_internalId" where "namespace"."emails"."user_id" = $1"`,
+      `"select "_fragno_root"."id" as "id", "_fragno_root"."user_id" as "user_id", "_fragno_root"."email" as "email", "_fragno_root"."is_primary" as "is_primary", "_fragno_root"."_internalId" as "_internalId", "_fragno_root"."_version" as "_version", ((select json_build_object('name', "_fragno_user_0"."name", 'id', "_fragno_user_0"."id", 'age', "_fragno_user_0"."age", '_internalId', "_fragno_user_0"."_internalId", '_version', "_fragno_user_0"."_version") as "_fragno_item" from "namespace"."users" as "_fragno_user_0" where "_fragno_user_0"."_internalId" = "_fragno_root"."user_id" limit $1)) as "user" from "namespace"."emails" as "_fragno_root" where "_fragno_root"."user_id" = $2"`,
     );
 
     expect(email).toMatchObject({
@@ -493,7 +497,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-external-id")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "SqlAdapter PGLite External ID User")),
       )
       .executeRetrieve();
@@ -510,12 +514,16 @@ describe("SqlAdapter PGLite", () => {
 
     const [[email]] = await queryEngine
       .createUnitOfWork("get-email-by-external-id")
-      .find("emails", (b) =>
+      .findNew("emails", (b) =>
         b
           .whereIndex("unique_email", (eb) =>
             eb("email", "=", "prisma-pglite-external-id@example.com"),
           )
-          .join((jb) => jb.user((builder) => builder.select(["name", "id"]))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["name", "id"]),
+          ),
       )
       .executeRetrieve();
 
@@ -557,12 +565,12 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("verify-user")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
       .executeRetrieve();
 
     const [[post]] = await queryEngine
       .createUnitOfWork("verify-post")
-      .find("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
+      .findNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
       .executeRetrieve();
 
     expect(user.name).toBe("SqlAdapter PGLite UOW User");
@@ -582,7 +590,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "SqlAdapter PGLite Author")),
       )
       .executeRetrieve();
@@ -597,7 +605,9 @@ describe("SqlAdapter PGLite", () => {
 
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
+      .findNew("posts", (b) =>
+        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
+      )
       .executeRetrieve();
 
     const createCommenterUow = queryEngine.createUnitOfWork("create-commenter");
@@ -606,7 +616,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "SqlAdapter PGLite Commenter")),
       )
       .executeRetrieve();
@@ -618,25 +628,31 @@ describe("SqlAdapter PGLite", () => {
       text: "Great Prisma post!",
     });
     await createCommentUow.executeMutations();
+    const createdCommentId = createCommentUow.getCreatedIds()[0]!;
 
     const uow = queryEngine
       .createUnitOfWork("test-complex-joins", { onQuery: (query) => queries.push(query) })
-      .find("comments", (b) =>
-        b.whereIndex("primary").join((jb) =>
-          jb
-            .post((postBuilder) =>
-              postBuilder
-                .select(["id", "title", "content"])
-                .orderByIndex("primary", "desc")
-                .pageSize(1)
-                .join((jb2) =>
-                  jb2.author((authorBuilder) =>
-                    authorBuilder.select(["id", "name", "age"]).orderByIndex("name_idx", "asc"),
-                  ),
-                ),
-            )
-            .commenter((commenterBuilder) => commenterBuilder.select(["id", "name"])),
-        ),
+      .findNew("comments", (b) =>
+        b
+          .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
+          .joinOne("post", "posts", (postBuilder) =>
+            postBuilder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+              .select(["id", "title", "content"])
+              .orderByIndex("primary", "desc")
+              .pageSize(1)
+              .joinOne("author", "users", (authorBuilder) =>
+                authorBuilder
+                  .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+                  .select(["id", "name", "age"])
+                  .orderByIndex("name_idx", "asc"),
+              ),
+          )
+          .joinOne("commenter", "users", (commenterBuilder) =>
+            commenterBuilder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["id", "name"]),
+          ),
       );
 
     const [[comment]] = await uow.executeRetrieve();
@@ -671,7 +687,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [query] = queries;
     expect(query.sql).toMatchInlineSnapshot(
-      `"select "post"."id" as "post:id", "post"."title" as "post:title", "post"."content" as "post:content", "post"."_internalId" as "post:_internalId", "post"."_version" as "post:_version", "post_author"."id" as "post:author:id", "post_author"."name" as "post:author:name", "post_author"."age" as "post:author:age", "post_author"."_internalId" as "post:author:_internalId", "post_author"."_version" as "post:author:_version", "commenter"."id" as "commenter:id", "commenter"."name" as "commenter:name", "commenter"."_internalId" as "commenter:_internalId", "commenter"."_version" as "commenter:_version", "namespace"."comments"."id" as "id", "namespace"."comments"."post_id" as "post_id", "namespace"."comments"."user_id" as "user_id", "namespace"."comments"."text" as "text", "namespace"."comments"."_internalId" as "_internalId", "namespace"."comments"."_version" as "_version" from "namespace"."comments" left join "namespace"."posts" as "post" on "namespace"."comments"."post_id" = "post"."_internalId" left join "namespace"."users" as "post_author" on "post"."user_id" = "post_author"."_internalId" left join "namespace"."users" as "commenter" on "namespace"."comments"."user_id" = "commenter"."_internalId""`,
+      `"select "_fragno_root"."id" as "id", "_fragno_root"."post_id" as "post_id", "_fragno_root"."user_id" as "user_id", "_fragno_root"."text" as "text", "_fragno_root"."_internalId" as "_internalId", "_fragno_root"."_version" as "_version", ((select json_build_object('id', "_fragno_post_0"."id", 'title', "_fragno_post_0"."title", 'content', "_fragno_post_0"."content", '_internalId', "_fragno_post_0"."_internalId", '_version', "_fragno_post_0"."_version", 'author', ((select json_build_object('id', "_fragno_post_author_1"."id", 'name', "_fragno_post_author_1"."name", 'age', "_fragno_post_author_1"."age", '_internalId', "_fragno_post_author_1"."_internalId", '_version', "_fragno_post_author_1"."_version") as "_fragno_item" from "namespace"."users" as "_fragno_post_author_1" where "_fragno_post_author_1"."_internalId" = "_fragno_post_0"."user_id" order by "_fragno_post_author_1"."name" asc limit $1))) as "_fragno_item" from "namespace"."posts" as "_fragno_post_0" where "_fragno_post_0"."_internalId" = "_fragno_root"."post_id" order by "_fragno_post_0"."id" desc limit $2)) as "post", ((select json_build_object('id', "_fragno_commenter_0"."id", 'name', "_fragno_commenter_0"."name", '_internalId', "_fragno_commenter_0"."_internalId", '_version', "_fragno_commenter_0"."_version") as "_fragno_item" from "namespace"."users" as "_fragno_commenter_0" where "_fragno_commenter_0"."_internalId" = "_fragno_root"."user_id" limit $3)) as "commenter" from "namespace"."comments" as "_fragno_root" where "_fragno_root"."id" = $4"`,
     );
   });
 
@@ -708,7 +724,7 @@ describe("SqlAdapter PGLite", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -717,7 +733,7 @@ describe("SqlAdapter PGLite", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -726,7 +742,7 @@ describe("SqlAdapter PGLite", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -786,7 +802,7 @@ describe("SqlAdapter PGLite", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -814,7 +830,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-event-for-timestamp")
-      .find("events", (b) =>
+      .findNew("events", (b) =>
         b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Timestamp Event PGLite")),
       )
       .executeRetrieve();
@@ -846,7 +862,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) =>
           eb("name", "=", "SqlAdapter PGLite Version Conflict User"),
         ),
@@ -870,7 +886,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter(
@@ -897,7 +913,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-event")
-      .find("events", (b) => b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Launch")))
+      .findNew("events", (b) => b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Launch")))
       .executeRetrieve();
 
     expect(event).toBeDefined();

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-pagination.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-pagination.test.ts
@@ -140,7 +140,7 @@ describe("SqlAdapter PGLite", () => {
 
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     const [users] = await uow.executeRetrieve();
 
@@ -153,7 +153,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -172,7 +172,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -194,7 +194,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .findNew("users", (b) => b.whereIndex("primary").selectCount())
+      .find("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     expect(totalCount).toBeGreaterThanOrEqual(3);
@@ -216,7 +216,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -237,7 +237,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -270,7 +270,7 @@ describe("SqlAdapter PGLite", () => {
     }
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -285,7 +285,7 @@ describe("SqlAdapter PGLite", () => {
     expect(firstPage.cursor).toBeInstanceOf(Cursor);
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -301,7 +301,7 @@ describe("SqlAdapter PGLite", () => {
     expect(secondPage.cursor).toBeInstanceOf(Cursor);
 
     const thirdPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(secondPage.cursor!)
@@ -317,7 +317,7 @@ describe("SqlAdapter PGLite", () => {
     expect(thirdPage.cursor).toBeUndefined();
 
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NoMatchPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -345,7 +345,7 @@ describe("SqlAdapter PGLite", () => {
     const all = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findNew("users", (b) =>
+        .find("users", (b) =>
           b
             .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
             .orderByIndex("name_id_idx", "asc"),
@@ -355,7 +355,7 @@ describe("SqlAdapter PGLite", () => {
     })();
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .orderByIndex("name_id_idx", "asc")
@@ -366,7 +366,7 @@ describe("SqlAdapter PGLite", () => {
     })();
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .after(firstPage.cursor!)
@@ -406,7 +406,7 @@ describe("SqlAdapter PGLite", () => {
       })();
     }
 
-    const uow = queryEngine.createUnitOfWork("cursor-test").findWithCursorNew("users", (b) =>
+    const uow = queryEngine.createUnitOfWork("cursor-test").findWithCursor("users", (b) =>
       b
         .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
         .orderByIndex("name_idx", "asc")
@@ -431,7 +431,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [usersResult] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "SqlAdapter PGLite Email User")),
       )
       .executeRetrieve();
@@ -450,7 +450,7 @@ describe("SqlAdapter PGLite", () => {
 
     const uow = queryEngine
       .createUnitOfWork("test-joins", { onQuery: (query) => queries.push(query) })
-      .findNew("emails", (b) =>
+      .find("emails", (b) =>
         b
           .whereIndex("user_emails", (eb) => eb("user_id", "=", createdUser.id))
           .joinOne("user", "users", (builder) =>
@@ -497,7 +497,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-external-id")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "SqlAdapter PGLite External ID User")),
       )
       .executeRetrieve();
@@ -514,7 +514,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[email]] = await queryEngine
       .createUnitOfWork("get-email-by-external-id")
-      .findNew("emails", (b) =>
+      .find("emails", (b) =>
         b
           .whereIndex("unique_email", (eb) =>
             eb("email", "=", "prisma-pglite-external-id@example.com"),
@@ -565,12 +565,12 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("verify-user")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
       .executeRetrieve();
 
     const [[post]] = await queryEngine
       .createUnitOfWork("verify-post")
-      .findNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
+      .find("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
       .executeRetrieve();
 
     expect(user.name).toBe("SqlAdapter PGLite UOW User");
@@ -590,7 +590,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "SqlAdapter PGLite Author")),
       )
       .executeRetrieve();
@@ -605,9 +605,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .findNew("posts", (b) =>
-        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
-      )
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
       .executeRetrieve();
 
     const createCommenterUow = queryEngine.createUnitOfWork("create-commenter");
@@ -616,7 +614,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "SqlAdapter PGLite Commenter")),
       )
       .executeRetrieve();
@@ -632,7 +630,7 @@ describe("SqlAdapter PGLite", () => {
 
     const uow = queryEngine
       .createUnitOfWork("test-complex-joins", { onQuery: (query) => queries.push(query) })
-      .findNew("comments", (b) =>
+      .find("comments", (b) =>
         b
           .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
           .joinOne("post", "posts", (postBuilder) =>
@@ -724,7 +722,7 @@ describe("SqlAdapter PGLite", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -733,7 +731,7 @@ describe("SqlAdapter PGLite", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -742,7 +740,7 @@ describe("SqlAdapter PGLite", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -802,7 +800,7 @@ describe("SqlAdapter PGLite", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -830,7 +828,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-event-for-timestamp")
-      .findNew("events", (b) =>
+      .find("events", (b) =>
         b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Timestamp Event PGLite")),
       )
       .executeRetrieve();
@@ -862,7 +860,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) =>
           eb("name", "=", "SqlAdapter PGLite Version Conflict User"),
         ),
@@ -886,7 +884,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter(
@@ -913,7 +911,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-event")
-      .findNew("events", (b) => b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Launch")))
+      .find("events", (b) => b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Launch")))
       .executeRetrieve();
 
     expect(event).toBeDefined();

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-queries.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-queries.test.ts
@@ -151,7 +151,7 @@ describe("SqlAdapter PGLite", () => {
     // Fetch the created user to get its ID
     const [[initialUser]] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .find("users")
+      .findNew("users", (b) => b.whereIndex("primary"))
       .executeRetrieve();
 
     expect(initialUser).toBeDefined();
@@ -164,7 +164,7 @@ describe("SqlAdapter PGLite", () => {
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
       // Retrieval phase: find the user
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     // Execute retrieval and transition to mutation phase
     const [users] = await uow.executeRetrieve();
@@ -182,7 +182,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the user was updated
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -208,7 +208,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the user was NOT updated
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -232,7 +232,7 @@ describe("SqlAdapter PGLite", () => {
     // Count all users
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .find("users", (b) => b.whereIndex("primary").selectCount())
+      .findNew("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     // Tests are not isolated, so we can't use expect(totalCount).toBe(3)
@@ -254,7 +254,7 @@ describe("SqlAdapter PGLite", () => {
     // Fetch first page ordered by name
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .find("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
+      .findNew("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
       .executeRetrieve();
 
     // Verify first page contains the first 2 users alphabetically
@@ -272,7 +272,7 @@ describe("SqlAdapter PGLite", () => {
     // Fetch next page using cursor
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").after(cursor).pageSize(2),
       )
       .executeRetrieve();
@@ -299,7 +299,7 @@ describe("SqlAdapter PGLite", () => {
     // Get an existing user to create an email for
     const [[existingUser]] = await queryEngine
       .createUnitOfWork("get-existing-user")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
       .executeRetrieve();
 
     // Create an email for testing joins
@@ -314,17 +314,21 @@ describe("SqlAdapter PGLite", () => {
     // Test join query
     const uow = queryEngine
       .createUnitOfWork("test-joins", { onQuery: (query) => queries.push(query) })
-      .find("emails", (b) =>
+      .findNew("emails", (b) =>
         b
           .whereIndex("user_emails")
-          .join((jb) => jb.user((builder) => builder.select(["name", "id", "age"]))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["name", "id", "age"]),
+          ),
       );
 
     const [[email]] = await uow.executeRetrieve();
 
     const [query] = queries;
     expect(query.sql).toMatchInlineSnapshot(
-      `"select "user"."name" as "user:name", "user"."id" as "user:id", "user"."age" as "user:age", "user"."_internalId" as "user:_internalId", "user"."_version" as "user:_version", "namespace"."emails"."id" as "id", "namespace"."emails"."user_id" as "user_id", "namespace"."emails"."email" as "email", "namespace"."emails"."is_primary" as "is_primary", "namespace"."emails"."_internalId" as "_internalId", "namespace"."emails"."_version" as "_version" from "namespace"."emails" left join "namespace"."users" as "user" on "namespace"."emails"."user_id" = "user"."_internalId""`,
+      `"select "_fragno_root"."id" as "id", "_fragno_root"."user_id" as "user_id", "_fragno_root"."email" as "email", "_fragno_root"."is_primary" as "is_primary", "_fragno_root"."_internalId" as "_internalId", "_fragno_root"."_version" as "_version", ((select json_build_object('name', "_fragno_user_0"."name", 'id', "_fragno_user_0"."id", 'age', "_fragno_user_0"."age", '_internalId', "_fragno_user_0"."_internalId", '_version', "_fragno_user_0"."_version") as "_fragno_item" from "namespace"."users" as "_fragno_user_0" where "_fragno_user_0"."_internalId" = "_fragno_root"."user_id" limit $1)) as "user" from "namespace"."emails" as "_fragno_root""`,
     );
 
     expect(email).toMatchObject({
@@ -359,7 +363,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the user
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-external-id")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "External ID Test User")),
       )
       .executeRetrieve();
@@ -378,10 +382,14 @@ describe("SqlAdapter PGLite", () => {
     // Verify the email was created and can be retrieved with a join
     const [[email]] = await queryEngine
       .createUnitOfWork("get-email-by-external-id")
-      .find("emails", (b) =>
+      .findNew("emails", (b) =>
         b
           .whereIndex("unique_email", (eb) => eb("email", "=", "external-id-test@example.com"))
-          .join((jb) => jb.user((builder) => builder.select(["name", "id"]))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["name", "id"]),
+          ),
       )
       .executeRetrieve();
 
@@ -412,7 +420,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the author
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
       .executeRetrieve();
 
     // Create a post by the author
@@ -425,7 +433,10 @@ describe("SqlAdapter PGLite", () => {
     await createPostUow.executeMutations();
 
     // Get the post
-    const [[post]] = await queryEngine.createUnitOfWork("get-post").find("posts").executeRetrieve();
+    const [[post]] = await queryEngine
+      .createUnitOfWork("get-post")
+      .findNew("posts", (b) => b.whereIndex("primary"))
+      .executeRetrieve();
 
     // Create a commenter
     const createCommenterUow = queryEngine.createUnitOfWork("create-commenter");
@@ -435,7 +446,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the commenter
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
       .executeRetrieve();
 
     // Create a comment on the post
@@ -446,27 +457,32 @@ describe("SqlAdapter PGLite", () => {
       text: "Great post!",
     });
     await createCommentUow.executeMutations();
+    const createdCommentId = createCommentUow.getCreatedIds()[0]!;
 
     // Now perform a complex nested join: comments -> post -> author, and comments -> commenter
     const uow = queryEngine
       .createUnitOfWork("test-complex-joins", { onQuery: (query) => queries.push(query) })
-      .find("comments", (b) =>
-        b.whereIndex("primary").join((jb) =>
-          jb
-            .post((postBuilder) =>
-              postBuilder
-                .select(["id", "title", "content"])
-                .orderByIndex("primary", "desc")
-                .pageSize(1)
-                .join((jb2) =>
-                  // Nested join to the post's author
-                  jb2.author((authorBuilder) =>
-                    authorBuilder.select(["id", "name", "age"]).orderByIndex("name_idx", "asc"),
-                  ),
-                ),
-            )
-            .commenter((commenterBuilder) => commenterBuilder.select(["id", "name"])),
-        ),
+      .findNew("comments", (b) =>
+        b
+          .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
+          .joinOne("post", "posts", (postBuilder) =>
+            postBuilder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+              .select(["id", "title", "content"])
+              .orderByIndex("primary", "desc")
+              .pageSize(1)
+              .joinOne("author", "users", (authorBuilder) =>
+                authorBuilder
+                  .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+                  .select(["id", "name", "age"])
+                  .orderByIndex("name_idx", "asc"),
+              ),
+          )
+          .joinOne("commenter", "users", (commenterBuilder) =>
+            commenterBuilder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["id", "name"]),
+          ),
       );
 
     const [[comment]] = await uow.executeRetrieve();
@@ -505,7 +521,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [query] = queries;
     expect(query.sql).toMatchInlineSnapshot(
-      `"select "post"."id" as "post:id", "post"."title" as "post:title", "post"."content" as "post:content", "post"."_internalId" as "post:_internalId", "post"."_version" as "post:_version", "post_author"."id" as "post:author:id", "post_author"."name" as "post:author:name", "post_author"."age" as "post:author:age", "post_author"."_internalId" as "post:author:_internalId", "post_author"."_version" as "post:author:_version", "commenter"."id" as "commenter:id", "commenter"."name" as "commenter:name", "commenter"."_internalId" as "commenter:_internalId", "commenter"."_version" as "commenter:_version", "namespace"."comments"."id" as "id", "namespace"."comments"."post_id" as "post_id", "namespace"."comments"."user_id" as "user_id", "namespace"."comments"."text" as "text", "namespace"."comments"."_internalId" as "_internalId", "namespace"."comments"."_version" as "_version" from "namespace"."comments" left join "namespace"."posts" as "post" on "namespace"."comments"."post_id" = "post"."_internalId" left join "namespace"."users" as "post_author" on "post"."user_id" = "post_author"."_internalId" left join "namespace"."users" as "commenter" on "namespace"."comments"."user_id" = "commenter"."_internalId""`,
+      `"select "_fragno_root"."id" as "id", "_fragno_root"."post_id" as "post_id", "_fragno_root"."user_id" as "user_id", "_fragno_root"."text" as "text", "_fragno_root"."_internalId" as "_internalId", "_fragno_root"."_version" as "_version", ((select json_build_object('id', "_fragno_post_0"."id", 'title', "_fragno_post_0"."title", 'content', "_fragno_post_0"."content", '_internalId', "_fragno_post_0"."_internalId", '_version', "_fragno_post_0"."_version", 'author', ((select json_build_object('id', "_fragno_post_author_1"."id", 'name', "_fragno_post_author_1"."name", 'age', "_fragno_post_author_1"."age", '_internalId', "_fragno_post_author_1"."_internalId", '_version', "_fragno_post_author_1"."_version") as "_fragno_item" from "namespace"."users" as "_fragno_post_author_1" where "_fragno_post_author_1"."_internalId" = "_fragno_post_0"."user_id" order by "_fragno_post_author_1"."name" asc limit $1))) as "_fragno_item" from "namespace"."posts" as "_fragno_post_0" where "_fragno_post_0"."_internalId" = "_fragno_root"."post_id" order by "_fragno_post_0"."id" desc limit $2)) as "post", ((select json_build_object('id', "_fragno_commenter_0"."id", 'name', "_fragno_commenter_0"."name", '_internalId', "_fragno_commenter_0"."_internalId", '_version', "_fragno_commenter_0"."_version") as "_fragno_item" from "namespace"."users" as "_fragno_commenter_0" where "_fragno_commenter_0"."_internalId" = "_fragno_root"."user_id" limit $3)) as "commenter" from "namespace"."comments" as "_fragno_root" where "_fragno_root"."id" = $4"`,
     );
   });
 
@@ -519,7 +535,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-timestamp")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
       .executeRetrieve();
 
     // Create a post with database-generated timestamp (defaultTo(b => b.now()))
@@ -539,7 +555,7 @@ describe("SqlAdapter PGLite", () => {
     // Retrieve the specific post we just created by its ID
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post-with-timestamp")
-      .find("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postId)))
+      .findNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postId)))
       .executeRetrieve();
 
     // Verify created_at is a Date
@@ -598,7 +614,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("verify-user")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
       .executeRetrieve();
 
     expect(user.name).toBe("UOW Test User");
@@ -606,7 +622,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[post]] = await queryEngine
       .createUnitOfWork("verify-post")
-      .find("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
+      .findNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
       .executeRetrieve();
 
     expect(post.title).toBe("UOW Test Post");
@@ -655,7 +671,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Fetch first page with cursor (pageSize=10, total=15 items)
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -676,7 +692,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Fetch second page using cursor (last page with 5 remaining items)
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -698,7 +714,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Test empty results
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NonExistentPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -718,7 +734,7 @@ describe("SqlAdapter PGLite", () => {
     // Use findWithCursor in UOW
     const uow = queryEngine
       .createUnitOfWork("cursor-test")
-      .findWithCursor("users", (b) =>
+      .findWithCursorNew("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(5),
       );
 
@@ -748,7 +764,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the user
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Version Conflict User")),
       )
       .executeRetrieve();
@@ -774,7 +790,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the post was NOT created
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter((p) => p.title === "Should Not Be Created");

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-queries.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-queries.test.ts
@@ -151,7 +151,7 @@ describe("SqlAdapter PGLite", () => {
     // Fetch the created user to get its ID
     const [[initialUser]] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .findNew("users", (b) => b.whereIndex("primary"))
+      .find("users", (b) => b.whereIndex("primary"))
       .executeRetrieve();
 
     expect(initialUser).toBeDefined();
@@ -164,7 +164,7 @@ describe("SqlAdapter PGLite", () => {
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
       // Retrieval phase: find the user
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     // Execute retrieval and transition to mutation phase
     const [users] = await uow.executeRetrieve();
@@ -182,7 +182,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the user was updated
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -208,7 +208,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the user was NOT updated
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -232,7 +232,7 @@ describe("SqlAdapter PGLite", () => {
     // Count all users
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .findNew("users", (b) => b.whereIndex("primary").selectCount())
+      .find("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     // Tests are not isolated, so we can't use expect(totalCount).toBe(3)
@@ -254,7 +254,7 @@ describe("SqlAdapter PGLite", () => {
     // Fetch first page ordered by name
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .findNew("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
+      .find("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
       .executeRetrieve();
 
     // Verify first page contains the first 2 users alphabetically
@@ -272,7 +272,7 @@ describe("SqlAdapter PGLite", () => {
     // Fetch next page using cursor
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").after(cursor).pageSize(2),
       )
       .executeRetrieve();
@@ -299,7 +299,7 @@ describe("SqlAdapter PGLite", () => {
     // Get an existing user to create an email for
     const [[existingUser]] = await queryEngine
       .createUnitOfWork("get-existing-user")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
       .executeRetrieve();
 
     // Create an email for testing joins
@@ -314,7 +314,7 @@ describe("SqlAdapter PGLite", () => {
     // Test join query
     const uow = queryEngine
       .createUnitOfWork("test-joins", { onQuery: (query) => queries.push(query) })
-      .findNew("emails", (b) =>
+      .find("emails", (b) =>
         b
           .whereIndex("user_emails")
           .joinOne("user", "users", (builder) =>
@@ -363,7 +363,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the user
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-external-id")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "External ID Test User")),
       )
       .executeRetrieve();
@@ -382,7 +382,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the email was created and can be retrieved with a join
     const [[email]] = await queryEngine
       .createUnitOfWork("get-email-by-external-id")
-      .findNew("emails", (b) =>
+      .find("emails", (b) =>
         b
           .whereIndex("unique_email", (eb) => eb("email", "=", "external-id-test@example.com"))
           .joinOne("user", "users", (builder) =>
@@ -420,7 +420,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the author
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
       .executeRetrieve();
 
     // Create a post by the author
@@ -435,7 +435,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the post
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .findNew("posts", (b) => b.whereIndex("primary"))
+      .find("posts", (b) => b.whereIndex("primary"))
       .executeRetrieve();
 
     // Create a commenter
@@ -446,7 +446,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the commenter
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
       .executeRetrieve();
 
     // Create a comment on the post
@@ -462,7 +462,7 @@ describe("SqlAdapter PGLite", () => {
     // Now perform a complex nested join: comments -> post -> author, and comments -> commenter
     const uow = queryEngine
       .createUnitOfWork("test-complex-joins", { onQuery: (query) => queries.push(query) })
-      .findNew("comments", (b) =>
+      .find("comments", (b) =>
         b
           .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
           .joinOne("post", "posts", (postBuilder) =>
@@ -535,7 +535,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-timestamp")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
       .executeRetrieve();
 
     // Create a post with database-generated timestamp (defaultTo(b => b.now()))
@@ -555,7 +555,7 @@ describe("SqlAdapter PGLite", () => {
     // Retrieve the specific post we just created by its ID
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post-with-timestamp")
-      .findNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postId)))
+      .find("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postId)))
       .executeRetrieve();
 
     // Verify created_at is a Date
@@ -614,7 +614,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("verify-user")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
       .executeRetrieve();
 
     expect(user.name).toBe("UOW Test User");
@@ -622,7 +622,7 @@ describe("SqlAdapter PGLite", () => {
 
     const [[post]] = await queryEngine
       .createUnitOfWork("verify-post")
-      .findNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
+      .find("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
       .executeRetrieve();
 
     expect(post.title).toBe("UOW Test Post");
@@ -671,7 +671,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Fetch first page with cursor (pageSize=10, total=15 items)
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -692,7 +692,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Fetch second page using cursor (last page with 5 remaining items)
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -714,7 +714,7 @@ describe("SqlAdapter PGLite", () => {
 
     // Test empty results
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NonExistentPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -734,7 +734,7 @@ describe("SqlAdapter PGLite", () => {
     // Use findWithCursor in UOW
     const uow = queryEngine
       .createUnitOfWork("cursor-test")
-      .findWithCursorNew("users", (b) =>
+      .findWithCursor("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(5),
       );
 
@@ -764,7 +764,7 @@ describe("SqlAdapter PGLite", () => {
     // Get the user
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Version Conflict User")),
       )
       .executeRetrieve();
@@ -790,7 +790,7 @@ describe("SqlAdapter PGLite", () => {
     // Verify the post was NOT created
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter((p) => p.title === "Should Not Be Created");

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-queries.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-pglite-queries.test.ts
@@ -27,7 +27,7 @@ describe("SqlAdapter PGLite", () => {
       .addTable("emails", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("email", column("string"))
           .addColumn("is_primary", column("bool").defaultTo(false))
           .createIndex("unique_email", ["email"], { unique: true })
@@ -36,7 +36,7 @@ describe("SqlAdapter PGLite", () => {
       .addTable("posts", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
           .addColumn(
@@ -48,31 +48,11 @@ describe("SqlAdapter PGLite", () => {
       .addTable("comments", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("post_id", referenceColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("post_id", referenceColumn({ table: "posts" }))
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("text", column("string"))
           .createIndex("comments_post_idx", ["post_id"])
           .createIndex("comments_user_idx", ["user_id"]);
-      })
-      .addReference("user", {
-        type: "one",
-        from: { table: "emails", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "comments", column: "post_id" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("commenter", {
-        type: "one",
-        from: { table: "comments", column: "user_id" },
-        to: { table: "users", column: "id" },
       });
   });
 
@@ -88,9 +68,9 @@ describe("SqlAdapter PGLite", () => {
       .addTable("orders", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("product_id", referenceColumn())
+          .addColumn("product_id", referenceColumn({ table: "products" }))
           .addColumn("quantity", column("integer"))
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", column("string"))
           .createIndex("orders_user_idx", ["user_id"])
           .createIndex("orders_product_idx", ["product_id"]);
       });

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-driver.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-driver.test.ts
@@ -163,7 +163,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Verify both users were created by fetching them
     const [allUsers] = await queryEngine
       .createUnitOfWork("get-all-users")
-      .find("users")
+      .findNew("users", (b) => b.whereIndex("primary"))
       .executeRetrieve();
 
     expect(allUsers).toHaveLength(2);
@@ -195,7 +195,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
       // Retrieval phase: find Alice
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     // Execute retrieval and transition to mutation phase
     const [users] = await uow.executeRetrieve();
@@ -214,7 +214,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Verify Alice was updated
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -240,7 +240,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Verify Alice was NOT updated
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -263,7 +263,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Count all users
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .find("users", (b) => b.whereIndex("primary").selectCount())
+      .findFirstNew("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     // Tests are not isolated, so we can't use expect(totalCount).toBe(3)
@@ -286,7 +286,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch first page ordered by name
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .find("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
+      .findNew("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
       .executeRetrieve();
 
     // Verify first page contains the first 2 users alphabetically
@@ -305,7 +305,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch next page using cursor
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").after(cursor).pageSize(2),
       )
       .executeRetrieve();
@@ -334,7 +334,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const all = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .find("users", (b) =>
+        .findNew("users", (b) =>
           b
             .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
             .orderByIndex("name_id_idx", "asc"),
@@ -344,7 +344,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     })();
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .orderByIndex("name_id_idx", "asc")
@@ -355,7 +355,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     })();
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .after(firstPage.cursor!)
@@ -388,7 +388,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the created user to get the proper ID
     const [usersResult] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
       .executeRetrieve();
 
     expect(usersResult).toHaveLength(1);
@@ -408,10 +408,14 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Test join query
     const uow = queryEngine
       .createUnitOfWork("test-joins")
-      .find("emails", (b) =>
+      .findNew("emails", (b) =>
         b
           .whereIndex("user_emails", (eb) => eb("user_id", "=", createdUser.id))
-          .join((jb) => jb.user((builder) => builder.select(["name", "id", "age"]))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["name", "id", "age"]),
+          ),
       );
 
     const [[email]] = await uow.executeRetrieve();
@@ -448,7 +452,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the created author to get the proper ID
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
       .executeRetrieve();
 
     // Create a post by the author
@@ -463,7 +467,9 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the created post to get the proper ID
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
+      .findNew("posts", (b) =>
+        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
+      )
       .executeRetrieve();
 
     // Create a commenter
@@ -474,7 +480,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the created commenter to get the proper ID
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
       .executeRetrieve();
 
     // Create a comment on the post
@@ -485,25 +491,30 @@ describe("SqlAdapter with better-sqlite3", () => {
       text: "Great post!",
     });
     await createCommentUow.executeMutations();
+    const createdCommentId = createCommentUow.getCreatedIds()[0]!;
 
     // Now perform a complex nested join: comments -> post -> author, and comments -> commenter
-    const uow = queryEngine.createUnitOfWork("test-complex-joins").find("comments", (b) =>
-      b.whereIndex("primary").join((jb) =>
-        jb
-          .post((postBuilder) =>
-            postBuilder
-              .select(["id", "title", "content"])
-              .orderByIndex("primary", "desc")
-              .pageSize(1)
-              .join((jb2) =>
-                // Nested join to the post's author
-                jb2.author((authorBuilder) =>
-                  authorBuilder.select(["id", "name", "age"]).orderByIndex("name_idx", "asc"),
-                ),
-              ),
-          )
-          .commenter((commenterBuilder) => commenterBuilder.select(["id", "name"])),
-      ),
+    const uow = queryEngine.createUnitOfWork("test-complex-joins").findNew("comments", (b) =>
+      b
+        .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
+        .joinOne("post", "posts", (postBuilder) =>
+          postBuilder
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+            .select(["id", "title", "content"])
+            .orderByIndex("primary", "desc")
+            .pageSize(1)
+            .joinOne("author", "users", (authorBuilder) =>
+              authorBuilder
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+                .select(["id", "name", "age"])
+                .orderByIndex("name_idx", "asc"),
+            ),
+        )
+        .joinOne("commenter", "users", (commenterBuilder) =>
+          commenterBuilder
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+            .select(["id", "name"]),
+        ),
     );
 
     const [[comment]] = await uow.executeRetrieve();
@@ -539,6 +550,160 @@ describe("SqlAdapter with better-sqlite3", () => {
         name: "Commenter User",
       },
     });
+  });
+
+  it("should support query-tree joins without schema references", async () => {
+    const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
+
+    const createAuthorUow = queryEngine.createUnitOfWork("create-author-query-tree");
+    createAuthorUow.create("users", { name: "Tree Author", age: 31 });
+    await createAuthorUow.executeMutations();
+
+    const [[author]] = await queryEngine
+      .createUnitOfWork("get-author-query-tree")
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Tree Author")))
+      .executeRetrieve();
+
+    const createPostUow = queryEngine.createUnitOfWork("create-post-query-tree");
+    createPostUow.create("posts", {
+      user_id: author.id,
+      title: "Tree Post",
+      content: "Nested query tree post",
+    });
+    await createPostUow.executeMutations();
+
+    const [[post]] = await queryEngine
+      .createUnitOfWork("get-post-query-tree")
+      .findNew("posts", (b) =>
+        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
+      )
+      .executeRetrieve();
+
+    const createCommenterUow = queryEngine.createUnitOfWork("create-commenter-query-tree");
+    createCommenterUow.create("users", { name: "Tree Commenter", age: 26 });
+    await createCommenterUow.executeMutations();
+
+    const [[commenter]] = await queryEngine
+      .createUnitOfWork("get-commenter-query-tree")
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Tree Commenter")))
+      .executeRetrieve();
+
+    const createCommentUow = queryEngine.createUnitOfWork("create-comment-query-tree");
+    createCommentUow.create("comments", {
+      post_id: post.id,
+      user_id: commenter.id,
+      text: "Query tree comment",
+    });
+    await createCommentUow.executeMutations();
+
+    const [[createdComment]] = await queryEngine
+      .createUnitOfWork("get-comment-query-tree")
+      .findNew("comments", (b) =>
+        b.whereIndex("comments_user_idx", (eb) => eb("user_id", "=", commenter.id)),
+      )
+      .executeRetrieve();
+
+    const expectedPostExternalId = String(post.id);
+    const expectedAuthorExternalId = String(author.id);
+    const expectedCommenterExternalId = String(commenter.id);
+
+    const query = queryEngine.createUnitOfWork("query-tree-joins").findNew("comments", (q) =>
+      q
+        .whereIndex("primary", (eb) => eb("id", "=", createdComment.id))
+        .select(["id", "text", "post_id", "user_id"])
+        .joinOne("post", "posts", (joinedPost) =>
+          joinedPost
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+            .select(["id", "title", "content", "user_id"])
+            .joinOne("author", "users", (joinedAuthor) =>
+              joinedAuthor
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+                .whereIndex("name_idx", (eb) => eb("name", "=", "Tree Author"))
+                .select(["id", "name", "age"]),
+            ),
+        )
+        .joinOne("commenter", "users", (joinedCommenter) =>
+          joinedCommenter
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+            .whereIndex("name_idx", (eb) => eb("name", "=", "Tree Commenter"))
+            .select(["id", "name"]),
+        ),
+    );
+
+    const [[comment]] = await query.executeRetrieve();
+
+    expect(comment).toMatchObject({
+      id: expect.objectContaining({
+        externalId: expect.stringMatching(/^[a-z0-9]{20,}$/),
+        internalId: expect.any(BigInt),
+      }),
+      text: "Query tree comment",
+      post: {
+        id: expect.objectContaining({ externalId: expectedPostExternalId }),
+        title: "Tree Post",
+        content: "Nested query tree post",
+        author: {
+          id: expect.objectContaining({ externalId: expectedAuthorExternalId }),
+          name: "Tree Author",
+          age: 31,
+        },
+      },
+      commenter: {
+        id: expect.objectContaining({ externalId: expectedCommenterExternalId }),
+        name: "Tree Commenter",
+      },
+    });
+  });
+
+  it("should support query-tree cursor pagination", async () => {
+    const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
+    const prefix = "SQLite QueryTree Cursor";
+
+    for (let i = 1; i <= 5; i += 1) {
+      const createUow = queryEngine.createUnitOfWork(`create-query-tree-cursor-${i}`);
+      createUow.create("users", {
+        name: `${prefix} ${i.toString().padStart(2, "0")}`,
+        age: 20 + i,
+      });
+      await createUow.executeMutations();
+    }
+
+    const firstPage = await (async () => {
+      const uow = queryEngine
+        .createUnitOfWork("query-tree-cursor-page-1")
+        .findWithCursorNew("users", (q) =>
+          q
+            .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
+            .orderByIndex("name_idx", "asc")
+            .pageSize(2)
+            .select(["id", "name"]),
+        );
+      await uow.executeRetrieve();
+      return (await uow.retrievalPhase)[0];
+    })();
+
+    const secondPage = await (async () => {
+      const uow = queryEngine
+        .createUnitOfWork("query-tree-cursor-page-2")
+        .findWithCursorNew("users", (q) =>
+          q
+            .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
+            .after(firstPage.cursor!)
+            .orderByIndex("name_idx", "asc")
+            .pageSize(2)
+            .select(["id", "name"]),
+        );
+      await uow.executeRetrieve();
+      return (await uow.retrievalPhase)[0];
+    })();
+
+    expect(firstPage.items.map((user) => user.name)).toEqual([`${prefix} 01`, `${prefix} 02`]);
+    expect(firstPage.hasNextPage).toBe(true);
+    expect(firstPage.cursor).toBeDefined();
+
+    expect(secondPage.items.map((user) => user.name)).toEqual([`${prefix} 03`, `${prefix} 04`]);
+    expect(secondPage.hasNextPage).toBe(true);
+    expect(secondPage.cursor).toBeDefined();
   });
 
   it("should return created IDs from UOW create operations", async () => {
@@ -578,7 +743,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -588,7 +753,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -598,7 +763,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -666,7 +831,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -690,7 +855,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-timestamp")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
       .executeRetrieve();
 
     // Create a post (note: SQLite schema doesn't have created_at column)
@@ -705,7 +870,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Retrieve the post
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post-for-timestamp")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     expect(post).toBeDefined();
@@ -760,12 +925,12 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const view1 = uow
       .forSchema(testSchema)
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Multi Schema User"))
           .select(["id", "name"]),
       )
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Multi Schema User"))
           .select(["name", "age"]),
@@ -773,7 +938,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const view2 = uow
       .forSchema(schema2)
-      .find("products", (b) => b.whereIndex("primary").select(["name", "price"]));
+      .findNew("products", (b) => b.whereIndex("primary").select(["name", "price"]));
 
     // Execute the retrieval phase once
     await uow.executeRetrieve();
@@ -847,7 +1012,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     // Test 1: First page with more results available (pageSize=10, total=15)
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -863,7 +1028,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     // Test 2: Second page (last page, partial results: 5 items remaining)
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -880,7 +1045,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     // Test 3: Empty results
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NonExistentPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -906,7 +1071,9 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the user to get their ID
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-execute-uow")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")))
+      .findNew("users", (b) =>
+        b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")),
+      )
       .executeRetrieve();
 
     // Use handlerTx to increment age with optimistic locking
@@ -916,7 +1083,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const getUserById = (userId: typeof user.id) => {
       return createServiceTxBuilder(testSchema, currentUow!)
         .retrieve((uow) =>
-          uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+          uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
         )
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
@@ -955,7 +1122,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -984,7 +1151,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Get the user
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Version Conflict User SQLite")),
       )
       .executeRetrieve();
@@ -1009,7 +1176,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Verify the post was NOT created
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter((p) => p.title === "Should Not Be Created SQLite");

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-driver.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-driver.test.ts
@@ -31,7 +31,7 @@ describe("SqlAdapter with better-sqlite3", () => {
       .addTable("emails", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("email", column("string"))
           .addColumn("is_primary", column("bool").defaultTo(false))
           .createIndex("unique_email", ["email"], { unique: true })
@@ -40,7 +40,7 @@ describe("SqlAdapter with better-sqlite3", () => {
       .addTable("posts", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
           .createIndex("posts_user_idx", ["user_id"]);
@@ -48,31 +48,11 @@ describe("SqlAdapter with better-sqlite3", () => {
       .addTable("comments", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("post_id", referenceColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("post_id", referenceColumn({ table: "posts" }))
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("text", column("string"))
           .createIndex("comments_post_idx", ["post_id"])
           .createIndex("comments_user_idx", ["user_id"]);
-      })
-      .addReference("user", {
-        type: "one",
-        from: { table: "emails", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "comments", column: "post_id" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("commenter", {
-        type: "one",
-        from: { table: "comments", column: "user_id" },
-        to: { table: "users", column: "id" },
       });
   });
 
@@ -89,14 +69,9 @@ describe("SqlAdapter with better-sqlite3", () => {
       .addTable("orders", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("product_id", referenceColumn())
+          .addColumn("product_id", referenceColumn({ table: "products" }))
           .addColumn("quantity", column("integer"))
           .createIndex("product_orders_idx", ["product_id"]);
-      })
-      .addReference("product", {
-        type: "one",
-        from: { table: "orders", column: "product_id" },
-        to: { table: "products", column: "id" },
       });
   });
 
@@ -1194,12 +1169,9 @@ describe("SQLite recreate-table foreign keys", () => {
           return t.addColumn("id", idColumn()).addColumn("name", column("string"));
         })
         .addTable("sessions", (t) => {
-          return t.addColumn("id", idColumn()).addColumn("userId", referenceColumn());
-        })
-        .addReference("sessionUser", {
-          type: "one",
-          from: { table: "sessions", column: "userId" },
-          to: { table: "users", column: "id" },
+          return t
+            .addColumn("id", idColumn())
+            .addColumn("userId", referenceColumn({ table: "users" }));
         })
         .alterTable("users", (t) => {
           return t.alterColumn("name").nullable();
@@ -1258,15 +1230,10 @@ describe("SQLite migration failure scenarios", () => {
           return t.addColumn("id", idColumn()).addColumn("name", column("string"));
         })
         .addTable("posts", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("title", column("string"))
-            .addColumn("authorId", referenceColumn());
+          return t.addColumn("id", idColumn()).addColumn("title", column("string"));
         })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
+        .alterTable("posts", (t) => {
+          return t.addColumn("authorId", referenceColumn({ table: "users" }));
         });
     });
 

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-driver.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-driver.test.ts
@@ -163,7 +163,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Verify both users were created by fetching them
     const [allUsers] = await queryEngine
       .createUnitOfWork("get-all-users")
-      .findNew("users", (b) => b.whereIndex("primary"))
+      .find("users", (b) => b.whereIndex("primary"))
       .executeRetrieve();
 
     expect(allUsers).toHaveLength(2);
@@ -195,7 +195,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
       // Retrieval phase: find Alice
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     // Execute retrieval and transition to mutation phase
     const [users] = await uow.executeRetrieve();
@@ -214,7 +214,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Verify Alice was updated
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -240,7 +240,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Verify Alice was NOT updated
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -263,7 +263,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Count all users
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .findFirstNew("users", (b) => b.whereIndex("primary").selectCount())
+      .findFirst("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     // Tests are not isolated, so we can't use expect(totalCount).toBe(3)
@@ -286,7 +286,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch first page ordered by name
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .findNew("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
+      .find("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
       .executeRetrieve();
 
     // Verify first page contains the first 2 users alphabetically
@@ -305,7 +305,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch next page using cursor
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").after(cursor).pageSize(2),
       )
       .executeRetrieve();
@@ -334,7 +334,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const all = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findNew("users", (b) =>
+        .find("users", (b) =>
           b
             .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
             .orderByIndex("name_id_idx", "asc"),
@@ -344,7 +344,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     })();
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .orderByIndex("name_id_idx", "asc")
@@ -355,7 +355,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     })();
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .after(firstPage.cursor!)
@@ -388,7 +388,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the created user to get the proper ID
     const [usersResult] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
       .executeRetrieve();
 
     expect(usersResult).toHaveLength(1);
@@ -408,7 +408,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Test join query
     const uow = queryEngine
       .createUnitOfWork("test-joins")
-      .findNew("emails", (b) =>
+      .find("emails", (b) =>
         b
           .whereIndex("user_emails", (eb) => eb("user_id", "=", createdUser.id))
           .joinOne("user", "users", (builder) =>
@@ -452,7 +452,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the created author to get the proper ID
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
       .executeRetrieve();
 
     // Create a post by the author
@@ -467,9 +467,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the created post to get the proper ID
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .findNew("posts", (b) =>
-        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
-      )
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
       .executeRetrieve();
 
     // Create a commenter
@@ -480,7 +478,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the created commenter to get the proper ID
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
       .executeRetrieve();
 
     // Create a comment on the post
@@ -494,7 +492,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const createdCommentId = createCommentUow.getCreatedIds()[0]!;
 
     // Now perform a complex nested join: comments -> post -> author, and comments -> commenter
-    const uow = queryEngine.createUnitOfWork("test-complex-joins").findNew("comments", (b) =>
+    const uow = queryEngine.createUnitOfWork("test-complex-joins").find("comments", (b) =>
       b
         .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
         .joinOne("post", "posts", (postBuilder) =>
@@ -561,7 +559,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author-query-tree")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Tree Author")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Tree Author")))
       .executeRetrieve();
 
     const createPostUow = queryEngine.createUnitOfWork("create-post-query-tree");
@@ -574,9 +572,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post-query-tree")
-      .findNew("posts", (b) =>
-        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
-      )
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
       .executeRetrieve();
 
     const createCommenterUow = queryEngine.createUnitOfWork("create-commenter-query-tree");
@@ -585,7 +581,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter-query-tree")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Tree Commenter")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Tree Commenter")))
       .executeRetrieve();
 
     const createCommentUow = queryEngine.createUnitOfWork("create-comment-query-tree");
@@ -598,7 +594,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const [[createdComment]] = await queryEngine
       .createUnitOfWork("get-comment-query-tree")
-      .findNew("comments", (b) =>
+      .find("comments", (b) =>
         b.whereIndex("comments_user_idx", (eb) => eb("user_id", "=", commenter.id)),
       )
       .executeRetrieve();
@@ -607,7 +603,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const expectedAuthorExternalId = String(author.id);
     const expectedCommenterExternalId = String(commenter.id);
 
-    const query = queryEngine.createUnitOfWork("query-tree-joins").findNew("comments", (q) =>
+    const query = queryEngine.createUnitOfWork("query-tree-joins").find("comments", (q) =>
       q
         .whereIndex("primary", (eb) => eb("id", "=", createdComment.id))
         .select(["id", "text", "post_id", "user_id"])
@@ -671,7 +667,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const firstPage = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("query-tree-cursor-page-1")
-        .findWithCursorNew("users", (q) =>
+        .findWithCursor("users", (q) =>
           q
             .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
             .orderByIndex("name_idx", "asc")
@@ -685,7 +681,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const secondPage = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("query-tree-cursor-page-2")
-        .findWithCursorNew("users", (q) =>
+        .findWithCursor("users", (q) =>
           q
             .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
             .after(firstPage.cursor!)
@@ -743,7 +739,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -753,7 +749,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -763,7 +759,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -831,7 +827,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -855,7 +851,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-timestamp")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
       .executeRetrieve();
 
     // Create a post (note: SQLite schema doesn't have created_at column)
@@ -870,7 +866,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Retrieve the post
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post-for-timestamp")
-      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     expect(post).toBeDefined();
@@ -925,12 +921,12 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const view1 = uow
       .forSchema(testSchema)
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Multi Schema User"))
           .select(["id", "name"]),
       )
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Multi Schema User"))
           .select(["name", "age"]),
@@ -938,7 +934,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     const view2 = uow
       .forSchema(schema2)
-      .findNew("products", (b) => b.whereIndex("primary").select(["name", "price"]));
+      .find("products", (b) => b.whereIndex("primary").select(["name", "price"]));
 
     // Execute the retrieval phase once
     await uow.executeRetrieve();
@@ -1012,7 +1008,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     // Test 1: First page with more results available (pageSize=10, total=15)
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -1028,7 +1024,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     // Test 2: Second page (last page, partial results: 5 items remaining)
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -1045,7 +1041,7 @@ describe("SqlAdapter with better-sqlite3", () => {
 
     // Test 3: Empty results
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NonExistentPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -1071,9 +1067,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Fetch the user to get their ID
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-execute-uow")
-      .findNew("users", (b) =>
-        b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")),
-      )
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")))
       .executeRetrieve();
 
     // Use handlerTx to increment age with optimistic locking
@@ -1083,7 +1077,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const getUserById = (userId: typeof user.id) => {
       return createServiceTxBuilder(testSchema, currentUow!)
         .retrieve((uow) =>
-          uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+          uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
         )
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
@@ -1122,7 +1116,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1151,7 +1145,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Get the user
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Version Conflict User SQLite")),
       )
       .executeRetrieve();
@@ -1176,7 +1170,7 @@ describe("SqlAdapter with better-sqlite3", () => {
     // Verify the post was NOT created
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter((p) => p.title === "Should Not Be Created SQLite");

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-uow.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-uow.test.ts
@@ -30,7 +30,7 @@ describe("SqlAdapter SQLite", () => {
       .addTable("emails", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("email", column("string"))
           .addColumn("is_primary", column("bool").defaultTo(false))
           .createIndex("unique_email", ["email"], { unique: true })
@@ -39,7 +39,7 @@ describe("SqlAdapter SQLite", () => {
       .addTable("posts", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
           .createIndex("posts_user_idx", ["user_id"]);
@@ -47,43 +47,18 @@ describe("SqlAdapter SQLite", () => {
       .addTable("optional_emails", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn().nullable())
+          .addColumn("user_id", referenceColumn({ table: "users" }).nullable())
           .addColumn("email", column("string"))
           .createIndex("optional_emails_user_idx", ["user_id"]);
       })
       .addTable("comments", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("post_id", referenceColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("post_id", referenceColumn({ table: "posts" }))
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("text", column("string"))
           .createIndex("comments_post_idx", ["post_id"])
           .createIndex("comments_user_idx", ["user_id"]);
-      })
-      .addReference("user", {
-        type: "one",
-        from: { table: "emails", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("user", {
-        type: "one",
-        from: { table: "optional_emails", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "comments", column: "post_id" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("commenter", {
-        type: "one",
-        from: { table: "comments", column: "user_id" },
-        to: { table: "users", column: "id" },
       });
   });
 
@@ -100,14 +75,9 @@ describe("SqlAdapter SQLite", () => {
       .addTable("orders", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("product_id", referenceColumn())
+          .addColumn("product_id", referenceColumn({ table: "products" }))
           .addColumn("quantity", column("integer"))
           .createIndex("product_orders_idx", ["product_id"]);
-      })
-      .addReference("product", {
-        type: "one",
-        from: { table: "orders", column: "product_id" },
-        to: { table: "products", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-uow.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-uow.test.ts
@@ -163,7 +163,7 @@ describe("SqlAdapter SQLite", () => {
     });
 
     expectTypeOf<keyof typeof testSchema.tables>().toEqualTypeOf<
-      Parameters<typeof createUow.find>[0]
+      Parameters<typeof createUow.findNew>[0]
     >();
     expectTypeOf<keyof typeof testSchema.tables>().toEqualTypeOf<
       "users" | "emails" | "posts" | "comments" | "optional_emails"
@@ -178,7 +178,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify both users were created by fetching them
     const [allUsers] = await queryEngine
       .createUnitOfWork("get-all-users")
-      .find("users")
+      .findNew("users", (b) => b.whereIndex("primary"))
       .executeRetrieve();
 
     expect(allUsers).toHaveLength(2);
@@ -210,7 +210,7 @@ describe("SqlAdapter SQLite", () => {
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
       // Retrieval phase: find Alice
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     // Execute retrieval and transition to mutation phase
     const [users] = await uow.executeRetrieve();
@@ -229,7 +229,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify Alice was updated
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -255,7 +255,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify Alice was NOT updated
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -297,7 +297,7 @@ describe("SqlAdapter SQLite", () => {
 
     const verifyUow = queryEngine.createUnitOfWork("verify-duplicate-hook-id");
     const internalUow = verifyUow.forSchema(internalSchema);
-    const findUow = internalUow.find("fragno_hooks", (b) =>
+    const findUow = internalUow.findNew("fragno_hooks", (b) =>
       b.whereIndex("primary", (eb) => eb("id", "=", hookId)),
     );
     const [events] = await findUow.executeRetrieve();
@@ -317,7 +317,7 @@ describe("SqlAdapter SQLite", () => {
     // Count all users
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .find("users", (b) => b.whereIndex("primary").selectCount())
+      .findNew("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     // Tests are not isolated, so we can't use expect(totalCount).toBe(3)
@@ -340,7 +340,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch first page ordered by name
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .find("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
+      .findNew("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
       .executeRetrieve();
 
     // Verify first page contains the first 2 users alphabetically
@@ -359,7 +359,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch next page using cursor
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").after(cursor).pageSize(2),
       )
       .executeRetrieve();
@@ -387,7 +387,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the created user to get the proper ID
     const [usersResult] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
       .executeRetrieve();
 
     expect(usersResult).toHaveLength(1);
@@ -407,10 +407,14 @@ describe("SqlAdapter SQLite", () => {
     // Test join query
     const uow = queryEngine
       .createUnitOfWork("test-joins")
-      .find("emails", (b) =>
+      .findNew("emails", (b) =>
         b
           .whereIndex("user_emails", (eb) => eb("user_id", "=", createdUser.id))
-          .join((jb) => jb.user((builder) => builder.select(["name", "id", "age"]))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["name", "id", "age"]),
+          ),
       );
 
     const [[email]] = await uow.executeRetrieve();
@@ -448,7 +452,13 @@ describe("SqlAdapter SQLite", () => {
 
     const uow = queryEngine
       .createUnitOfWork("join-optional-email")
-      .find("optional_emails", (b) => b.whereIndex("primary").join((jb) => jb.user()));
+      .findNew("optional_emails", (b) =>
+        b
+          .whereIndex("primary")
+          .joinOne("user", "users", (builder) =>
+            builder.onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id"))),
+          ),
+      );
 
     const [[email]] = await uow.executeRetrieve();
 
@@ -467,7 +477,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the created author to get the proper ID
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
       .executeRetrieve();
 
     // Create a post by the author
@@ -482,7 +492,9 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the created post to get the proper ID
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
+      .findNew("posts", (b) =>
+        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
+      )
       .executeRetrieve();
 
     // Create a commenter
@@ -493,7 +505,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the created commenter to get the proper ID
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
       .executeRetrieve();
 
     // Create a comment on the post
@@ -504,25 +516,30 @@ describe("SqlAdapter SQLite", () => {
       text: "Great post!",
     });
     await createCommentUow.executeMutations();
+    const createdCommentId = createCommentUow.getCreatedIds()[0]!;
 
     // Now perform a complex nested join: comments -> post -> author, and comments -> commenter
-    const uow = queryEngine.createUnitOfWork("test-complex-joins").find("comments", (b) =>
-      b.whereIndex("primary").join((jb) =>
-        jb
-          .post((postBuilder) =>
-            postBuilder
-              .select(["id", "title", "content"])
-              .orderByIndex("primary", "desc")
-              .pageSize(1)
-              .join((jb2) =>
-                // Nested join to the post's author
-                jb2.author((authorBuilder) =>
-                  authorBuilder.select(["id", "name", "age"]).orderByIndex("name_idx", "asc"),
-                ),
-              ),
-          )
-          .commenter((commenterBuilder) => commenterBuilder.select(["id", "name"])),
-      ),
+    const uow = queryEngine.createUnitOfWork("test-complex-joins").findNew("comments", (b) =>
+      b
+        .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
+        .joinOne("post", "posts", (postBuilder) =>
+          postBuilder
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+            .select(["id", "title", "content"])
+            .orderByIndex("primary", "desc")
+            .pageSize(1)
+            .joinOne("author", "users", (authorBuilder) =>
+              authorBuilder
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+                .select(["id", "name", "age"])
+                .orderByIndex("name_idx", "asc"),
+            ),
+        )
+        .joinOne("commenter", "users", (commenterBuilder) =>
+          commenterBuilder
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+            .select(["id", "name"]),
+        ),
     );
 
     const [[comment]] = await uow.executeRetrieve();
@@ -597,7 +614,7 @@ describe("SqlAdapter SQLite", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -607,7 +624,7 @@ describe("SqlAdapter SQLite", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -617,7 +634,7 @@ describe("SqlAdapter SQLite", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -685,7 +702,7 @@ describe("SqlAdapter SQLite", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -709,7 +726,7 @@ describe("SqlAdapter SQLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-timestamp")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
+      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
       .executeRetrieve();
 
     // Create a post (note: SQLite schema doesn't have created_at column)
@@ -724,7 +741,7 @@ describe("SqlAdapter SQLite", () => {
     // Retrieve the post
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post-for-timestamp")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     expect(post).toBeDefined();
@@ -779,12 +796,12 @@ describe("SqlAdapter SQLite", () => {
 
     const view1 = uow
       .forSchema(testSchema)
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Multi Schema User"))
           .select(["id", "name"]),
       )
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Multi Schema User"))
           .select(["name", "age"]),
@@ -792,7 +809,7 @@ describe("SqlAdapter SQLite", () => {
 
     const view2 = uow
       .forSchema(schema2)
-      .find("products", (b) => b.whereIndex("primary").select(["name", "price"]));
+      .findNew("products", (b) => b.whereIndex("primary").select(["name", "price"]));
 
     // Execute the retrieval phase once
     await uow.executeRetrieve();
@@ -866,7 +883,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Test 1: First page with more results available (pageSize=10, total=15)
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -882,7 +899,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Test 2: Second page (last page, partial results: 5 items remaining)
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -899,7 +916,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Test 3: Empty results
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NonExistentPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -927,7 +944,7 @@ describe("SqlAdapter SQLite", () => {
     const all = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .find("users", (b) =>
+        .findNew("users", (b) =>
           b
             .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
             .orderByIndex("name_id_idx", "asc"),
@@ -937,7 +954,7 @@ describe("SqlAdapter SQLite", () => {
     })();
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .orderByIndex("name_id_idx", "asc")
@@ -948,7 +965,7 @@ describe("SqlAdapter SQLite", () => {
     })();
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .after(firstPage.cursor!)
@@ -980,7 +997,9 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the user to get their ID
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-execute-uow")
-      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")))
+      .findNew("users", (b) =>
+        b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")),
+      )
       .executeRetrieve();
 
     // Use handlerTx to increment age with optimistic locking
@@ -990,7 +1009,7 @@ describe("SqlAdapter SQLite", () => {
     const getUserById = (userId: typeof user.id) => {
       return createServiceTxBuilder(testSchema, currentUow!)
         .retrieve((uow) =>
-          uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+          uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
         )
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
@@ -1029,7 +1048,7 @@ describe("SqlAdapter SQLite", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1058,7 +1077,7 @@ describe("SqlAdapter SQLite", () => {
     // Get the user
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Version Conflict User SQLite")),
       )
       .executeRetrieve();
@@ -1083,7 +1102,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify the post was NOT created
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter((p) => p.title === "Should Not Be Created SQLite");

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-uow.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-uow.test.ts
@@ -163,7 +163,7 @@ describe("SqlAdapter SQLite", () => {
     });
 
     expectTypeOf<keyof typeof testSchema.tables>().toEqualTypeOf<
-      Parameters<typeof createUow.findNew>[0]
+      Parameters<typeof createUow.find>[0]
     >();
     expectTypeOf<keyof typeof testSchema.tables>().toEqualTypeOf<
       "users" | "emails" | "posts" | "comments" | "optional_emails"
@@ -178,7 +178,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify both users were created by fetching them
     const [allUsers] = await queryEngine
       .createUnitOfWork("get-all-users")
-      .findNew("users", (b) => b.whereIndex("primary"))
+      .find("users", (b) => b.whereIndex("primary"))
       .executeRetrieve();
 
     expect(allUsers).toHaveLength(2);
@@ -210,7 +210,7 @@ describe("SqlAdapter SQLite", () => {
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
       // Retrieval phase: find Alice
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     // Execute retrieval and transition to mutation phase
     const [users] = await uow.executeRetrieve();
@@ -229,7 +229,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify Alice was updated
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -255,7 +255,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify Alice was NOT updated
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -297,7 +297,7 @@ describe("SqlAdapter SQLite", () => {
 
     const verifyUow = queryEngine.createUnitOfWork("verify-duplicate-hook-id");
     const internalUow = verifyUow.forSchema(internalSchema);
-    const findUow = internalUow.findNew("fragno_hooks", (b) =>
+    const findUow = internalUow.find("fragno_hooks", (b) =>
       b.whereIndex("primary", (eb) => eb("id", "=", hookId)),
     );
     const [events] = await findUow.executeRetrieve();
@@ -317,7 +317,7 @@ describe("SqlAdapter SQLite", () => {
     // Count all users
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .findNew("users", (b) => b.whereIndex("primary").selectCount())
+      .find("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     // Tests are not isolated, so we can't use expect(totalCount).toBe(3)
@@ -340,7 +340,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch first page ordered by name
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .findNew("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
+      .find("users", (b) => b.whereIndex("name_idx").orderByIndex("name_idx", "asc").pageSize(2))
       .executeRetrieve();
 
     // Verify first page contains the first 2 users alphabetically
@@ -359,7 +359,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch next page using cursor
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx").orderByIndex("name_idx", "asc").after(cursor).pageSize(2),
       )
       .executeRetrieve();
@@ -387,7 +387,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the created user to get the proper ID
     const [usersResult] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Email User")))
       .executeRetrieve();
 
     expect(usersResult).toHaveLength(1);
@@ -407,7 +407,7 @@ describe("SqlAdapter SQLite", () => {
     // Test join query
     const uow = queryEngine
       .createUnitOfWork("test-joins")
-      .findNew("emails", (b) =>
+      .find("emails", (b) =>
         b
           .whereIndex("user_emails", (eb) => eb("user_id", "=", createdUser.id))
           .joinOne("user", "users", (builder) =>
@@ -452,7 +452,7 @@ describe("SqlAdapter SQLite", () => {
 
     const uow = queryEngine
       .createUnitOfWork("join-optional-email")
-      .findNew("optional_emails", (b) =>
+      .find("optional_emails", (b) =>
         b
           .whereIndex("primary")
           .joinOne("user", "users", (builder) =>
@@ -477,7 +477,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the created author to get the proper ID
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Blog Author")))
       .executeRetrieve();
 
     // Create a post by the author
@@ -492,9 +492,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the created post to get the proper ID
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .findNew("posts", (b) =>
-        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
-      )
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
       .executeRetrieve();
 
     // Create a commenter
@@ -505,7 +503,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the created commenter to get the proper ID
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Commenter User")))
       .executeRetrieve();
 
     // Create a comment on the post
@@ -519,7 +517,7 @@ describe("SqlAdapter SQLite", () => {
     const createdCommentId = createCommentUow.getCreatedIds()[0]!;
 
     // Now perform a complex nested join: comments -> post -> author, and comments -> commenter
-    const uow = queryEngine.createUnitOfWork("test-complex-joins").findNew("comments", (b) =>
+    const uow = queryEngine.createUnitOfWork("test-complex-joins").find("comments", (b) =>
       b
         .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
         .joinOne("post", "posts", (postBuilder) =>
@@ -614,7 +612,7 @@ describe("SqlAdapter SQLite", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -624,7 +622,7 @@ describe("SqlAdapter SQLite", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -634,7 +632,7 @@ describe("SqlAdapter SQLite", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -702,7 +700,7 @@ describe("SqlAdapter SQLite", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -726,7 +724,7 @@ describe("SqlAdapter SQLite", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-timestamp")
-      .findNew("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Timestamp User")))
       .executeRetrieve();
 
     // Create a post (note: SQLite schema doesn't have created_at column)
@@ -741,7 +739,7 @@ describe("SqlAdapter SQLite", () => {
     // Retrieve the post
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post-for-timestamp")
-      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     expect(post).toBeDefined();
@@ -796,12 +794,12 @@ describe("SqlAdapter SQLite", () => {
 
     const view1 = uow
       .forSchema(testSchema)
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Multi Schema User"))
           .select(["id", "name"]),
       )
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Multi Schema User"))
           .select(["name", "age"]),
@@ -809,7 +807,7 @@ describe("SqlAdapter SQLite", () => {
 
     const view2 = uow
       .forSchema(schema2)
-      .findNew("products", (b) => b.whereIndex("primary").select(["name", "price"]));
+      .find("products", (b) => b.whereIndex("primary").select(["name", "price"]));
 
     // Execute the retrieval phase once
     await uow.executeRetrieve();
@@ -883,7 +881,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Test 1: First page with more results available (pageSize=10, total=15)
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -899,7 +897,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Test 2: Second page (last page, partial results: 5 items remaining)
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -916,7 +914,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Test 3: Empty results
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NonExistentPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -944,7 +942,7 @@ describe("SqlAdapter SQLite", () => {
     const all = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findNew("users", (b) =>
+        .find("users", (b) =>
           b
             .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
             .orderByIndex("name_id_idx", "asc"),
@@ -954,7 +952,7 @@ describe("SqlAdapter SQLite", () => {
     })();
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .orderByIndex("name_id_idx", "asc")
@@ -965,7 +963,7 @@ describe("SqlAdapter SQLite", () => {
     })();
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .after(firstPage.cursor!)
@@ -997,9 +995,7 @@ describe("SqlAdapter SQLite", () => {
     // Fetch the user to get their ID
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-execute-uow")
-      .findNew("users", (b) =>
-        b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")),
-      )
+      .find("users", (b) => b.whereIndex("name_idx", (eb) => eb("name", "=", "Execute UOW User")))
       .executeRetrieve();
 
     // Use handlerTx to increment age with optimistic locking
@@ -1009,7 +1005,7 @@ describe("SqlAdapter SQLite", () => {
     const getUserById = (userId: typeof user.id) => {
       return createServiceTxBuilder(testSchema, currentUow!)
         .retrieve((uow) =>
-          uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+          uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
         )
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
@@ -1048,7 +1044,7 @@ describe("SqlAdapter SQLite", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1077,7 +1073,7 @@ describe("SqlAdapter SQLite", () => {
     // Get the user
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Version Conflict User SQLite")),
       )
       .executeRetrieve();
@@ -1102,7 +1098,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify the post was NOT created
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter((p) => p.title === "Should Not Be Created SQLite");

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlocal.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlocal.test.ts
@@ -81,7 +81,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Verify initial balances
     const initialAccount1 = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirstNew("accounts", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirst("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account1Id));
       });
       await uow.executeRetrieve();
@@ -89,7 +89,7 @@ describe("SqlAdapter SQLite", () => {
     })();
 
     const initialAccount2 = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirstNew("accounts", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirst("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account2Id));
       });
       await uow.executeRetrieve();
@@ -105,10 +105,10 @@ describe("SqlAdapter SQLite", () => {
     // Read current balances - chain the calls to properly set generics
     const uow = queryEngine
       .createUnitOfWork("balance-transfer")
-      .findNew("accounts", (b) => {
+      .find("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account1Id));
       })
-      .findNew("accounts", (b) => {
+      .find("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account2Id));
       });
 
@@ -139,7 +139,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Verify final balances
     const finalAccount1 = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirstNew("accounts", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirst("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account1Id));
       });
       await uow.executeRetrieve();
@@ -147,7 +147,7 @@ describe("SqlAdapter SQLite", () => {
     })();
 
     const finalAccount2 = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirstNew("accounts", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirst("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account2Id));
       });
       await uow.executeRetrieve();
@@ -163,7 +163,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Verify transaction was recorded
     const transaction = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirstNew("transactions", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirst("transactions", (b) => {
         return b.whereIndex("primary");
       });
       await uow.executeRetrieve();
@@ -199,7 +199,7 @@ describe("SqlAdapter SQLite", () => {
     const uow = queryEngine
       .createUnitOfWork("update-account-balance")
       // Retrieval phase: find the account
-      .findNew("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)));
+      .find("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)));
 
     // Execute retrieval and transition to mutation phase
     const [accounts] = await uow.executeRetrieve();
@@ -218,7 +218,7 @@ describe("SqlAdapter SQLite", () => {
     const updatedAccount = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("accounts", (b) =>
+        .findFirst("accounts", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)),
         );
       await uow.executeRetrieve();
@@ -248,7 +248,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify the account was NOT updated
     const [[unchangedAccount]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .findNew("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)))
+      .find("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)))
       .executeRetrieve();
 
     expect(unchangedAccount).toMatchObject({

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlocal.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlocal.test.ts
@@ -19,19 +19,9 @@ describe("SqlAdapter SQLite", () => {
       .addTable("transactions", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("fromAccountId", referenceColumn())
-          .addColumn("toAccountId", referenceColumn())
+          .addColumn("fromAccountId", referenceColumn({ table: "accounts" }))
+          .addColumn("toAccountId", referenceColumn({ table: "accounts" }))
           .addColumn("amount", column("integer"));
-      })
-      .addReference("fromAccount", {
-        type: "one",
-        from: { table: "transactions", column: "fromAccountId" },
-        to: { table: "accounts", column: "id" },
-      })
-      .addReference("toAccount", {
-        type: "one",
-        from: { table: "transactions", column: "toAccountId" },
-        to: { table: "accounts", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlocal.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlocal.test.ts
@@ -81,7 +81,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Verify initial balances
     const initialAccount1 = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirst("accounts", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirstNew("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account1Id));
       });
       await uow.executeRetrieve();
@@ -89,7 +89,7 @@ describe("SqlAdapter SQLite", () => {
     })();
 
     const initialAccount2 = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirst("accounts", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirstNew("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account2Id));
       });
       await uow.executeRetrieve();
@@ -105,10 +105,10 @@ describe("SqlAdapter SQLite", () => {
     // Read current balances - chain the calls to properly set generics
     const uow = queryEngine
       .createUnitOfWork("balance-transfer")
-      .find("accounts", (b) => {
+      .findNew("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account1Id));
       })
-      .find("accounts", (b) => {
+      .findNew("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account2Id));
       });
 
@@ -139,7 +139,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Verify final balances
     const finalAccount1 = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirst("accounts", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirstNew("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account1Id));
       });
       await uow.executeRetrieve();
@@ -147,7 +147,7 @@ describe("SqlAdapter SQLite", () => {
     })();
 
     const finalAccount2 = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirst("accounts", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirstNew("accounts", (b) => {
         return b.whereIndex("primary", (eb) => eb("id", "=", account2Id));
       });
       await uow.executeRetrieve();
@@ -163,7 +163,7 @@ describe("SqlAdapter SQLite", () => {
 
     // Verify transaction was recorded
     const transaction = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findFirst("transactions", (b) => {
+      const uow = queryEngine.createUnitOfWork("read").findFirstNew("transactions", (b) => {
         return b.whereIndex("primary");
       });
       await uow.executeRetrieve();
@@ -199,7 +199,7 @@ describe("SqlAdapter SQLite", () => {
     const uow = queryEngine
       .createUnitOfWork("update-account-balance")
       // Retrieval phase: find the account
-      .find("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)));
+      .findNew("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)));
 
     // Execute retrieval and transition to mutation phase
     const [accounts] = await uow.executeRetrieve();
@@ -218,7 +218,7 @@ describe("SqlAdapter SQLite", () => {
     const updatedAccount = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("accounts", (b) =>
+        .findFirstNew("accounts", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)),
         );
       await uow.executeRetrieve();
@@ -248,7 +248,7 @@ describe("SqlAdapter SQLite", () => {
     // Verify the account was NOT updated
     const [[unchangedAccount]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .find("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)))
+      .findNew("accounts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialAccountId)))
       .executeRetrieve();
 
     expect(unchangedAccount).toMatchObject({

--- a/packages/fragno-db/src/adapters/generic-sql/uow-decoder.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/uow-decoder.ts
@@ -1,5 +1,6 @@
 import type { NamingResolver } from "../../naming/sql-naming";
 import { createCursorFromRecord, type Cursor, type CursorResult } from "../../query/cursor";
+import { decodeQueryTreeRow } from "../../query/unit-of-work/query-tree-decoder";
 import type { UOWDecoder } from "../../query/unit-of-work/unit-of-work";
 import type { RetrievalOperation } from "../../query/unit-of-work/unit-of-work";
 import { decodeResult } from "../../query/value-decoding";
@@ -71,13 +72,21 @@ export class UnitOfWorkDecoder implements UOWDecoder<unknown> {
     }
 
     const decodedRows = rows.map((row) =>
-      decodeResult(
-        row,
-        operation.table,
-        this.#driverConfig,
-        this.#sqliteStorageMode,
-        this.#resolver,
-      ),
+      operation.options.queryTree
+        ? decodeQueryTreeRow(
+            row,
+            operation.options.queryTree,
+            this.#driverConfig,
+            this.#sqliteStorageMode,
+            this.#resolver,
+          )
+        : decodeResult(
+            row,
+            operation.table,
+            this.#driverConfig,
+            this.#sqliteStorageMode,
+            this.#resolver,
+          ),
     );
 
     if (operation.withCursor) {

--- a/packages/fragno-db/src/adapters/generic-sql/uow-encoder.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/uow-encoder.test.ts
@@ -26,7 +26,7 @@ describe("UnitOfWorkEncoder", () => {
       .addTable("posts", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("userId", referenceColumn())
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .addColumn("title", column("string"));
       });
   });

--- a/packages/fragno-db/src/adapters/in-memory/condition-evaluator.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/condition-evaluator.test.ts
@@ -156,13 +156,8 @@ describe("in-memory condition evaluator", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("title", column("string"))
-            .addColumn("userId", referenceColumn()),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        }),
+            .addColumn("userId", referenceColumn({ table: "users" })),
+        ),
     );
 
     const namespaceStore = createNamespaceStore(refSchema);

--- a/packages/fragno-db/src/adapters/in-memory/condition-evaluator.ts
+++ b/packages/fragno-db/src/adapters/in-memory/condition-evaluator.ts
@@ -3,7 +3,7 @@ import type { Condition } from "../../query/condition-builder";
 import { getDbNowOffsetMs, isDbNow } from "../../query/db-now";
 import { ReferenceSubquery, resolveFragnoIdValue } from "../../query/value-encoding";
 import type { AnyColumn, AnyTable } from "../../schema/create";
-import { Column, FragnoId, FragnoReference } from "../../schema/create";
+import { Column, FragnoId, FragnoReference, getTableForeignKey } from "../../schema/create";
 import { resolveReferenceSubquery } from "./reference-resolution";
 import type { InMemoryNamespaceStore, InMemoryRow } from "./store";
 import { normalizeIndexValue } from "./store";
@@ -42,16 +42,14 @@ const resolveReferenceValue = (
       throw new Error("In-memory condition evaluation requires a namespace store.");
     }
 
-    const relation = Object.values(table.relations).find((rel) =>
-      rel.on.some(([localCol]) => localCol === column.name),
-    );
-    if (!relation) {
-      throw new Error(`Missing relation for reference column "${column.name}".`);
+    const foreignKey = getTableForeignKey(table, column.name);
+    if (!foreignKey) {
+      throw new Error(`Missing foreign key for reference column "${column.name}".`);
     }
 
     return resolveReferenceSubquery(
       namespaceStore,
-      new ReferenceSubquery(relation.table, value),
+      new ReferenceSubquery(foreignKey.referencedTable, value),
       resolver,
     );
   }

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-uow.mutations.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-uow.mutations.test.ts
@@ -22,13 +22,8 @@ const fkSchema = schema("fk", (s) =>
       t
         .addColumn("id", idColumn())
         .addColumn("title", column("string"))
-        .addColumn("authorId", referenceColumn()),
-    )
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
-    }),
+        .addColumn("authorId", referenceColumn({ table: "users" })),
+    ),
 );
 
 const joinOnlySchema = schema("join-only", (s) =>
@@ -44,13 +39,7 @@ const joinOnlySchema = schema("join-only", (s) =>
         .addColumn("id", idColumn())
         .addColumn("email", column("string"))
         .createIndex("invitations_email_idx", ["email"]),
-    )
-    .addReference("invitedUser", {
-      type: "one",
-      from: { table: "invitations", column: "email" },
-      to: { table: "users", column: "email" },
-      foreignKey: false,
-    }),
+    ),
 );
 
 const createTestUowFactory = () => {

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-uow.mutations.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-uow.mutations.test.ts
@@ -108,7 +108,7 @@ describe("in-memory uow mutations", () => {
     expect(updateResult.success).toBe(true);
 
     const findAfterUpdate = createUow();
-    findAfterUpdate.find("users", (b) => b.whereIndex("primary"));
+    findAfterUpdate.findNew("users", (b) => b.whereIndex("primary"));
     const rows = (await findAfterUpdate.executeRetrieve()) as unknown[];
     const updatedUser = (rows[0] as { id: FragnoId; name: string }[])[0];
 
@@ -122,7 +122,7 @@ describe("in-memory uow mutations", () => {
     expect(staleResult.success).toBe(false);
 
     const findAfterStale = createUow();
-    findAfterStale.find("users", (b) => b.whereIndex("primary"));
+    findAfterStale.findNew("users", (b) => b.whereIndex("primary"));
     const staleRows = (await findAfterStale.executeRetrieve()) as unknown[];
     const staleUser = (staleRows[0] as { id: FragnoId; name: string }[])[0];
 
@@ -162,7 +162,7 @@ describe("in-memory uow mutations", () => {
     expect(badDeleteResult.success).toBe(false);
 
     const findBeforeDelete = createUow();
-    findBeforeDelete.find("users", (b) => b.whereIndex("primary"));
+    findBeforeDelete.findNew("users", (b) => b.whereIndex("primary"));
     const beforeDeleteRows = (await findBeforeDelete.executeRetrieve()) as unknown[];
     expect(beforeDeleteRows[0]).toHaveLength(1);
 
@@ -172,7 +172,7 @@ describe("in-memory uow mutations", () => {
     expect(deleteResult.success).toBe(true);
 
     const findAfterDelete = createUow();
-    findAfterDelete.find("users", (b) => b.whereIndex("primary"));
+    findAfterDelete.findNew("users", (b) => b.whereIndex("primary"));
     const afterDeleteRows = (await findAfterDelete.executeRetrieve()) as unknown[];
     expect(afterDeleteRows[0]).toHaveLength(0);
   });
@@ -302,7 +302,7 @@ describe("in-memory uow mutations", () => {
     expect(secondResult.success).toBe(true);
 
     const findDupes = createUow();
-    findDupes.find("users", (b) => b.whereIndex("primary"));
+    findDupes.findNew("users", (b) => b.whereIndex("primary"));
     const dupeRows = (await findDupes.executeRetrieve()) as unknown[];
     expect(dupeRows[0]).toHaveLength(2);
 

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-uow.mutations.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-uow.mutations.test.ts
@@ -108,7 +108,7 @@ describe("in-memory uow mutations", () => {
     expect(updateResult.success).toBe(true);
 
     const findAfterUpdate = createUow();
-    findAfterUpdate.findNew("users", (b) => b.whereIndex("primary"));
+    findAfterUpdate.find("users", (b) => b.whereIndex("primary"));
     const rows = (await findAfterUpdate.executeRetrieve()) as unknown[];
     const updatedUser = (rows[0] as { id: FragnoId; name: string }[])[0];
 
@@ -122,7 +122,7 @@ describe("in-memory uow mutations", () => {
     expect(staleResult.success).toBe(false);
 
     const findAfterStale = createUow();
-    findAfterStale.findNew("users", (b) => b.whereIndex("primary"));
+    findAfterStale.find("users", (b) => b.whereIndex("primary"));
     const staleRows = (await findAfterStale.executeRetrieve()) as unknown[];
     const staleUser = (staleRows[0] as { id: FragnoId; name: string }[])[0];
 
@@ -162,7 +162,7 @@ describe("in-memory uow mutations", () => {
     expect(badDeleteResult.success).toBe(false);
 
     const findBeforeDelete = createUow();
-    findBeforeDelete.findNew("users", (b) => b.whereIndex("primary"));
+    findBeforeDelete.find("users", (b) => b.whereIndex("primary"));
     const beforeDeleteRows = (await findBeforeDelete.executeRetrieve()) as unknown[];
     expect(beforeDeleteRows[0]).toHaveLength(1);
 
@@ -172,7 +172,7 @@ describe("in-memory uow mutations", () => {
     expect(deleteResult.success).toBe(true);
 
     const findAfterDelete = createUow();
-    findAfterDelete.findNew("users", (b) => b.whereIndex("primary"));
+    findAfterDelete.find("users", (b) => b.whereIndex("primary"));
     const afterDeleteRows = (await findAfterDelete.executeRetrieve()) as unknown[];
     expect(afterDeleteRows[0]).toHaveLength(0);
   });
@@ -302,7 +302,7 @@ describe("in-memory uow mutations", () => {
     expect(secondResult.success).toBe(true);
 
     const findDupes = createUow();
-    findDupes.findNew("users", (b) => b.whereIndex("primary"));
+    findDupes.find("users", (b) => b.whereIndex("primary"));
     const dupeRows = (await findDupes.executeRetrieve()) as unknown[];
     expect(dupeRows[0]).toHaveLength(2);
 

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-uow.retrieval.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-uow.retrieval.test.ts
@@ -157,20 +157,26 @@ describe("in-memory uow retrieval", () => {
     await createData.executeMutations();
 
     const query = createUow();
-    query.find("users", (b) =>
+    query.findNew("users", (b) =>
       b
         .whereIndex("primary", (eb) => eb("id", "=", "user-1"))
-        .join((jb) => jb.memberships((mb) => mb.select(["id"]))),
+        .joinMany("memberships", "memberships", (mb) =>
+          mb
+            .onIndex("idx_memberships_user", (eb) => eb("userId", "=", eb.parent("id")))
+            .select(["id"]),
+        ),
     );
 
     const [users] = (await query.executeRetrieve()) as Array<
-      Array<{ memberships?: { id: { externalId: string } } }>
+      Array<{ memberships?: Array<{ id: { externalId: string } }> }>
     >;
 
     expect(users).toHaveLength(1);
-    expect(users[0].memberships).toMatchObject({
-      id: expect.objectContaining({ externalId: "membership-1" }),
-    });
+    expect(users[0].memberships).toMatchObject([
+      {
+        id: expect.objectContaining({ externalId: "membership-1" }),
+      },
+    ]);
   });
 
   it("joins external-id relations without coercing both sides to internal ids", async () => {
@@ -202,10 +208,12 @@ describe("in-memory uow retrieval", () => {
     await createData.executeMutations();
 
     const query = createUow();
-    query.find("left", (b) =>
+    query.findNew("left", (b) =>
       b
         .whereIndex("primary", (eb) => eb("id", "=", "shared-id"))
-        .join((jb) => jb["rightMatch"]((rb) => rb.select(["id", "label"]))),
+        .joinOne("rightMatch", "right", (rb) =>
+          rb.onIndex("primary", (eb) => eb("id", "=", eb.parent("id"))).select(["id", "label"]),
+        ),
     );
 
     const [rows] = (await query.executeRetrieve()) as Array<
@@ -216,6 +224,151 @@ describe("in-memory uow retrieval", () => {
     expect(rows[0].rightMatch).toMatchObject({
       id: expect.objectContaining({ externalId: "shared-id" }),
       label: "Right Shared",
+    });
+  });
+
+  it("supports query-tree joins without schema relations", async () => {
+    const { createUow } = createHarness();
+
+    const createData = createUow();
+    createData.create("users", {
+      id: "user-1",
+      name: "Ada",
+      email: "ada@example.com",
+    });
+    createData.create("users", {
+      id: "user-2",
+      name: "Grace",
+      email: "grace@example.com",
+    });
+    createData.create("memberships", {
+      id: "membership-1",
+      userId: "user-1",
+    });
+    createData.create("memberships", {
+      id: "membership-2",
+      userId: "user-1",
+    });
+    createData.create("memberships", {
+      id: "membership-3",
+      userId: "user-2",
+    });
+    await createData.executeMutations();
+
+    const query = createUow();
+    query.findNew("users", (q) =>
+      q
+        .whereIndex("primary", (eb) => eb("id", "=", "user-1"))
+        .select(["id", "name"])
+        .joinMany("memberships", "memberships", (memberships) =>
+          memberships
+            .onIndex("idx_memberships_user", (eb) => eb("userId", "=", eb.parent("id")))
+            .select(["id", "userId"])
+            .joinOne("memberUser", "users", (memberUser) =>
+              memberUser
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                .select(["id", "name"]),
+            ),
+        ),
+    );
+
+    const [users] = (await query.executeRetrieve()) as Array<
+      Array<{
+        id: { externalId: string };
+        name: string;
+        memberships: Array<{
+          id: { externalId: string };
+          memberUser: { id: { externalId: string }; name: string } | null;
+        }>;
+      }>
+    >;
+
+    expect(users).toHaveLength(1);
+    expect(users[0]).toMatchObject({
+      id: expect.objectContaining({ externalId: "user-1" }),
+      name: "Ada",
+      memberships: expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.objectContaining({ externalId: "membership-1" }),
+          memberUser: expect.objectContaining({
+            id: expect.objectContaining({ externalId: "user-1" }),
+            name: "Ada",
+          }),
+        }),
+        expect.objectContaining({
+          id: expect.objectContaining({ externalId: "membership-2" }),
+          memberUser: expect.objectContaining({
+            id: expect.objectContaining({ externalId: "user-1" }),
+            name: "Ada",
+          }),
+        }),
+      ]),
+    });
+  });
+
+  it("supports findFirstNew and child whereIndex filtering", async () => {
+    const { createUow } = createHarness();
+
+    const createData = createUow();
+    createData.create("users", {
+      id: "user-1",
+      name: "Ada",
+      email: "ada@example.com",
+    });
+    createData.create("users", {
+      id: "user-2",
+      name: "Grace",
+      email: "grace@example.com",
+    });
+    createData.create("memberships", {
+      id: "membership-1",
+      userId: "user-1",
+    });
+    await createData.executeMutations();
+
+    const query = createUow();
+    query.findFirstNew("users", (q) =>
+      q
+        .whereIndex("idx_users_name", (eb) => eb("name", "=", "Ada"))
+        .select(["id", "name"])
+        .joinMany("memberships", "memberships", (memberships) =>
+          memberships
+            .onIndex("idx_memberships_user", (eb) => eb("userId", "=", eb.parent("id")))
+            .select(["id", "userId"])
+            .joinOne("memberUser", "users", (memberUser) =>
+              memberUser
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+                .whereIndex("idx_users_name", (eb) => eb("name", "=", "Ada"))
+                .select(["id", "name"]),
+            ),
+        ),
+    );
+
+    const [[user]] = (await query.executeRetrieve()) as Array<
+      [
+        {
+          id: { externalId: string };
+          name: string;
+          memberships: Array<{
+            id: { externalId: string };
+            memberUser: { id: { externalId: string }; name: string } | null;
+          }>;
+        } | null,
+      ]
+    >;
+
+    expect(user).toMatchObject({
+      id: expect.objectContaining({ externalId: "user-1" }),
+      name: "Ada",
+      memberships: [
+        {
+          id: expect.objectContaining({ externalId: "membership-1" }),
+          memberUser: {
+            id: expect.objectContaining({ externalId: "user-1" }),
+            name: "Ada",
+          },
+        },
+      ],
     });
   });
 
@@ -236,7 +389,7 @@ describe("in-memory uow retrieval", () => {
     await createData.executeMutations();
 
     const query = createUow();
-    query.findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", "user-2")));
+    query.findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", "user-2")));
 
     const [[user]] = (await query.executeRetrieve()) as Array<
       [

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-uow.retrieval.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-uow.retrieval.test.ts
@@ -157,7 +157,7 @@ describe("in-memory uow retrieval", () => {
     await createData.executeMutations();
 
     const query = createUow();
-    query.findNew("users", (b) =>
+    query.find("users", (b) =>
       b
         .whereIndex("primary", (eb) => eb("id", "=", "user-1"))
         .joinMany("memberships", "memberships", (mb) =>
@@ -208,7 +208,7 @@ describe("in-memory uow retrieval", () => {
     await createData.executeMutations();
 
     const query = createUow();
-    query.findNew("left", (b) =>
+    query.find("left", (b) =>
       b
         .whereIndex("primary", (eb) => eb("id", "=", "shared-id"))
         .joinOne("rightMatch", "right", (rb) =>
@@ -256,7 +256,7 @@ describe("in-memory uow retrieval", () => {
     await createData.executeMutations();
 
     const query = createUow();
-    query.findNew("users", (q) =>
+    query.find("users", (q) =>
       q
         .whereIndex("primary", (eb) => eb("id", "=", "user-1"))
         .select(["id", "name"])
@@ -306,7 +306,7 @@ describe("in-memory uow retrieval", () => {
     });
   });
 
-  it("supports findFirstNew and child whereIndex filtering", async () => {
+  it("supports findFirst and child whereIndex filtering", async () => {
     const { createUow } = createHarness();
 
     const createData = createUow();
@@ -327,7 +327,7 @@ describe("in-memory uow retrieval", () => {
     await createData.executeMutations();
 
     const query = createUow();
-    query.findFirstNew("users", (q) =>
+    query.findFirst("users", (q) =>
       q
         .whereIndex("idx_users_name", (eb) => eb("name", "=", "Ada"))
         .select(["id", "name"])
@@ -389,7 +389,7 @@ describe("in-memory uow retrieval", () => {
     await createData.executeMutations();
 
     const query = createUow();
-    query.findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", "user-2")));
+    query.findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", "user-2")));
 
     const [[user]] = (await query.executeRetrieve()) as Array<
       [

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-uow.retrieval.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-uow.retrieval.test.ts
@@ -2,14 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CompiledJoin } from "../../query/find-options";
 import { UnitOfWork, type RetrievalOperation } from "../../query/unit-of-work/unit-of-work";
-import {
-  column,
-  ExplicitRelationInit,
-  idColumn,
-  referenceColumn,
-  schema,
-  type AnySchema,
-} from "../../schema/create";
+import { column, getTableRelations, idColumn, referenceColumn, schema } from "../../schema/create";
 import {
   createInMemoryUowCompiler,
   createInMemoryUowExecutor,
@@ -31,36 +24,14 @@ const joinSchema = schema("join", (s) =>
       t
         .addColumn("id", idColumn())
         .addColumn("title", column("string"))
-        .addColumn("authorId", referenceColumn()),
+        .addColumn("authorId", referenceColumn({ table: "users" })),
     )
     .addTable("memberships", (t) =>
       t
         .addColumn("id", idColumn())
-        .addColumn("userId", referenceColumn())
+        .addColumn("userId", referenceColumn({ table: "users" }))
         .createIndex("idx_memberships_user", ["userId"]),
-    )
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("membershipUser", {
-      type: "one",
-      from: { table: "memberships", column: "userId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("memberships", {
-      type: "many",
-      from: { table: "users", column: "id" },
-      to: { table: "memberships", column: "userId" },
-      foreignKey: false,
-    }),
-);
-
-const externalJoinSchema = schema("external-join", (s) =>
-  s
-    .addTable("left", (t) => t.addColumn("id", idColumn()).addColumn("label", column("string")))
-    .addTable("right", (t) => t.addColumn("id", idColumn()).addColumn("label", column("string"))),
+    ),
 );
 
 const createHarness = () => {
@@ -73,18 +44,6 @@ const createHarness = () => {
   return {
     createUow: () => new UnitOfWork(compiler, executor, decoder).forSchema(joinSchema),
     executor,
-  };
-};
-
-const createExternalJoinHarness = () => {
-  const store = createInMemoryStore();
-  const options = resolveInMemoryAdapterOptions({ idSeed: "seed" });
-  const compiler = createInMemoryUowCompiler();
-  const executor = createInMemoryUowExecutor(store, options);
-  const decoder = new InMemoryUowDecoder();
-
-  return {
-    createUow: () => new UnitOfWork(compiler, executor, decoder).forSchema(externalJoinSchema),
   };
 };
 
@@ -105,7 +64,7 @@ describe("in-memory uow retrieval", () => {
     });
     await createData.executeMutations();
 
-    const relation = joinSchema.tables.posts.relations.author;
+    const relation = getTableRelations(joinSchema.tables.posts)["author"];
     const join: CompiledJoin = {
       relation,
       options: {
@@ -134,9 +93,7 @@ describe("in-memory uow retrieval", () => {
       },
     } satisfies RetrievalOperation<typeof joinSchema>;
 
-    const opForExecutor = op as unknown as RetrievalOperation<AnySchema>;
-
-    await expect(executor.executeRetrievalPhase([opForExecutor])).rejects.toThrow(
+    await expect(executor.executeRetrievalPhase([op])).rejects.toThrow(
       'In-memory adapter only supports orderByIndex; received orderBy on table "users".',
     );
   });
@@ -156,8 +113,7 @@ describe("in-memory uow retrieval", () => {
     });
     await createData.executeMutations();
 
-    const query = createUow();
-    query.find("users", (b) =>
+    const query = createUow().find("users", (b) =>
       b
         .whereIndex("primary", (eb) => eb("id", "=", "user-1"))
         .joinMany("memberships", "memberships", (mb) =>
@@ -167,9 +123,7 @@ describe("in-memory uow retrieval", () => {
         ),
     );
 
-    const [users] = (await query.executeRetrieve()) as Array<
-      Array<{ memberships?: Array<{ id: { externalId: string } }> }>
-    >;
+    const [users] = await query.executeRetrieve();
 
     expect(users).toHaveLength(1);
     expect(users[0].memberships).toMatchObject([
@@ -177,54 +131,6 @@ describe("in-memory uow retrieval", () => {
         id: expect.objectContaining({ externalId: "membership-1" }),
       },
     ]);
-  });
-
-  it("joins external-id relations without coercing both sides to internal ids", async () => {
-    const { createUow } = createExternalJoinHarness();
-
-    const relationInit = new ExplicitRelationInit(
-      "one",
-      externalJoinSchema.tables.right,
-      externalJoinSchema.tables.left,
-      { foreignKey: false },
-    );
-    relationInit.on.push(["id", "id"]);
-    const relation = relationInit.init("rightMatch");
-    externalJoinSchema.tables.left.relations["rightMatch"] = relation;
-
-    const createData = createUow();
-    createData.create("left", {
-      id: "left-1",
-      label: "Left One",
-    });
-    createData.create("left", {
-      id: "shared-id",
-      label: "Left Shared",
-    });
-    createData.create("right", {
-      id: "shared-id",
-      label: "Right Shared",
-    });
-    await createData.executeMutations();
-
-    const query = createUow();
-    query.find("left", (b) =>
-      b
-        .whereIndex("primary", (eb) => eb("id", "=", "shared-id"))
-        .joinOne("rightMatch", "right", (rb) =>
-          rb.onIndex("primary", (eb) => eb("id", "=", eb.parent("id"))).select(["id", "label"]),
-        ),
-    );
-
-    const [rows] = (await query.executeRetrieve()) as Array<
-      Array<{ rightMatch?: { id: { externalId: string }; label: string } }>
-    >;
-
-    expect(rows).toHaveLength(1);
-    expect(rows[0].rightMatch).toMatchObject({
-      id: expect.objectContaining({ externalId: "shared-id" }),
-      label: "Right Shared",
-    });
   });
 
   it("supports query-tree joins without schema relations", async () => {
@@ -255,8 +161,7 @@ describe("in-memory uow retrieval", () => {
     });
     await createData.executeMutations();
 
-    const query = createUow();
-    query.find("users", (q) =>
+    const query = createUow().find("users", (q) =>
       q
         .whereIndex("primary", (eb) => eb("id", "=", "user-1"))
         .select(["id", "name"])
@@ -272,16 +177,7 @@ describe("in-memory uow retrieval", () => {
         ),
     );
 
-    const [users] = (await query.executeRetrieve()) as Array<
-      Array<{
-        id: { externalId: string };
-        name: string;
-        memberships: Array<{
-          id: { externalId: string };
-          memberUser: { id: { externalId: string }; name: string } | null;
-        }>;
-      }>
-    >;
+    const [users] = await query.executeRetrieve();
 
     expect(users).toHaveLength(1);
     expect(users[0]).toMatchObject({
@@ -326,8 +222,7 @@ describe("in-memory uow retrieval", () => {
     });
     await createData.executeMutations();
 
-    const query = createUow();
-    query.findFirst("users", (q) =>
+    const query = createUow().findFirst("users", (q) =>
       q
         .whereIndex("idx_users_name", (eb) => eb("name", "=", "Ada"))
         .select(["id", "name"])
@@ -344,18 +239,7 @@ describe("in-memory uow retrieval", () => {
         ),
     );
 
-    const [[user]] = (await query.executeRetrieve()) as Array<
-      [
-        {
-          id: { externalId: string };
-          name: string;
-          memberships: Array<{
-            id: { externalId: string };
-            memberUser: { id: { externalId: string }; name: string } | null;
-          }>;
-        } | null,
-      ]
-    >;
+    const [user] = await query.executeRetrieve();
 
     expect(user).toMatchObject({
       id: expect.objectContaining({ externalId: "user-1" }),
@@ -388,17 +272,11 @@ describe("in-memory uow retrieval", () => {
     });
     await createData.executeMutations();
 
-    const query = createUow();
-    query.findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", "user-2")));
+    const query = createUow().findFirst("users", (b) =>
+      b.whereIndex("primary", (eb) => eb("id", "=", "user-2")),
+    );
 
-    const [[user]] = (await query.executeRetrieve()) as Array<
-      [
-        {
-          id: { externalId: string };
-          name: string;
-        } | null,
-      ]
-    >;
+    const [user] = await query.executeRetrieve();
 
     expect(user).toMatchObject({
       id: expect.objectContaining({ externalId: "user-2" }),

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-uow.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-uow.ts
@@ -39,7 +39,7 @@ import {
   ReferenceSubquery,
 } from "../../query/value-encoding";
 import type { AnySchema, AnyTable } from "../../schema/create";
-import { FragnoId, FragnoReference } from "../../schema/create";
+import { FragnoId, FragnoReference, getTableRelations } from "../../schema/create";
 import { SQLocalDriverConfig } from "../generic-sql/driver-config";
 import { evaluateCondition } from "./condition-evaluator";
 import type { ResolvedInMemoryAdapterOptions } from "./options";
@@ -463,7 +463,7 @@ const enforceOutgoingForeignKeys = (
   columnsToCheck?: Set<string>,
   resolver?: NamingResolver,
 ): void => {
-  for (const relation of Object.values(table.relations)) {
+  for (const relation of Object.values(getTableRelations(table))) {
     if (relation.type !== "one" || relation.foreignKey === false) {
       continue;
     }
@@ -530,7 +530,7 @@ const enforceNoIncomingForeignKeys = (
   resolver?: NamingResolver,
 ): void => {
   for (const sourceTable of Object.values(schema.tables)) {
-    for (const relation of Object.values(sourceTable.relations)) {
+    for (const relation of Object.values(getTableRelations(sourceTable))) {
       if (relation.type !== "one" || relation.foreignKey === false) {
         continue;
       }
@@ -1638,7 +1638,7 @@ export class InMemoryUowDecoder implements UOWDecoder<InMemoryRawResult> {
 
       const relationName = key.slice(0, colonIndex);
       const remainder = key.slice(colonIndex + 1);
-      const relation = table.relations[relationName];
+      const relation = getTableRelations(table)[relationName];
       if (!relation) {
         continue;
       }
@@ -1648,7 +1648,7 @@ export class InMemoryUowDecoder implements UOWDecoder<InMemoryRawResult> {
     }
 
     for (const relationName in relationData) {
-      const relation = table.relations[relationName];
+      const relation = getTableRelations(table)[relationName];
       if (!relation) {
         continue;
       }

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-uow.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-uow.ts
@@ -43,6 +43,7 @@ import { FragnoId, FragnoReference } from "../../schema/create";
 import { SQLocalDriverConfig } from "../generic-sql/driver-config";
 import { evaluateCondition } from "./condition-evaluator";
 import type { ResolvedInMemoryAdapterOptions } from "./options";
+import { buildQueryTreeRowRaw } from "./query-tree";
 import { resolveReferenceSubqueries } from "./reference-resolution";
 import type {
   InMemoryNamespaceStore,
@@ -706,9 +707,11 @@ const findRows = (
 
   const entries = orderIndex.index.scan(scanOptions);
 
-  const whereResult = op.options.where
-    ? buildCondition(table.columns, op.options.where)
-    : undefined;
+  const whereResult = op.options.queryTree
+    ? op.options.queryTree.where
+    : op.options.where
+      ? buildCondition(table.columns, op.options.where)
+      : undefined;
 
   if (whereResult === false) {
     return [];
@@ -723,6 +726,23 @@ const findRows = (
       continue;
     }
     if (condition && !evaluateCondition(condition, table, row, namespaceStore, resolver, now)) {
+      continue;
+    }
+
+    if (op.options.queryTree) {
+      results.push(
+        buildQueryTreeRowRaw(
+          op.options.queryTree,
+          row,
+          namespaceStore,
+          resolver,
+          now,
+          op.readTracking,
+        ),
+      );
+      if (limit !== undefined && results.length >= limit) {
+        break;
+      }
       continue;
     }
 
@@ -1565,7 +1585,11 @@ export class InMemoryUowDecoder implements UOWDecoder<InMemoryRawResult> {
 
       const resolver = getResolver(op.schema, op.namespace, this.#resolverFactory);
       const rows = result as InMemoryRow[];
-      const decodedRows = rows.map((row) => this.decodeRow(row, op.table, resolver));
+      const decodedRows = rows.map((row) =>
+        op.options.queryTree
+          ? this.decodeQueryTreeRow(row, op.options.queryTree, resolver)
+          : this.decodeRow(row, op.table, resolver),
+      );
 
       if (op.withCursor) {
         return this.decodeCursorResult(decodedRows, op.table, op);
@@ -1669,6 +1693,32 @@ export class InMemoryUowDecoder implements UOWDecoder<InMemoryRawResult> {
       }
 
       output[key] = columnValues[key];
+    }
+
+    return output;
+  }
+
+  private decodeQueryTreeRow(
+    row: InMemoryRow,
+    node:
+      | import("../../query/unit-of-work/query-tree").CompiledQueryTreeRootNode
+      | import("../../query/unit-of-work/query-tree").CompiledQueryTreeChildNode,
+    resolver?: NamingResolver,
+  ): Record<string, unknown> {
+    const output = this.decodeRow(row, node.table, resolver);
+
+    for (const child of node.children) {
+      const value = row[child.alias];
+      if (child.cardinality === "many") {
+        output[child.alias] = Array.isArray(value)
+          ? value.map((item) => this.decodeQueryTreeRow(item as InMemoryRow, child, resolver))
+          : [];
+      } else {
+        output[child.alias] =
+          value && typeof value === "object"
+            ? this.decodeQueryTreeRow(value as InMemoryRow, child, resolver)
+            : null;
+      }
     }
 
     return output;

--- a/packages/fragno-db/src/adapters/in-memory/outbox.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/outbox.test.ts
@@ -25,13 +25,8 @@ const buildOutboxSchema = () =>
       .addTable("posts", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("authorId", referenceColumn())
+          .addColumn("authorId", referenceColumn({ table: "users" }))
           .addColumn("title", column("string"));
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "authorId" },
-        to: { table: "users", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/adapters/in-memory/outbox.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/outbox.test.ts
@@ -97,7 +97,7 @@ async function listOutboxMutations(internalFragment: InternalFragmentInstance): 
   return internalFragment.inContext(async function (this: DatabaseRequestContext) {
     return await this.handlerTx()
       .retrieve(({ forSchema }) =>
-        forSchema(internalSchema).find("fragno_db_outbox_mutations", (b) =>
+        forSchema(internalSchema).findNew("fragno_db_outbox_mutations", (b) =>
           b
             .whereIndex("idx_outbox_mutations_entry")
             .orderByIndex("idx_outbox_mutations_entry", "asc"),
@@ -116,7 +116,7 @@ async function createUser(fragment: AnyFragnoInstantiatedDatabaseFragment, email
 
     const user = await this.handlerTx()
       .retrieve(({ forSchema }) =>
-        forSchema(outboxSchema).findFirst("users", (b) =>
+        forSchema(outboxSchema).findFirstNew("users", (b) =>
           b.whereIndex("idx_users_email", (eb) => eb("email", "=", email)),
         ),
       )
@@ -272,7 +272,7 @@ describe("in-memory outbox", () => {
 
         const user = await this.handlerTx()
           .retrieve(({ forSchema }) =>
-            forSchema(schemaA).findFirst("users", (b) =>
+            forSchema(schemaA).findFirstNew("users", (b) =>
               b.whereIndex("idx_users_email", (eb) => eb("email", "=", "tenant-a@example.com")),
             ),
           )
@@ -295,7 +295,7 @@ describe("in-memory outbox", () => {
 
         const user = await this.handlerTx()
           .retrieve(({ forSchema }) =>
-            forSchema(schemaB).findFirst("users", (b) =>
+            forSchema(schemaB).findFirstNew("users", (b) =>
               b.whereIndex("idx_users_email", (eb) => eb("email", "=", "tenant-b@example.com")),
             ),
           )

--- a/packages/fragno-db/src/adapters/in-memory/outbox.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/outbox.test.ts
@@ -97,7 +97,7 @@ async function listOutboxMutations(internalFragment: InternalFragmentInstance): 
   return internalFragment.inContext(async function (this: DatabaseRequestContext) {
     return await this.handlerTx()
       .retrieve(({ forSchema }) =>
-        forSchema(internalSchema).findNew("fragno_db_outbox_mutations", (b) =>
+        forSchema(internalSchema).find("fragno_db_outbox_mutations", (b) =>
           b
             .whereIndex("idx_outbox_mutations_entry")
             .orderByIndex("idx_outbox_mutations_entry", "asc"),
@@ -116,7 +116,7 @@ async function createUser(fragment: AnyFragnoInstantiatedDatabaseFragment, email
 
     const user = await this.handlerTx()
       .retrieve(({ forSchema }) =>
-        forSchema(outboxSchema).findFirstNew("users", (b) =>
+        forSchema(outboxSchema).findFirst("users", (b) =>
           b.whereIndex("idx_users_email", (eb) => eb("email", "=", email)),
         ),
       )
@@ -272,7 +272,7 @@ describe("in-memory outbox", () => {
 
         const user = await this.handlerTx()
           .retrieve(({ forSchema }) =>
-            forSchema(schemaA).findFirstNew("users", (b) =>
+            forSchema(schemaA).findFirst("users", (b) =>
               b.whereIndex("idx_users_email", (eb) => eb("email", "=", "tenant-a@example.com")),
             ),
           )
@@ -295,7 +295,7 @@ describe("in-memory outbox", () => {
 
         const user = await this.handlerTx()
           .retrieve(({ forSchema }) =>
-            forSchema(schemaB).findFirstNew("users", (b) =>
+            forSchema(schemaB).findFirst("users", (b) =>
               b.whereIndex("idx_users_email", (eb) => eb("email", "=", "tenant-b@example.com")),
             ),
           )

--- a/packages/fragno-db/src/adapters/in-memory/query-tree.ts
+++ b/packages/fragno-db/src/adapters/in-memory/query-tree.ts
@@ -1,0 +1,437 @@
+import type { NamingResolver } from "../../naming/sql-naming";
+import type { Condition } from "../../query/condition-builder";
+import { getDbNowOffsetMs, isDbNow } from "../../query/db-now";
+import type {
+  CompiledQueryTreeChildNode,
+  CompiledQueryTreeRootNode,
+} from "../../query/unit-of-work/query-tree";
+import {
+  getQueryTreeSelectedColumnNames,
+  isParentColumnRef,
+} from "../../query/unit-of-work/query-tree";
+import { resolveFragnoIdValue } from "../../query/value-encoding";
+import type { AnyColumn, AnyTable } from "../../schema/create";
+import { Column, FragnoId, FragnoReference } from "../../schema/create";
+import type { InMemoryNamespaceStore, InMemoryRow, InMemoryTableStore } from "./store";
+import { normalizeIndexValue } from "./store";
+import { compareNormalizedValues } from "./value-comparison";
+
+const isNullish = (value: unknown): value is null | undefined =>
+  value === null || value === undefined;
+
+const getPhysicalColumnName = (table: AnyTable, columnName: string, resolver?: NamingResolver) =>
+  resolver ? resolver.getColumnName(table.name, columnName) : columnName;
+
+const getTableStore = (
+  namespaceStore: InMemoryNamespaceStore,
+  table: AnyTable,
+  resolver?: NamingResolver,
+): InMemoryTableStore => {
+  const physicalTableName = resolver ? resolver.getTableName(table.name) : table.name;
+  const tableStore = namespaceStore.tables.get(physicalTableName);
+  if (!tableStore) {
+    throw new Error(`Missing in-memory table store for "${physicalTableName}".`);
+  }
+  return tableStore;
+};
+
+const selectNodeRow = (
+  row: InMemoryRow,
+  table: AnyTable,
+  select: true | readonly string[],
+  resolver?: NamingResolver,
+  extraColumnNames: readonly string[] = [],
+): InMemoryRow => {
+  const selected: InMemoryRow = {};
+
+  for (const columnName of getQueryTreeSelectedColumnNames(table, select, extraColumnNames)) {
+    const physical = getPhysicalColumnName(table, columnName, resolver);
+    if (Object.prototype.hasOwnProperty.call(row, physical)) {
+      selected[columnName] = row[physical];
+    }
+  }
+
+  return selected;
+};
+
+const resolveComparableColumn = (column: AnyColumn, table: AnyTable) =>
+  column.role === "external-id" ? table.getInternalIdColumn() : column;
+
+const resolveComparisonValue = (
+  value: unknown,
+  column: AnyColumn,
+  currentTable: AnyTable,
+  currentRow: InMemoryRow,
+  parentTable: AnyTable | undefined,
+  parentRow: InMemoryRow | undefined,
+  now: () => Date,
+  resolver?: NamingResolver,
+): { value: unknown; column: AnyColumn } => {
+  if (isParentColumnRef(value)) {
+    if (!parentTable || !parentRow) {
+      throw new Error("Parent column references can only be evaluated for child query-tree nodes.");
+    }
+
+    let leftColumn = column;
+    let parentColumn = value.column;
+
+    if (leftColumn.role === "external-id" && parentColumn.role !== "external-id") {
+      leftColumn = resolveComparableColumn(leftColumn, currentTable);
+    }
+    if (parentColumn.role === "external-id" && leftColumn.role !== "external-id") {
+      parentColumn = resolveComparableColumn(parentColumn, parentTable);
+    }
+
+    const parentColumnName = getPhysicalColumnName(parentTable, parentColumn.name, resolver);
+    return {
+      value: parentRow[parentColumnName],
+      column: parentColumn,
+    };
+  }
+
+  if (value instanceof Column) {
+    const columnName = getPhysicalColumnName(currentTable, value.name, resolver);
+    return { value: currentRow[columnName], column: value };
+  }
+
+  if (isDbNow(value)) {
+    const base = now();
+    const offsetMs = getDbNowOffsetMs(value);
+    return {
+      value: offsetMs === 0 ? base : new Date(base.getTime() + offsetMs),
+      column,
+    };
+  }
+
+  if (value instanceof FragnoReference) {
+    return { value: value.internalId, column };
+  }
+
+  if (value instanceof FragnoId) {
+    if (column.role === "reference" || column.role === "internal-id") {
+      return { value: value.internalId, column };
+    }
+    return { value: value.externalId, column };
+  }
+
+  return { value: resolveFragnoIdValue(value, column), column };
+};
+
+export const evaluateQueryTreeCondition = (
+  condition: Condition | undefined,
+  currentTable: AnyTable,
+  currentRow: InMemoryRow,
+  parentTable: AnyTable | undefined,
+  parentRow: InMemoryRow | undefined,
+  resolver?: NamingResolver,
+  now: () => Date = () => new Date(),
+): boolean => {
+  if (!condition) {
+    return true;
+  }
+
+  switch (condition.type) {
+    case "and":
+      return condition.items.every((item) =>
+        evaluateQueryTreeCondition(
+          item,
+          currentTable,
+          currentRow,
+          parentTable,
+          parentRow,
+          resolver,
+          now,
+        ),
+      );
+    case "or":
+      return condition.items.some((item) =>
+        evaluateQueryTreeCondition(
+          item,
+          currentTable,
+          currentRow,
+          parentTable,
+          parentRow,
+          resolver,
+          now,
+        ),
+      );
+    case "not":
+      return !evaluateQueryTreeCondition(
+        condition.item,
+        currentTable,
+        currentRow,
+        parentTable,
+        parentRow,
+        resolver,
+        now,
+      );
+    case "compare":
+      break;
+    default: {
+      const exhaustiveCheck: never = condition;
+      throw new Error(`Unsupported condition type: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+
+  let leftColumn = condition.a;
+  let rightColumn = condition.a;
+  const right = resolveComparisonValue(
+    condition.b,
+    leftColumn,
+    currentTable,
+    currentRow,
+    parentTable,
+    parentRow,
+    now,
+    resolver,
+  );
+
+  if (isParentColumnRef(condition.b)) {
+    if (leftColumn.role === "external-id" && right.column.role !== "external-id") {
+      leftColumn = resolveComparableColumn(leftColumn, currentTable);
+    }
+    if (right.column.role === "external-id" && leftColumn.role !== "external-id" && parentTable) {
+      rightColumn = resolveComparableColumn(right.column, parentTable);
+    } else {
+      rightColumn = right.column;
+    }
+  }
+
+  const leftColumnName = getPhysicalColumnName(currentTable, leftColumn.name, resolver);
+  const leftValue = currentRow[leftColumnName];
+  const rightValue = right.value;
+  const op = condition.operator;
+
+  if (op === "is" || op === "is not") {
+    if (isNullish(rightValue)) {
+      const matches = isNullish(leftValue);
+      return op === "is" ? matches : !matches;
+    }
+
+    if (isNullish(leftValue)) {
+      return op === "is not";
+    }
+
+    const leftNormalized = normalizeIndexValue(leftValue, leftColumn);
+    const rightNormalized = normalizeIndexValue(rightValue, rightColumn);
+    const matches = compareNormalizedValues(leftNormalized, rightNormalized) === 0;
+    return op === "is" ? matches : !matches;
+  }
+
+  if (isNullish(leftValue) || isNullish(rightValue)) {
+    return false;
+  }
+
+  if (op === "in" || op === "not in") {
+    if (!Array.isArray(rightValue)) {
+      throw new Error(`Operator "${op}" expects an array value.`);
+    }
+
+    const leftNormalized = normalizeIndexValue(leftValue, leftColumn);
+    const matches = rightValue.some((item) => {
+      if (isNullish(item)) {
+        return false;
+      }
+      return compareNormalizedValues(leftNormalized, normalizeIndexValue(item, leftColumn)) === 0;
+    });
+
+    return op === "in" ? matches : !matches;
+  }
+
+  if (
+    op === "contains" ||
+    op === "starts with" ||
+    op === "ends with" ||
+    op === "not contains" ||
+    op === "not starts with" ||
+    op === "not ends with"
+  ) {
+    const leftText = String(normalizeIndexValue(leftValue, leftColumn) ?? "").toLowerCase();
+    const rightText = String(normalizeIndexValue(rightValue, rightColumn) ?? "").toLowerCase();
+
+    let matches = false;
+    if (op.includes("contains")) {
+      matches = leftText.includes(rightText);
+    } else if (op.includes("starts with")) {
+      matches = leftText.startsWith(rightText);
+    } else {
+      matches = leftText.endsWith(rightText);
+    }
+
+    return op.startsWith("not ") ? !matches : matches;
+  }
+
+  const leftNormalized = normalizeIndexValue(leftValue, leftColumn);
+  const rightNormalized = normalizeIndexValue(rightValue, rightColumn);
+  const comparison = compareNormalizedValues(leftNormalized, rightNormalized);
+
+  switch (op) {
+    case "=":
+      return comparison === 0;
+    case "!=":
+      return comparison !== 0;
+    case ">":
+      return comparison > 0;
+    case ">=":
+      return comparison >= 0;
+    case "<":
+      return comparison < 0;
+    case "<=":
+      return comparison <= 0;
+    default:
+      throw new Error(`Unsupported operator ${op}`);
+  }
+};
+
+const resolveOrderByColumns = (table: AnyTable, indexName: string): AnyColumn[] => {
+  if (indexName === "_primary") {
+    return [table.getIdColumn()];
+  }
+
+  const index = table.indexes[indexName];
+  if (!index) {
+    throw new Error(`Index "${indexName}" not found on table "${table.name}".`);
+  }
+
+  return index.columns;
+};
+
+const orderRows = (
+  rows: InMemoryRow[],
+  table: AnyTable,
+  orderByIndex: { indexName: string; direction: "asc" | "desc" } | undefined,
+  resolver?: NamingResolver,
+): InMemoryRow[] => {
+  if (!orderByIndex) {
+    return rows;
+  }
+
+  const columns = resolveOrderByColumns(table, orderByIndex.indexName);
+  return rows.slice().sort((left, right) => {
+    for (const column of columns) {
+      const columnName = getPhysicalColumnName(table, column.name, resolver);
+      const leftValue = normalizeIndexValue(left[columnName], column);
+      const rightValue = normalizeIndexValue(right[columnName], column);
+      const comparison = compareNormalizedValues(leftValue, rightValue);
+      if (comparison !== 0) {
+        return orderByIndex.direction === "asc" ? comparison : -comparison;
+      }
+    }
+    return 0;
+  });
+};
+
+const buildChildRawValue = (
+  child: CompiledQueryTreeChildNode,
+  parentTable: AnyTable,
+  parentRow: InMemoryRow,
+  namespaceStore: InMemoryNamespaceStore,
+  resolver?: NamingResolver,
+  now: () => Date = () => new Date(),
+  readTracking = false,
+): unknown => {
+  const childStore = getTableStore(namespaceStore, child.table, resolver);
+  const matchingRows: InMemoryRow[] = [];
+
+  for (const row of childStore.rows.values()) {
+    if (
+      !evaluateQueryTreeCondition(
+        child.onIndex,
+        child.table,
+        row,
+        parentTable,
+        parentRow,
+        resolver,
+        now,
+      )
+    ) {
+      continue;
+    }
+
+    if (
+      !evaluateQueryTreeCondition(
+        child.where,
+        child.table,
+        row,
+        undefined,
+        undefined,
+        resolver,
+        now,
+      )
+    ) {
+      continue;
+    }
+
+    matchingRows.push(row);
+  }
+
+  const ordered = orderRows(matchingRows, child.table, child.orderByIndex, resolver);
+  const limited = child.pageSize !== undefined ? ordered.slice(0, child.pageSize) : ordered;
+  const items = limited.map((row) =>
+    buildQueryTreeRowRaw(child, row, namespaceStore, resolver, now, readTracking),
+  );
+
+  if (child.cardinality === "one") {
+    return items[0] ?? null;
+  }
+
+  return items;
+};
+
+export const buildQueryTreeRowRaw = (
+  node: CompiledQueryTreeRootNode | CompiledQueryTreeChildNode,
+  row: InMemoryRow,
+  namespaceStore: InMemoryNamespaceStore,
+  resolver?: NamingResolver,
+  now: () => Date = () => new Date(),
+  readTracking = false,
+): InMemoryRow => {
+  const output = selectNodeRow(
+    row,
+    node.table,
+    node.select,
+    resolver,
+    readTracking ? [node.table.getIdColumn().name] : [],
+  );
+
+  for (const child of node.children) {
+    output[child.alias] = buildChildRawValue(
+      child,
+      node.table,
+      row,
+      namespaceStore,
+      resolver,
+      now,
+      readTracking,
+    );
+  }
+
+  return output;
+};
+
+export const executeQueryTreeRoot = (
+  root: CompiledQueryTreeRootNode,
+  tableStore: InMemoryTableStore,
+  namespaceStore: InMemoryNamespaceStore,
+  resolver?: NamingResolver,
+  now: () => Date = () => new Date(),
+  readTracking = false,
+): InMemoryRow[] => {
+  const matches: InMemoryRow[] = [];
+
+  for (const row of tableStore.rows.values()) {
+    if (
+      !evaluateQueryTreeCondition(root.where, root.table, row, undefined, undefined, resolver, now)
+    ) {
+      continue;
+    }
+    matches.push(row);
+  }
+
+  const ordered = orderRows(matches, root.table, root.orderByIndex, resolver);
+  const limited = root.pageSize !== undefined ? ordered.slice(0, root.pageSize) : ordered;
+
+  return limited.map((row) =>
+    buildQueryTreeRowRaw(root, row, namespaceStore, resolver, now, readTracking),
+  );
+};

--- a/packages/fragno-db/src/adapters/in-memory/reference-resolution.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/reference-resolution.test.ts
@@ -8,12 +8,9 @@ import { createInMemoryStore, ensureNamespaceStore } from "./store";
 const testSchema = schema("test", (s) =>
   s
     .addTable("users", (t) => t.addColumn("id", idColumn()).addColumn("name", column("string")))
-    .addTable("posts", (t) => t.addColumn("id", idColumn()).addColumn("userId", referenceColumn()))
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "userId" },
-      to: { table: "users", column: "id" },
-    }),
+    .addTable("posts", (t) =>
+      t.addColumn("id", idColumn()).addColumn("userId", referenceColumn({ table: "users" })),
+    ),
 );
 
 describe("in-memory reference resolution", () => {

--- a/packages/fragno-db/src/adapters/in-memory/value-normalization.test.ts
+++ b/packages/fragno-db/src/adapters/in-memory/value-normalization.test.ts
@@ -4,16 +4,18 @@ import { column, idColumn, referenceColumn, schema } from "../../schema/create";
 import { buildIndexKey } from "./store";
 
 const testSchema = schema("test", (s) =>
-  s.addTable("events", (t) =>
-    t
-      .addColumn("id", idColumn())
-      .addColumn("createdAt", column("timestamp"))
-      .addColumn("isActive", column("bool"))
-      .addColumn("payload", column("json"))
-      .addColumn("size", column("bigint"))
-      .addColumn("userId", referenceColumn())
-      .createIndex("compound_idx", ["createdAt", "isActive", "payload", "size", "userId"]),
-  ),
+  s
+    .addTable("users", (t) => t.addColumn("id", idColumn()))
+    .addTable("events", (t) =>
+      t
+        .addColumn("id", idColumn())
+        .addColumn("createdAt", column("timestamp"))
+        .addColumn("isActive", column("bool"))
+        .addColumn("payload", column("json"))
+        .addColumn("size", column("bigint"))
+        .addColumn("userId", referenceColumn({ table: "users" }))
+        .createIndex("compound_idx", ["createdAt", "isActive", "payload", "size", "userId"]),
+    ),
 );
 
 describe("in-memory index normalization", () => {

--- a/packages/fragno-db/src/adapters/prisma/prisma-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/prisma/prisma-adapter-sqlite3.test.ts
@@ -31,7 +31,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       .addTable("emails", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("email", column("string"))
           .addColumn("is_primary", column("bool").defaultTo(false))
           .createIndex("unique_email", ["email"], { unique: true })
@@ -40,7 +40,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       .addTable("posts", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
           .createIndex("posts_user_idx", ["user_id"]);
@@ -48,8 +48,8 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       .addTable("comments", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("post_id", referenceColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("post_id", referenceColumn({ table: "posts" }))
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("text", column("string"))
           .createIndex("comments_post_idx", ["post_id"])
           .createIndex("comments_user_idx", ["user_id"]);
@@ -66,26 +66,6 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
           .addColumn("payload", column("json").nullable())
           .addColumn("big_score", column("bigint"))
           .createIndex("events_name_idx", ["name"]);
-      })
-      .addReference("user", {
-        type: "one",
-        from: { table: "emails", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "user_id" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "comments", column: "post_id" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("commenter", {
-        type: "one",
-        from: { table: "comments", column: "user_id" },
-        to: { table: "users", column: "id" },
       });
   });
 
@@ -101,14 +81,9 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       .addTable("orders", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("product_id", referenceColumn())
+          .addColumn("product_id", referenceColumn({ table: "products" }))
           .addColumn("quantity", column("integer"))
           .createIndex("product_orders_idx", ["product_id"]);
-      })
-      .addReference("product", {
-        type: "one",
-        from: { table: "orders", column: "product_id" },
-        to: { table: "products", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/adapters/prisma/prisma-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/prisma/prisma-adapter-sqlite3.test.ts
@@ -264,7 +264,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [createdUsers] = await queryEngine
       .createUnitOfWork("get-created-users")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) =>
           eb("name", "in", ["Prisma SQLite Alice", "Prisma SQLite Bob"]),
         ),
@@ -277,7 +277,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     const [users] = await uow.executeRetrieve();
 
@@ -290,7 +290,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -309,7 +309,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -331,7 +331,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .findNew("users", (b) => b.whereIndex("primary").selectCount())
+      .find("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     expect(totalCount).toBeGreaterThanOrEqual(3);
@@ -353,7 +353,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -374,7 +374,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -400,7 +400,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const all = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findNew("users", (b) =>
+        .find("users", (b) =>
           b
             .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
             .orderByIndex("name_id_idx", "asc"),
@@ -410,7 +410,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     })();
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .orderByIndex("name_id_idx", "asc")
@@ -421,7 +421,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     })();
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .after(firstPage.cursor!)
@@ -462,7 +462,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     }
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -477,7 +477,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     expect(firstPage.cursor).toBeInstanceOf(Cursor);
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -493,7 +493,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     expect(secondPage.cursor).toBeUndefined();
 
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NoMatchPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -527,7 +527,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       })();
     }
 
-    const uow = queryEngine.createUnitOfWork("cursor-test").findWithCursorNew("users", (b) =>
+    const uow = queryEngine.createUnitOfWork("cursor-test").findWithCursor("users", (b) =>
       b
         .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
         .orderByIndex("name_idx", "asc")
@@ -561,12 +561,12 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const view1 = uow
       .forSchema(testSchema)
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Prisma Multi Schema User"))
           .select(["id", "name"]),
       )
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Prisma Multi Schema User"))
           .select(["name", "age"]),
@@ -574,7 +574,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const view2 = uow
       .forSchema(schema2)
-      .findNew("products", (b) => b.whereIndex("primary").select(["name", "price"]));
+      .find("products", (b) => b.whereIndex("primary").select(["name", "price"]));
 
     await uow.executeRetrieve();
 
@@ -631,7 +631,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [usersResult] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma SQLite Email User")),
       )
       .executeRetrieve();
@@ -650,7 +650,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const uow = queryEngine
       .createUnitOfWork("test-joins")
-      .findNew("emails", (b) =>
+      .find("emails", (b) =>
         b
           .whereIndex("user_emails", (eb) => eb("user_id", "=", createdUser.id))
           .joinOne("user", "users", (builder) =>
@@ -692,7 +692,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-external-id")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma SQLite External ID User")),
       )
       .executeRetrieve();
@@ -709,7 +709,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[email]] = await queryEngine
       .createUnitOfWork("get-email-by-external-id")
-      .findNew("emails", (b) =>
+      .find("emails", (b) =>
         b
           .whereIndex("unique_email", (eb) =>
             eb("email", "=", "prisma-sqlite-external-id@example.com"),
@@ -760,12 +760,12 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("verify-user")
-      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
+      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
       .executeRetrieve();
 
     const [[post]] = await queryEngine
       .createUnitOfWork("verify-post")
-      .findNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
+      .find("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
       .executeRetrieve();
 
     expect(user.name).toBe("Prisma SQLite UOW User");
@@ -784,7 +784,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma SQLite Author")),
       )
       .executeRetrieve();
@@ -799,9 +799,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .findNew("posts", (b) =>
-        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
-      )
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
       .executeRetrieve();
 
     const createCommenterUow = queryEngine.createUnitOfWork("create-commenter");
@@ -810,7 +808,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma SQLite Commenter")),
       )
       .executeRetrieve();
@@ -824,7 +822,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     await createCommentUow.executeMutations();
     const createdCommentId = createCommentUow.getCreatedIds()[0]!;
 
-    const uow = queryEngine.createUnitOfWork("test-complex-joins").findNew("comments", (b) =>
+    const uow = queryEngine.createUnitOfWork("test-complex-joins").find("comments", (b) =>
       b
         .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
         .joinOne("post", "posts", (postBuilder) =>
@@ -911,7 +909,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -920,7 +918,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -929,7 +927,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) =>
+        .findFirst("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -989,7 +987,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1017,7 +1015,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-event-for-timestamp")
-      .findNew("events", (b) =>
+      .find("events", (b) =>
         b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Timestamp Event SQLite")),
       )
       .executeRetrieve();
@@ -1067,7 +1065,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-execute-uow")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma Execute UOW User")),
       )
       .executeRetrieve();
@@ -1077,7 +1075,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const getUserById = (userId: typeof user.id) => {
       return createServiceTxBuilder(testSchema, currentUow!)
         .retrieve((uow) =>
-          uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+          uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
         )
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
@@ -1113,7 +1111,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
+        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1140,7 +1138,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma Version Conflict User")),
       )
       .executeRetrieve();
@@ -1162,7 +1160,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter((p) => p.title === "Prisma Should Not Be Created");
@@ -1187,7 +1185,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-event")
-      .findNew("events", (b) => b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Launch")))
+      .find("events", (b) => b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Launch")))
       .executeRetrieve();
 
     expect(event).toBeDefined();
@@ -1223,7 +1221,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-utc-event")
-      .findNew("events", (b) =>
+      .find("events", (b) =>
         b.whereIndex("events_name_idx", (eb) => eb("name", "=", "UTC Timestamp")),
       )
       .executeRetrieve();
@@ -1250,7 +1248,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
       const [[event]] = await queryEngine
         .createUnitOfWork("get-safe-bigint-event")
-        .findNew("events", (b) =>
+        .find("events", (b) =>
           b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Safe BigInt")),
         )
         .executeRetrieve();
@@ -1279,7 +1277,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       await expect(
         queryEngine
           .createUnitOfWork("get-unsafe-event")
-          .findNew("events", (b) =>
+          .find("events", (b) =>
             b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Unsafe BigInt")),
           )
           .executeRetrieve(),

--- a/packages/fragno-db/src/adapters/prisma/prisma-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/prisma/prisma-adapter-sqlite3.test.ts
@@ -264,7 +264,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [createdUsers] = await queryEngine
       .createUnitOfWork("get-created-users")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) =>
           eb("name", "in", ["Prisma SQLite Alice", "Prisma SQLite Bob"]),
         ),
@@ -277,7 +277,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const uow = queryEngine
       .createUnitOfWork("update-user-age")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)));
 
     const [users] = await uow.executeRetrieve();
 
@@ -290,7 +290,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[updatedUser]] = await queryEngine
       .createUnitOfWork("get-updated-user")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(updatedUser).toMatchObject({
@@ -309,7 +309,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[unchangedUser]] = await queryEngine
       .createUnitOfWork("verify-unchanged")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", initialUserId)))
       .executeRetrieve();
 
     expect(unchangedUser).toMatchObject({
@@ -331,7 +331,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [totalCount] = await queryEngine
       .createUnitOfWork("count-all")
-      .find("users", (b) => b.whereIndex("primary").selectCount())
+      .findNew("users", (b) => b.whereIndex("primary").selectCount())
       .executeRetrieve();
 
     expect(totalCount).toBeGreaterThanOrEqual(3);
@@ -353,7 +353,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [firstPage] = await queryEngine
       .createUnitOfWork("first-page")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -374,7 +374,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [secondPage] = await queryEngine
       .createUnitOfWork("second-page")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -400,7 +400,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const all = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .find("users", (b) =>
+        .findNew("users", (b) =>
           b
             .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
             .orderByIndex("name_id_idx", "asc"),
@@ -410,7 +410,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     })();
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .orderByIndex("name_id_idx", "asc")
@@ -421,7 +421,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     })();
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_id_idx", (eb) => eb("name", "=", nameValue))
           .after(firstPage.cursor!)
@@ -462,7 +462,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     }
 
     const firstPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .orderByIndex("name_idx", "asc")
@@ -477,7 +477,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     expect(firstPage.cursor).toBeInstanceOf(Cursor);
 
     const secondPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
           .after(firstPage.cursor!)
@@ -493,7 +493,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     expect(secondPage.cursor).toBeUndefined();
 
     const emptyPage = await (async () => {
-      const uow = queryEngine.createUnitOfWork("read").findWithCursor("users", (b) =>
+      const uow = queryEngine.createUnitOfWork("read").findWithCursorNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "NoMatchPrefix"))
           .orderByIndex("name_idx", "asc")
@@ -527,7 +527,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       })();
     }
 
-    const uow = queryEngine.createUnitOfWork("cursor-test").findWithCursor("users", (b) =>
+    const uow = queryEngine.createUnitOfWork("cursor-test").findWithCursorNew("users", (b) =>
       b
         .whereIndex("name_idx", (eb) => eb("name", "starts with", prefix))
         .orderByIndex("name_idx", "asc")
@@ -561,12 +561,12 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const view1 = uow
       .forSchema(testSchema)
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Prisma Multi Schema User"))
           .select(["id", "name"]),
       )
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b
           .whereIndex("name_idx", (eb) => eb("name", "starts with", "Prisma Multi Schema User"))
           .select(["name", "age"]),
@@ -574,7 +574,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const view2 = uow
       .forSchema(schema2)
-      .find("products", (b) => b.whereIndex("primary").select(["name", "price"]));
+      .findNew("products", (b) => b.whereIndex("primary").select(["name", "price"]));
 
     await uow.executeRetrieve();
 
@@ -631,7 +631,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [usersResult] = await queryEngine
       .createUnitOfWork("get-created-user")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma SQLite Email User")),
       )
       .executeRetrieve();
@@ -650,10 +650,14 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const uow = queryEngine
       .createUnitOfWork("test-joins")
-      .find("emails", (b) =>
+      .findNew("emails", (b) =>
         b
           .whereIndex("user_emails", (eb) => eb("user_id", "=", createdUser.id))
-          .join((jb) => jb.user((builder) => builder.select(["name", "id", "age"]))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["name", "id", "age"]),
+          ),
       );
 
     const [[email]] = await uow.executeRetrieve();
@@ -688,7 +692,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-external-id")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma SQLite External ID User")),
       )
       .executeRetrieve();
@@ -705,12 +709,16 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[email]] = await queryEngine
       .createUnitOfWork("get-email-by-external-id")
-      .find("emails", (b) =>
+      .findNew("emails", (b) =>
         b
           .whereIndex("unique_email", (eb) =>
             eb("email", "=", "prisma-sqlite-external-id@example.com"),
           )
-          .join((jb) => jb.user((builder) => builder.select(["name", "id"]))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+              .select(["name", "id"]),
+          ),
       )
       .executeRetrieve();
 
@@ -752,12 +760,12 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("verify-user")
-      .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
+      .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userIdStr)))
       .executeRetrieve();
 
     const [[post]] = await queryEngine
       .createUnitOfWork("verify-post")
-      .find("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
+      .findNew("posts", (b) => b.whereIndex("primary", (eb) => eb("id", "=", postIdStr)))
       .executeRetrieve();
 
     expect(user.name).toBe("Prisma SQLite UOW User");
@@ -776,7 +784,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[author]] = await queryEngine
       .createUnitOfWork("get-author")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma SQLite Author")),
       )
       .executeRetrieve();
@@ -791,7 +799,9 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[post]] = await queryEngine
       .createUnitOfWork("get-post")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)))
+      .findNew("posts", (b) =>
+        b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", author.id)),
+      )
       .executeRetrieve();
 
     const createCommenterUow = queryEngine.createUnitOfWork("create-commenter");
@@ -800,7 +810,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[commenter]] = await queryEngine
       .createUnitOfWork("get-commenter")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma SQLite Commenter")),
       )
       .executeRetrieve();
@@ -812,23 +822,29 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       text: "Great Prisma post!",
     });
     await createCommentUow.executeMutations();
+    const createdCommentId = createCommentUow.getCreatedIds()[0]!;
 
-    const uow = queryEngine.createUnitOfWork("test-complex-joins").find("comments", (b) =>
-      b.whereIndex("primary").join((jb) =>
-        jb
-          .post((postBuilder) =>
-            postBuilder
-              .select(["id", "title", "content"])
-              .orderByIndex("primary", "desc")
-              .pageSize(1)
-              .join((jb2) =>
-                jb2.author((authorBuilder) =>
-                  authorBuilder.select(["id", "name", "age"]).orderByIndex("name_idx", "asc"),
-                ),
-              ),
-          )
-          .commenter((commenterBuilder) => commenterBuilder.select(["id", "name"])),
-      ),
+    const uow = queryEngine.createUnitOfWork("test-complex-joins").findNew("comments", (b) =>
+      b
+        .whereIndex("primary", (eb) => eb("id", "=", createdCommentId))
+        .joinOne("post", "posts", (postBuilder) =>
+          postBuilder
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+            .select(["id", "title", "content"])
+            .orderByIndex("primary", "desc")
+            .pageSize(1)
+            .joinOne("author", "users", (authorBuilder) =>
+              authorBuilder
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+                .select(["id", "name", "age"])
+                .orderByIndex("name_idx", "asc"),
+            ),
+        )
+        .joinOne("commenter", "users", (commenterBuilder) =>
+          commenterBuilder
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+            .select(["id", "name"]),
+        ),
     );
 
     const [[comment]] = await uow.executeRetrieve();
@@ -895,7 +911,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const user1 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[0].externalId)),
         );
       await uow.executeRetrieve();
@@ -904,7 +920,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const user2 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[1].externalId)),
         );
       await uow.executeRetrieve();
@@ -913,7 +929,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const user3 = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) =>
+        .findFirstNew("users", (b) =>
           b.whereIndex("primary", (eb) => eb("id", "=", createdIds1[2].externalId)),
         );
       await uow.executeRetrieve();
@@ -973,7 +989,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const customIdUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", customId)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1001,7 +1017,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-event-for-timestamp")
-      .find("events", (b) =>
+      .findNew("events", (b) =>
         b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Timestamp Event SQLite")),
       )
       .executeRetrieve();
@@ -1051,7 +1067,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-execute-uow")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma Execute UOW User")),
       )
       .executeRetrieve();
@@ -1061,7 +1077,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const getUserById = (userId: typeof user.id) => {
       return createServiceTxBuilder(testSchema, currentUow!)
         .retrieve((uow) =>
-          uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+          uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
         )
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
@@ -1097,7 +1113,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     const updatedUser = await (async () => {
       const uow = queryEngine
         .createUnitOfWork("read")
-        .findFirst("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
+        .findFirstNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", user.id)));
       await uow.executeRetrieve();
       return (await uow.retrievalPhase)[0];
     })();
@@ -1124,7 +1140,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[user]] = await queryEngine
       .createUnitOfWork("get-user-for-version-conflict")
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("name_idx", (eb) => eb("name", "=", "Prisma Version Conflict User")),
       )
       .executeRetrieve();
@@ -1146,7 +1162,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [posts] = await queryEngine
       .createUnitOfWork("get-posts-for-version-conflict")
-      .find("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
+      .findNew("posts", (b) => b.whereIndex("posts_user_idx", (eb) => eb("user_id", "=", user.id)))
       .executeRetrieve();
 
     const conflictPosts = posts.filter((p) => p.title === "Prisma Should Not Be Created");
@@ -1171,7 +1187,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-event")
-      .find("events", (b) => b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Launch")))
+      .findNew("events", (b) => b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Launch")))
       .executeRetrieve();
 
     expect(event).toBeDefined();
@@ -1207,7 +1223,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
     const [[event]] = await queryEngine
       .createUnitOfWork("get-utc-event")
-      .find("events", (b) =>
+      .findNew("events", (b) =>
         b.whereIndex("events_name_idx", (eb) => eb("name", "=", "UTC Timestamp")),
       )
       .executeRetrieve();
@@ -1234,7 +1250,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
       const [[event]] = await queryEngine
         .createUnitOfWork("get-safe-bigint-event")
-        .find("events", (b) =>
+        .findNew("events", (b) =>
           b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Safe BigInt")),
         )
         .executeRetrieve();
@@ -1263,7 +1279,7 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       await expect(
         queryEngine
           .createUnitOfWork("get-unsafe-event")
-          .find("events", (b) =>
+          .findNew("events", (b) =>
             b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Unsafe BigInt")),
           )
           .executeRetrieve(),

--- a/packages/fragno-db/src/db-fragment-integration.test.ts
+++ b/packages/fragno-db/src/db-fragment-integration.test.ts
@@ -66,7 +66,7 @@ describe.sequential("Database Fragment Integration", () => {
         getUserById(userId: FragnoId | string) {
           return this.serviceTx(usersSchema)
             .retrieve((uow) =>
-              uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+              uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
             )
             .transformRetrieve(
               ([users]): { id: FragnoId; name: string; email: string } | null => users[0] ?? null,
@@ -155,7 +155,7 @@ describe.sequential("Database Fragment Integration", () => {
         getOrdersByUser(userExternalId: string) {
           return this.serviceTx(ordersSchema)
             .retrieve((uow) =>
-              uow.findNew("orders", (b) =>
+              uow.find("orders", (b) =>
                 b.whereIndex("orders_user_idx", (eb) =>
                   eb("user_external_id", "=", userExternalId),
                 ),
@@ -419,7 +419,7 @@ describe.sequential("Database Fragment Integration", () => {
       return await this.handlerTx()
         // Add a retrieve op so retry is allowed for the forced conflict below.
         .retrieve(({ forSchema }) =>
-          forSchema(usersSchema).findNew("users", (b) => b.whereIndex("primary")),
+          forSchema(usersSchema).find("users", (b) => b.whereIndex("primary")),
         )
         .mutate(({ forSchema, idempotencyKey, currentAttempt }) => {
           if (currentAttempt === 0) {
@@ -482,7 +482,7 @@ describe.sequential("Database Fragment Integration", () => {
       const result = await usersFragment.inContext(async function () {
         return await this.handlerTx()
           .retrieve(({ forSchema }) =>
-            forSchema(usersSchema).findNew("users", (b) =>
+            forSchema(usersSchema).find("users", (b) =>
               b.whereIndex("primary", (eb) => eb("id", "=", userId)),
             ),
           )
@@ -528,7 +528,7 @@ describe.sequential("Database Fragment Integration", () => {
       const result = await ordersFragment.inContext(async function () {
         return await this.handlerTx()
           .retrieve(({ forSchema }) =>
-            forSchema(ordersSchema).findNew("orders", (b) =>
+            forSchema(ordersSchema).find("orders", (b) =>
               b.whereIndex("orders_user_idx", (eb) => eb("user_external_id", "=", userId)),
             ),
           )

--- a/packages/fragno-db/src/db-fragment-integration.test.ts
+++ b/packages/fragno-db/src/db-fragment-integration.test.ts
@@ -27,14 +27,9 @@ describe.sequential("Database Fragment Integration", () => {
       .addTable("profiles", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("user_id", referenceColumn())
+          .addColumn("user_id", referenceColumn({ table: "users" }))
           .addColumn("bio", column("string"))
           .createIndex("profile_user_idx", ["user_id"]);
-      })
-      .addReference("user", {
-        type: "one",
-        from: { table: "profiles", column: "user_id" },
-        to: { table: "users", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/db-fragment-integration.test.ts
+++ b/packages/fragno-db/src/db-fragment-integration.test.ts
@@ -66,7 +66,7 @@ describe.sequential("Database Fragment Integration", () => {
         getUserById(userId: FragnoId | string) {
           return this.serviceTx(usersSchema)
             .retrieve((uow) =>
-              uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+              uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
             )
             .transformRetrieve(
               ([users]): { id: FragnoId; name: string; email: string } | null => users[0] ?? null,
@@ -155,7 +155,7 @@ describe.sequential("Database Fragment Integration", () => {
         getOrdersByUser(userExternalId: string) {
           return this.serviceTx(ordersSchema)
             .retrieve((uow) =>
-              uow.find("orders", (b) =>
+              uow.findNew("orders", (b) =>
                 b.whereIndex("orders_user_idx", (eb) =>
                   eb("user_external_id", "=", userExternalId),
                 ),
@@ -418,7 +418,9 @@ describe.sequential("Database Fragment Integration", () => {
     const result = await usersFragment.inContext(async function () {
       return await this.handlerTx()
         // Add a retrieve op so retry is allowed for the forced conflict below.
-        .retrieve(({ forSchema }) => forSchema(usersSchema).find("users"))
+        .retrieve(({ forSchema }) =>
+          forSchema(usersSchema).findNew("users", (b) => b.whereIndex("primary")),
+        )
         .mutate(({ forSchema, idempotencyKey, currentAttempt }) => {
           if (currentAttempt === 0) {
             firstIdempotencyKey = idempotencyKey;
@@ -480,7 +482,7 @@ describe.sequential("Database Fragment Integration", () => {
       const result = await usersFragment.inContext(async function () {
         return await this.handlerTx()
           .retrieve(({ forSchema }) =>
-            forSchema(usersSchema).find("users", (b) =>
+            forSchema(usersSchema).findNew("users", (b) =>
               b.whereIndex("primary", (eb) => eb("id", "=", userId)),
             ),
           )
@@ -526,7 +528,7 @@ describe.sequential("Database Fragment Integration", () => {
       const result = await ordersFragment.inContext(async function () {
         return await this.handlerTx()
           .retrieve(({ forSchema }) =>
-            forSchema(ordersSchema).find("orders", (b) =>
+            forSchema(ordersSchema).findNew("orders", (b) =>
               b.whereIndex("orders_user_idx", (eb) => eb("user_external_id", "=", userId)),
             ),
           )

--- a/packages/fragno-db/src/fragments/internal-fragment.routes.test.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.routes.test.ts
@@ -301,7 +301,7 @@ describe("internal fragment sync routes", () => {
     const syncRecord = await internalFragment.inContext(async function () {
       return await this.handlerTx()
         .retrieve(({ forSchema }) =>
-          forSchema(internalSchema).findFirstNew("fragno_db_sync_requests", (b) =>
+          forSchema(internalSchema).findFirst("fragno_db_sync_requests", (b) =>
             b.whereIndex("idx_sync_request_id", (eb) => eb("requestId", "=", "req-1")),
           ),
         )
@@ -475,7 +475,7 @@ describe("internal fragment sync routes", () => {
           countItems() {
             return this.serviceTx(alphaSchema)
               .retrieve((uow) =>
-                uow.findNew("alpha_items", (b) => b.whereIndex("primary").selectCount()),
+                uow.find("alpha_items", (b) => b.whereIndex("primary").selectCount()),
               )
               .transformRetrieve(([count]) => (typeof count === "number" ? count : 0))
               .build();
@@ -557,7 +557,7 @@ describe("internal fragment sync routes", () => {
     const createdItem = await alphaFragment.inContext(async function () {
       return await this.handlerTx()
         .retrieve(({ forSchema }) =>
-          forSchema(alphaSchema).findFirstNew("alpha_items", (b) => b.whereIndex("primary")),
+          forSchema(alphaSchema).findFirst("alpha_items", (b) => b.whereIndex("primary")),
         )
         .transformRetrieve(([result]) => result)
         .execute();

--- a/packages/fragno-db/src/fragments/internal-fragment.routes.test.ts
+++ b/packages/fragno-db/src/fragments/internal-fragment.routes.test.ts
@@ -301,7 +301,7 @@ describe("internal fragment sync routes", () => {
     const syncRecord = await internalFragment.inContext(async function () {
       return await this.handlerTx()
         .retrieve(({ forSchema }) =>
-          forSchema(internalSchema).findFirst("fragno_db_sync_requests", (b) =>
+          forSchema(internalSchema).findFirstNew("fragno_db_sync_requests", (b) =>
             b.whereIndex("idx_sync_request_id", (eb) => eb("requestId", "=", "req-1")),
           ),
         )
@@ -475,7 +475,7 @@ describe("internal fragment sync routes", () => {
           countItems() {
             return this.serviceTx(alphaSchema)
               .retrieve((uow) =>
-                uow.find("alpha_items", (b) => b.whereIndex("primary").selectCount()),
+                uow.findNew("alpha_items", (b) => b.whereIndex("primary").selectCount()),
               )
               .transformRetrieve(([count]) => (typeof count === "number" ? count : 0))
               .build();
@@ -557,7 +557,7 @@ describe("internal fragment sync routes", () => {
     const createdItem = await alphaFragment.inContext(async function () {
       return await this.handlerTx()
         .retrieve(({ forSchema }) =>
-          forSchema(alphaSchema).findFirst("alpha_items", (b) => b.whereIndex("primary")),
+          forSchema(alphaSchema).findFirstNew("alpha_items", (b) => b.whereIndex("primary")),
         )
         .transformRetrieve(([result]) => result)
         .execute();

--- a/packages/fragno-db/src/hooks/durable-hooks-processor.test.ts
+++ b/packages/fragno-db/src/hooks/durable-hooks-processor.test.ts
@@ -31,7 +31,7 @@ const testFragmentDefinition = defineFragment("test")
     defineService({
       getItemCount() {
         return this.serviceTx(testSchema)
-          .retrieve((uow) => uow.findNew("items", (b) => b.whereIndex("primary")))
+          .retrieve((uow) => uow.find("items", (b) => b.whereIndex("primary")))
           .transformRetrieve(([items]) => items.length)
           .build();
       },

--- a/packages/fragno-db/src/hooks/durable-hooks-processor.test.ts
+++ b/packages/fragno-db/src/hooks/durable-hooks-processor.test.ts
@@ -31,7 +31,7 @@ const testFragmentDefinition = defineFragment("test")
     defineService({
       getItemCount() {
         return this.serviceTx(testSchema)
-          .retrieve((uow) => uow.find("items", (b) => b.whereIndex("primary")))
+          .retrieve((uow) => uow.findNew("items", (b) => b.whereIndex("primary")))
           .transformRetrieve(([items]) => items.length)
           .build();
       },

--- a/packages/fragno-db/src/migration-engine/auto-from-schema.test.ts
+++ b/packages/fragno-db/src/migration-engine/auto-from-schema.test.ts
@@ -86,66 +86,33 @@ describe("generateMigrationFromSchema", () => {
           return t.addColumn("id", idColumn());
         })
         .addTable("posts", (t) => {
-          return t.addColumn("id", idColumn()).addColumn("authorId", referenceColumn());
-        })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
+          return t
+            .addColumn("id", idColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }));
         });
     });
 
-    // Version 0 -> 1: users table
-    // Version 1 -> 2: posts table
-    // Version 2 -> 3: author foreign key
-    const operations = generateMigrationFromSchema(mySchema, 2, 3);
+    const operations = generateMigrationFromSchema(mySchema, 1, 2);
 
-    expect(operations).toHaveLength(1);
+    expect(operations).toHaveLength(2);
     expect(operations[0]).toMatchObject({
+      type: "create-table",
+      name: "posts",
+    });
+    expect(operations[1]).toMatchObject({
       type: "add-foreign-key",
       table: "posts",
     });
 
-    const fkOp = operations[0];
+    const fkOp = operations[1];
     if (fkOp.type === "add-foreign-key") {
       expect(fkOp.value).toMatchObject({
-        name: "author",
+        name: "posts_authorId_fk",
         referencedTable: "users",
         columns: ["authorId"],
         referencedColumns: ["_internalId"],
       });
     }
-  });
-
-  it("should skip add-foreign-key operation for join-only references", () => {
-    const mySchema = schema("my", (s) => {
-      return s
-        .addTable("users", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("email", column("string"))
-            .createIndex("idx_users_email", ["email"]);
-        })
-        .addTable("invitations", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("email", column("string"))
-            .createIndex("idx_inv_email", ["email"]);
-        })
-        .addReference("invitedUser", {
-          type: "one",
-          from: { table: "invitations", column: "email" },
-          to: { table: "users", column: "email" },
-          foreignKey: false,
-        });
-    });
-
-    // Version 0 -> 1: users table
-    // Version 1 -> 2: invitations table
-    // Version 2 -> 3: join-only relation (no FK)
-    const operations = generateMigrationFromSchema(mySchema, 2, 3);
-
-    expect(operations).toHaveLength(0);
   });
 
   it("should generate add-index operation for indexes added via alterTable", () => {
@@ -240,17 +207,14 @@ describe("generateMigrationFromSchema", () => {
           return t.addColumn("id", idColumn()).addColumn("name", column("string"));
         })
         .addTable("posts", (t) => {
-          return t.addColumn("id", idColumn()).addColumn("authorId", referenceColumn());
-        })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
+          return t
+            .addColumn("id", idColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }));
         });
     });
 
     // Generate all migrations from scratch
-    const operations = generateMigrationFromSchema(mySchema, 0, 3);
+    const operations = generateMigrationFromSchema(mySchema, 0, 2);
 
     expect(operations).toHaveLength(3);
     expect(operations[0].type).toBe("create-table");
@@ -268,17 +232,14 @@ describe("generateMigrationFromSchema", () => {
           return t.createIndex("idx_email", ["email"], { unique: true });
         })
         .addTable("posts", (t) => {
-          return t.addColumn("id", idColumn()).addColumn("authorId", referenceColumn());
-        })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
+          return t
+            .addColumn("id", idColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }));
         });
     });
 
     // Generate all migrations from scratch
-    const operations = generateMigrationFromSchema(mySchema, 0, 4);
+    const operations = generateMigrationFromSchema(mySchema, 0, 3);
 
     expect(operations).toHaveLength(4);
     expect(operations[0].type).toBe("create-table");
@@ -331,7 +292,7 @@ describe("generateMigrationFromSchema", () => {
     }).toThrow("fromVersion cannot be negative");
   });
 
-  it("should only create constraints for references, not for referenceColumns", () => {
+  it("should create constraints for referenceColumns", () => {
     const mySchema = schema("my", (s) => {
       return s
         .addTable("posts", (t) => {
@@ -339,17 +300,12 @@ describe("generateMigrationFromSchema", () => {
             .addColumn("id", idColumn().defaultTo("auto"))
             .addColumn("title", column("string"))
             .addColumn("content", column("string"))
-            .addColumn("userId", referenceColumn());
+            .addColumn("userId", referenceColumn({ table: "users" }));
         })
         .addTable("users", (t) => {
           return t
             .addColumn("id", idColumn().defaultTo("auto"))
             .addColumn("name", column("string"));
-        })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
         })
         .alterTable("posts", (t) => {
           return t
@@ -361,8 +317,8 @@ describe("generateMigrationFromSchema", () => {
     const operations = generateMigrationFromSchema(mySchema, 0, mySchema.version);
     expect(operations.map((o) => o.type)).toEqual([
       "create-table",
-      "create-table",
       "add-foreign-key",
+      "create-table",
       "alter-table",
       "add-index",
     ]);
@@ -373,13 +329,8 @@ describe("generateMigrationFromSchema", () => {
       return s
         .addTable("users", (t) => t.addColumn("id", idColumn()))
         .addTable("posts", (t) =>
-          t.addColumn("id", idColumn()).addColumn("userId", referenceColumn()),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        });
+          t.addColumn("id", idColumn()).addColumn("userId", referenceColumn({ table: "users" })),
+        );
     });
 
     const operations = generateMigrationFromSchema(mySchema, 0, mySchema.version);

--- a/packages/fragno-db/src/migration-engine/auto-from-schema.ts
+++ b/packages/fragno-db/src/migration-engine/auto-from-schema.ts
@@ -1,9 +1,4 @@
-import {
-  type AnySchema,
-  type AnyColumn,
-  type TableSubOperation,
-  type SchemaOperation,
-} from "../schema/create";
+import { type AnySchema, type AnyColumn, type TableSubOperation } from "../schema/create";
 import type {
   MigrationOperation,
   ColumnInfo,
@@ -49,6 +44,13 @@ function createTableState(operations: TableSubOperation[]): TableState {
         columns: [...subOp.columns],
         unique: subOp.unique,
       };
+    } else if (subOp.type === "add-foreign-key") {
+      state.foreignKeys.push({
+        name: subOp.name,
+        columns: [...subOp.columns],
+        referencedTable: subOp.referencedTable,
+        referencedColumns: [...subOp.referencedColumns],
+      });
     }
   }
 
@@ -88,6 +90,13 @@ function applyTableSubOperations(state: TableState, operations: TableSubOperatio
         columns: [...subOp.columns],
         unique: subOp.unique,
       };
+    } else if (subOp.type === "add-foreign-key") {
+      state.foreignKeys.push({
+        name: subOp.name,
+        columns: [...subOp.columns],
+        referencedTable: subOp.referencedTable,
+        referencedColumns: [...subOp.referencedColumns],
+      });
     }
   }
 }
@@ -199,21 +208,6 @@ function applyRenameDropToColumnList(
   return next;
 }
 
-function applyReferenceOperation(
-  state: TableState,
-  operation: Extract<SchemaOperation, { type: "add-reference" }>,
-): void {
-  if (operation.config.foreignKey === false) {
-    return;
-  }
-  state.foreignKeys.push({
-    name: operation.referenceName,
-    columns: [operation.config.from.column],
-    referencedTable: operation.config.to.table,
-    referencedColumns: [operation.config.to.column],
-  });
-}
-
 function buildTableStates(schema: AnySchema, version: number): Map<string, TableState> {
   const tableStates = new Map<string, TableState>();
   const operations = schema.operations.slice(0, version);
@@ -227,12 +221,6 @@ function buildTableStates(schema: AnySchema, version: number): Map<string, Table
         continue;
       }
       applyTableSubOperations(state, op.operations);
-    } else if (op.type === "add-reference") {
-      const state = tableStates.get(op.tableName);
-      if (!state) {
-        continue;
-      }
-      applyReferenceOperation(state, op);
     }
   }
 
@@ -447,7 +435,7 @@ export function generateMigrationFromSchema(
         migrationOperations.push(alterTableOperation);
       }
 
-      // Add indexes as separate operations
+      // Add indexes and foreign keys as separate operations
       for (const subOp of op.operations) {
         if (subOp.type === "add-index") {
           migrationOperations.push({
@@ -457,6 +445,17 @@ export function generateMigrationFromSchema(
             columns: subOp.columns,
             unique: subOp.unique,
           });
+        } else if (subOp.type === "add-foreign-key") {
+          migrationOperations.push({
+            type: "add-foreign-key",
+            table: op.tableName,
+            value: {
+              name: subOp.name,
+              columns: subOp.columns,
+              referencedTable: subOp.referencedTable,
+              referencedColumns: subOp.referencedColumns,
+            },
+          });
         }
       }
 
@@ -464,28 +463,6 @@ export function generateMigrationFromSchema(
         const nextState = cloneTableState(tableState);
         applyTableSubOperations(nextState, op.operations);
         tableStates.set(op.tableName, nextState);
-      }
-    } else if (op.type === "add-reference") {
-      if (!op.referenceName || op.referenceName.trim().length === 0) {
-        throw new Error(`referenceName is required for add-reference on ${op.tableName}`);
-      }
-      if (op.config.foreignKey === false) {
-        continue;
-      }
-      migrationOperations.push({
-        type: "add-foreign-key",
-        table: op.tableName,
-        value: {
-          name: op.referenceName,
-          columns: [op.config.from.column],
-          referencedTable: op.config.to.table,
-          referencedColumns: [op.config.to.column],
-        },
-      });
-
-      const tableState = tableStates.get(op.tableName);
-      if (tableState) {
-        applyReferenceOperation(tableState, op);
       }
     }
   }

--- a/packages/fragno-db/src/migration-engine/create.test.ts
+++ b/packages/fragno-db/src/migration-engine/create.test.ts
@@ -303,12 +303,9 @@ describe("createMigrator", () => {
             return t.addColumn("id", idColumn());
           })
           .addTable("posts", (t) => {
-            return t.addColumn("id", idColumn()).addColumn("authorId", referenceColumn());
-          })
-          .addReference("author", {
-            type: "one",
-            from: { table: "posts", column: "authorId" },
-            to: { table: "users", column: "id" },
+            return t
+              .addColumn("id", idColumn())
+              .addColumn("authorId", referenceColumn({ table: "users" }));
           });
       });
 

--- a/packages/fragno-db/src/outbox/outbox-builder.ts
+++ b/packages/fragno-db/src/outbox/outbox-builder.ts
@@ -1,7 +1,7 @@
 import { internalSchema } from "../fragments/internal-fragment.schema";
 import type { MutationOperation } from "../query/unit-of-work/unit-of-work";
 import type { AnySchema, AnyTable } from "../schema/create";
-import { FragnoId, FragnoReference } from "../schema/create";
+import { FragnoId, FragnoReference, getTableForeignKey } from "../schema/create";
 import type { OutboxRefLookup, OutboxPayload, OutboxMutation } from "./outbox";
 import { encodeVersionstamp, versionstampToHex } from "./outbox";
 
@@ -211,10 +211,9 @@ function createReferencePlaceholder(options: {
 }
 
 function resolveReferencedTable(table: AnyTable, columnName: string): AnyTable {
-  for (const relation of Object.values(table.relations)) {
-    if (relation.on.some(([localColumn]) => localColumn === columnName)) {
-      return relation.table;
-    }
+  const foreignKey = getTableForeignKey(table, columnName);
+  if (foreignKey) {
+    return foreignKey.referencedTable;
   }
 
   throw new Error(`Reference column ${columnName} not found in table ${table.name}`);

--- a/packages/fragno-db/src/outbox/outbox.test.ts
+++ b/packages/fragno-db/src/outbox/outbox.test.ts
@@ -159,7 +159,7 @@ async function listOutboxMutations(internalFragment: InternalFragmentInstance): 
   return internalFragment.inContext(async function (this: DatabaseRequestContext) {
     return await this.handlerTx()
       .retrieve(({ forSchema }) =>
-        forSchema(internalSchema).findNew("fragno_db_outbox_mutations", (b) =>
+        forSchema(internalSchema).find("fragno_db_outbox_mutations", (b) =>
           b
             .whereIndex("idx_outbox_mutations_entry")
             .orderByIndex("idx_outbox_mutations_entry", "asc"),
@@ -178,7 +178,7 @@ async function createUser(fragment: AnyFragnoInstantiatedDatabaseFragment, email
 
     const user = await this.handlerTx()
       .retrieve(({ forSchema }) =>
-        forSchema(outboxSchema).findFirstNew("users", (b) =>
+        forSchema(outboxSchema).findFirst("users", (b) =>
           b.whereIndex("idx_users_email", (eb) => eb("email", "=", email)),
         ),
       )

--- a/packages/fragno-db/src/outbox/outbox.test.ts
+++ b/packages/fragno-db/src/outbox/outbox.test.ts
@@ -29,13 +29,8 @@ const outboxSchema = schema("outbox", (s) => {
     .addTable("posts", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("authorId", referenceColumn())
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .addColumn("title", column("string"));
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
     });
 });
 

--- a/packages/fragno-db/src/outbox/outbox.test.ts
+++ b/packages/fragno-db/src/outbox/outbox.test.ts
@@ -159,7 +159,7 @@ async function listOutboxMutations(internalFragment: InternalFragmentInstance): 
   return internalFragment.inContext(async function (this: DatabaseRequestContext) {
     return await this.handlerTx()
       .retrieve(({ forSchema }) =>
-        forSchema(internalSchema).find("fragno_db_outbox_mutations", (b) =>
+        forSchema(internalSchema).findNew("fragno_db_outbox_mutations", (b) =>
           b
             .whereIndex("idx_outbox_mutations_entry")
             .orderByIndex("idx_outbox_mutations_entry", "asc"),
@@ -178,7 +178,7 @@ async function createUser(fragment: AnyFragnoInstantiatedDatabaseFragment, email
 
     const user = await this.handlerTx()
       .retrieve(({ forSchema }) =>
-        forSchema(outboxSchema).findFirst("users", (b) =>
+        forSchema(outboxSchema).findFirstNew("users", (b) =>
           b.whereIndex("idx_users_email", (eb) => eb("email", "=", email)),
         ),
       )

--- a/packages/fragno-db/src/query/find-options.ts
+++ b/packages/fragno-db/src/query/find-options.ts
@@ -1,4 +1,5 @@
 import type { AnyColumn, AnyRelation, AnyTable } from "../schema/create";
+import { getTableRelations } from "../schema/create";
 import { buildCondition, type Condition } from "./condition-builder";
 import type {
   AnySelectClause,
@@ -66,8 +67,10 @@ function buildJoin<TTable extends AnyTable>(
   const compiled: CompiledJoin[] = [];
   const builder: Record<string, unknown> = {};
 
-  for (const name in table.relations) {
-    const relation = table.relations[name]!;
+  const relations = getTableRelations(table);
+
+  for (const name in relations) {
+    const relation = relations[name]!;
 
     builder[name] = (options: FindFirstOptions | FindManyOptions = {}) => {
       compiled.push({

--- a/packages/fragno-db/src/query/mod.ts
+++ b/packages/fragno-db/src/query/mod.ts
@@ -1,4 +1,4 @@
-import type { IdColumn, AnyTable, Relation } from "../schema/create";
+import type { IdColumn, AnyTable } from "../schema/create";
 import type { Prettify } from "../util/types";
 import type { Condition, ConditionBuilder } from "./condition-builder";
 import type { FindBuilder } from "./unit-of-work/unit-of-work";
@@ -49,25 +49,7 @@ export type SelectResult<T extends AnyTable, JoinOut, Select extends SelectClaus
   MainSelectResult<Select, T> & JoinOut
 >;
 
-interface MapRelationType<Type> {
-  one: Type | null;
-  many: Type[];
-}
-
-export type JoinBuilder<T extends AnyTable, Out = {}> = {
-  [K in keyof T["relations"]]: T["relations"][K] extends Relation<infer Type, infer Target>
-    ? <Select extends SelectClause<Target> = true, JoinOut = {}>(
-        options?: FindManyOptions<Target, Select, JoinOut, false>,
-      ) => JoinBuilder<
-        T,
-        Prettify<
-          Out & {
-            [$K in K]: MapRelationType<SelectResult<Target, JoinOut, Select>>[Type];
-          }
-        >
-      >
-    : never;
-};
+export type JoinBuilder<_T extends AnyTable, _Out = {}> = never;
 
 export type OrderBy<Column = string> = [columnName: Column, "asc" | "desc"];
 
@@ -117,7 +99,7 @@ export type FindManyOptions<
   where?: (eb: ConditionBuilder<T["columns"]>) => Condition | boolean;
   limit?: number;
   orderBy?: OrderBy<keyof T["columns"]> | OrderBy<keyof T["columns"]>[];
-  join?: (jb: JoinBuilder<T>) => void;
+  join?: never;
 } & (IsRoot extends true
   ? {
       // drizzle doesn't support `offset` in join queries (this may be changed in future, we can add it back)

--- a/packages/fragno-db/src/query/query-type.test.ts
+++ b/packages/fragno-db/src/query/query-type.test.ts
@@ -170,28 +170,18 @@ describe("query type tests", () => {
           return t
             .addColumn("id", idColumn())
             .addColumn("title", column("string"))
-            .addColumn("userId", referenceColumn());
+            .addColumn("userId", referenceColumn({ table: "users" }));
         })
         .addTable("tags", (t) => {
           return t.addColumn("id", idColumn()).addColumn("name", column("string"));
-        })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
         });
     });
 
-    it("should handle join correctly", () => {
+    it("removes relation-key join builder typing", () => {
       const _table = userSchema.tables.posts;
-      const _relations = _table.relations;
-
-      type _Relations = typeof _table.relations;
       type Builder1 = JoinBuilder<typeof _table>;
 
-      expectTypeOf<Builder1>().toExtend<{
-        author: () => void;
-      }>();
+      expectTypeOf<Builder1>().toEqualTypeOf<never>();
     });
   });
 

--- a/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
@@ -182,7 +182,7 @@ describe("Unified Tx API", () => {
       const baseUow = createUnitOfWork(compiler, executor, decoder);
 
       const txResult = createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
         .build();
 
       expect(isTxResult(txResult)).toBe(true);
@@ -217,7 +217,7 @@ describe("Unified Tx API", () => {
       const baseUow = createUnitOfWork(compiler, executor, decoder);
 
       const txResult = createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
         .build();
 
       expect(isTxResult(txResult)).toBe(true);
@@ -244,7 +244,7 @@ describe("Unified Tx API", () => {
       const baseUow = createUnitOfWork(compiler, executor, decoder);
 
       const txResult = createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
 
@@ -272,7 +272,7 @@ describe("Unified Tx API", () => {
 
       // Create a dependency TxResult
       const depTxResult = createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
 
@@ -335,7 +335,7 @@ describe("Unified Tx API", () => {
 
       // When success is provided but mutate is NOT, mutateResult should be undefined
       createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
         .transformRetrieve(([users]) => users[0] ?? null)
         // NO mutate callback
         .transform(({ mutateResult, retrieveResult }) => {
@@ -371,7 +371,7 @@ describe("Unified Tx API", () => {
       // When retrieve IS provided but retrieveSuccess is NOT, retrieveResult should be TRetrieveResults
       // (the raw array from the retrieve callback), NOT unknown
       createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
         // NO transformRetrieve callback - this is the key scenario
         .mutate(({ uow, retrieveResult }) => {
           // Key type assertion: retrieveResult should be the raw array type, NOT unknown
@@ -423,7 +423,7 @@ describe("Unified Tx API", () => {
         createUnitOfWork: () => createUnitOfWork(compiler, executor, decoder),
       })
         .retrieve(({ forSchema }) =>
-          forSchema(testSchema).findNew("users", (b) => b.whereIndex("idx_email")),
+          forSchema(testSchema).find("users", (b) => b.whereIndex("idx_email")),
         )
         .execute();
 
@@ -454,7 +454,7 @@ describe("Unified Tx API", () => {
         onAfterRetrieve,
       })
         .retrieve(({ forSchema }) =>
-          forSchema(testSchema).findNew("users", (b) => b.whereIndex("idx_email")),
+          forSchema(testSchema).find("users", (b) => b.whereIndex("idx_email")),
         )
         .execute();
 
@@ -525,7 +525,7 @@ describe("Unified Tx API", () => {
       // Service that retrieves
       const getUserById = () => {
         return createServiceTxBuilder(testSchema, currentUow!)
-          .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
       };
@@ -562,7 +562,7 @@ describe("Unified Tx API", () => {
       // Service that retrieves
       const getUserById = () => {
         return createServiceTxBuilder(testSchema, currentUow!)
-          .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
       };
@@ -612,7 +612,7 @@ describe("Unified Tx API", () => {
       // Service that retrieves
       const getUserById = () => {
         return createServiceTxBuilder(testSchema, currentUow!)
-          .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
       };
@@ -669,7 +669,7 @@ describe("Unified Tx API", () => {
       const getUserById = (userId: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
@@ -931,7 +931,7 @@ describe("Unified Tx API", () => {
         retryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 5, initialDelayMs: 1 }),
       })
         .retrieve(({ forSchema }) =>
-          forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary")),
+          forSchema(testSchema).find("users", (b) => b.whereIndex("primary")),
         )
         .mutate(({ forSchema }) => {
           forSchema(testSchema).create("users", {
@@ -963,7 +963,7 @@ describe("Unified Tx API", () => {
           retryPolicy: new NoRetryPolicy(),
         })
           .retrieve(({ forSchema }) =>
-            forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary")),
+            forSchema(testSchema).find("users", (b) => b.whereIndex("primary")),
           )
           .mutate(() => ({ done: true }))
           .execute(),
@@ -1015,7 +1015,7 @@ describe("Unified Tx API", () => {
         retryPolicy: new LinearBackoffRetryPolicy({ maxRetries: 3, delayMs: 1 }),
       })
         .retrieve(({ forSchema }) =>
-          forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary")),
+          forSchema(testSchema).find("users", (b) => b.whereIndex("primary")),
         )
         .mutate(({ forSchema }) => {
           forSchema(testSchema).create("users", {
@@ -1050,7 +1050,7 @@ describe("Unified Tx API", () => {
           signal: controller.signal,
         })
           .retrieve(({ forSchema }) =>
-            forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary")),
+            forSchema(testSchema).find("users", (b) => b.whereIndex("primary")),
           )
           .mutate(() => ({ done: true }))
           .execute(),
@@ -1076,7 +1076,7 @@ describe("Unified Tx API", () => {
       const createIfNotExists = (email: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.findNew("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
+            uow.find("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
           )
           .mutate(({ uow, retrieveResult: [users] }) => {
             if (users.length > 0) {
@@ -1114,7 +1114,7 @@ describe("Unified Tx API", () => {
       const createIfNotExists = (email: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.findNew("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
+            uow.find("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
           )
           .mutate(({ uow, retrieveResult: [users] }) => {
             if (users.length > 0) {
@@ -1159,7 +1159,7 @@ describe("Unified Tx API", () => {
       const getUserAndUpdateBalance = (userId: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .mutate(({ uow, retrieveResult: user }) => {
@@ -1298,7 +1298,7 @@ describe("Unified Tx API", () => {
       // Service that just retrieves
       const getUser = () => {
         return createServiceTxBuilder(testSchema, currentUow!)
-          .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
       };
@@ -1338,7 +1338,7 @@ describe("Unified Tx API", () => {
       const getUserById = () => {
         return (
           createServiceTxBuilder(testSchema, currentUow!)
-            .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+            .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
             // This transformRetrieve transforms the result
             .transformRetrieve(([users]) => ({ transformed: true, user: users[0] }))
             .build()
@@ -1382,7 +1382,7 @@ describe("Unified Tx API", () => {
       const getUserById = () => {
         return (
           createServiceTxBuilder(testSchema, currentUow!)
-            .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
+            .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
             .transformRetrieve(([users]) => users[0])
             // This mutate returns a different result
             .mutate(({ retrieveResult: user }) => ({ mutated: true, userId: user?.id }))
@@ -1524,7 +1524,7 @@ describe("Unified Tx API", () => {
         }
         return createServiceTxBuilder(testSchema, currentUow)
           .retrieve((uow) =>
-            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
@@ -1599,7 +1599,7 @@ describe("Unified Tx API", () => {
       const getUserById = (userId: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
@@ -1669,7 +1669,7 @@ describe("Unified Tx API", () => {
       const getUserById = (userId: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
@@ -1757,7 +1757,7 @@ describe("Unified Tx API", () => {
       const subscribeUser = (email: string) => {
         return createServiceTxBuilder(testSchema, currentUow!, hooks)
           .retrieve((uow) =>
-            uow.findNew("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
+            uow.find("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .mutate(({ uow, retrieveResult: existingUser }) => {
@@ -1827,7 +1827,7 @@ describe("Unified Tx API", () => {
         return (
           createServiceTxBuilder(testSchema, currentUow!, hooks)
             .retrieve((uow) =>
-              uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+              uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
             )
             // NO transformRetrieve - mutate receives raw [users[]] array
             .mutate(({ uow, retrieveResult: [users] }) => {
@@ -1913,7 +1913,7 @@ describe("Unified Tx API", () => {
       const hooks = await (async () => {
         const uow = internalQuery
           .createUnitOfWork("read")
-          .findNew("fragno_hooks", (b) => b.whereIndex("primary"));
+          .find("fragno_hooks", (b) => b.whereIndex("primary"));
         await uow.executeRetrieve();
         return (await uow.retrievalPhase)[0];
       })();
@@ -1977,7 +1977,7 @@ describe("Unified Tx API", () => {
       const hooks = await (async () => {
         const uow = internalQuery
           .createUnitOfWork("read")
-          .findNew("fragno_hooks", (b) => b.whereIndex("primary"));
+          .find("fragno_hooks", (b) => b.whereIndex("primary"));
         await uow.executeRetrieve();
         return (await uow.retrievalPhase)[0];
       })();

--- a/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
@@ -182,7 +182,7 @@ describe("Unified Tx API", () => {
       const baseUow = createUnitOfWork(compiler, executor, decoder);
 
       const txResult = createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
         .build();
 
       expect(isTxResult(txResult)).toBe(true);
@@ -217,7 +217,7 @@ describe("Unified Tx API", () => {
       const baseUow = createUnitOfWork(compiler, executor, decoder);
 
       const txResult = createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
         .build();
 
       expect(isTxResult(txResult)).toBe(true);
@@ -244,7 +244,7 @@ describe("Unified Tx API", () => {
       const baseUow = createUnitOfWork(compiler, executor, decoder);
 
       const txResult = createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
 
@@ -272,7 +272,7 @@ describe("Unified Tx API", () => {
 
       // Create a dependency TxResult
       const depTxResult = createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
         .transformRetrieve(([users]) => users[0] ?? null)
         .build();
 
@@ -335,7 +335,7 @@ describe("Unified Tx API", () => {
 
       // When success is provided but mutate is NOT, mutateResult should be undefined
       createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
         .transformRetrieve(([users]) => users[0] ?? null)
         // NO mutate callback
         .transform(({ mutateResult, retrieveResult }) => {
@@ -371,7 +371,7 @@ describe("Unified Tx API", () => {
       // When retrieve IS provided but retrieveSuccess is NOT, retrieveResult should be TRetrieveResults
       // (the raw array from the retrieve callback), NOT unknown
       createServiceTxBuilder(testSchema, baseUow)
-        .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+        .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
         // NO transformRetrieve callback - this is the key scenario
         .mutate(({ uow, retrieveResult }) => {
           // Key type assertion: retrieveResult should be the raw array type, NOT unknown
@@ -423,7 +423,7 @@ describe("Unified Tx API", () => {
         createUnitOfWork: () => createUnitOfWork(compiler, executor, decoder),
       })
         .retrieve(({ forSchema }) =>
-          forSchema(testSchema).find("users", (b) => b.whereIndex("idx_email")),
+          forSchema(testSchema).findNew("users", (b) => b.whereIndex("idx_email")),
         )
         .execute();
 
@@ -454,7 +454,7 @@ describe("Unified Tx API", () => {
         onAfterRetrieve,
       })
         .retrieve(({ forSchema }) =>
-          forSchema(testSchema).find("users", (b) => b.whereIndex("idx_email")),
+          forSchema(testSchema).findNew("users", (b) => b.whereIndex("idx_email")),
         )
         .execute();
 
@@ -525,7 +525,7 @@ describe("Unified Tx API", () => {
       // Service that retrieves
       const getUserById = () => {
         return createServiceTxBuilder(testSchema, currentUow!)
-          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+          .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
       };
@@ -562,7 +562,7 @@ describe("Unified Tx API", () => {
       // Service that retrieves
       const getUserById = () => {
         return createServiceTxBuilder(testSchema, currentUow!)
-          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+          .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
       };
@@ -612,7 +612,7 @@ describe("Unified Tx API", () => {
       // Service that retrieves
       const getUserById = () => {
         return createServiceTxBuilder(testSchema, currentUow!)
-          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+          .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
       };
@@ -669,7 +669,7 @@ describe("Unified Tx API", () => {
       const getUserById = (userId: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
@@ -930,7 +930,9 @@ describe("Unified Tx API", () => {
         createUnitOfWork: () => createUnitOfWork(compiler, executor, decoder),
         retryPolicy: new ExponentialBackoffRetryPolicy({ maxRetries: 5, initialDelayMs: 1 }),
       })
-        .retrieve(({ forSchema }) => forSchema(testSchema).find("users"))
+        .retrieve(({ forSchema }) =>
+          forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary")),
+        )
         .mutate(({ forSchema }) => {
           forSchema(testSchema).create("users", {
             email: "test@example.com",
@@ -960,7 +962,9 @@ describe("Unified Tx API", () => {
           createUnitOfWork: () => createUnitOfWork(compiler, executor, decoder),
           retryPolicy: new NoRetryPolicy(),
         })
-          .retrieve(({ forSchema }) => forSchema(testSchema).find("users"))
+          .retrieve(({ forSchema }) =>
+            forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary")),
+          )
           .mutate(() => ({ done: true }))
           .execute(),
       ).rejects.toThrow(ConcurrencyConflictError);
@@ -1010,7 +1014,9 @@ describe("Unified Tx API", () => {
         },
         retryPolicy: new LinearBackoffRetryPolicy({ maxRetries: 3, delayMs: 1 }),
       })
-        .retrieve(({ forSchema }) => forSchema(testSchema).find("users"))
+        .retrieve(({ forSchema }) =>
+          forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary")),
+        )
         .mutate(({ forSchema }) => {
           forSchema(testSchema).create("users", {
             email: "test@example.com",
@@ -1043,7 +1049,9 @@ describe("Unified Tx API", () => {
           retryPolicy: new LinearBackoffRetryPolicy({ maxRetries: 5, delayMs: 100 }),
           signal: controller.signal,
         })
-          .retrieve(({ forSchema }) => forSchema(testSchema).find("users"))
+          .retrieve(({ forSchema }) =>
+            forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary")),
+          )
           .mutate(() => ({ done: true }))
           .execute(),
       ).rejects.toThrow("Transaction execution aborted");
@@ -1068,7 +1076,7 @@ describe("Unified Tx API", () => {
       const createIfNotExists = (email: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.find("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
+            uow.findNew("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
           )
           .mutate(({ uow, retrieveResult: [users] }) => {
             if (users.length > 0) {
@@ -1106,7 +1114,7 @@ describe("Unified Tx API", () => {
       const createIfNotExists = (email: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.find("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
+            uow.findNew("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
           )
           .mutate(({ uow, retrieveResult: [users] }) => {
             if (users.length > 0) {
@@ -1151,7 +1159,7 @@ describe("Unified Tx API", () => {
       const getUserAndUpdateBalance = (userId: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .mutate(({ uow, retrieveResult: user }) => {
@@ -1290,7 +1298,7 @@ describe("Unified Tx API", () => {
       // Service that just retrieves
       const getUser = () => {
         return createServiceTxBuilder(testSchema, currentUow!)
-          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+          .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
       };
@@ -1330,7 +1338,7 @@ describe("Unified Tx API", () => {
       const getUserById = () => {
         return (
           createServiceTxBuilder(testSchema, currentUow!)
-            .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+            .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
             // This transformRetrieve transforms the result
             .transformRetrieve(([users]) => ({ transformed: true, user: users[0] }))
             .build()
@@ -1374,7 +1382,7 @@ describe("Unified Tx API", () => {
       const getUserById = () => {
         return (
           createServiceTxBuilder(testSchema, currentUow!)
-            .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+            .retrieve((uow) => uow.findNew("users", (b) => b.whereIndex("idx_email")))
             .transformRetrieve(([users]) => users[0])
             // This mutate returns a different result
             .mutate(({ retrieveResult: user }) => ({ mutated: true, userId: user?.id }))
@@ -1516,7 +1524,7 @@ describe("Unified Tx API", () => {
         }
         return createServiceTxBuilder(testSchema, currentUow)
           .retrieve((uow) =>
-            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
@@ -1591,7 +1599,7 @@ describe("Unified Tx API", () => {
       const getUserById = (userId: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
@@ -1661,7 +1669,7 @@ describe("Unified Tx API", () => {
       const getUserById = (userId: string) => {
         return createServiceTxBuilder(testSchema, currentUow!)
           .retrieve((uow) =>
-            uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+            uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .build();
@@ -1749,7 +1757,7 @@ describe("Unified Tx API", () => {
       const subscribeUser = (email: string) => {
         return createServiceTxBuilder(testSchema, currentUow!, hooks)
           .retrieve((uow) =>
-            uow.find("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
+            uow.findNew("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email))),
           )
           .transformRetrieve(([users]) => users[0] ?? null)
           .mutate(({ uow, retrieveResult: existingUser }) => {
@@ -1819,7 +1827,7 @@ describe("Unified Tx API", () => {
         return (
           createServiceTxBuilder(testSchema, currentUow!, hooks)
             .retrieve((uow) =>
-              uow.find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
+              uow.findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId))),
             )
             // NO transformRetrieve - mutate receives raw [users[]] array
             .mutate(({ uow, retrieveResult: [users] }) => {
@@ -1903,7 +1911,9 @@ describe("Unified Tx API", () => {
         .execute();
 
       const hooks = await (async () => {
-        const uow = internalQuery.createUnitOfWork("read").find("fragno_hooks");
+        const uow = internalQuery
+          .createUnitOfWork("read")
+          .findNew("fragno_hooks", (b) => b.whereIndex("primary"));
         await uow.executeRetrieve();
         return (await uow.retrievalPhase)[0];
       })();
@@ -1965,7 +1975,9 @@ describe("Unified Tx API", () => {
         .execute();
 
       const hooks = await (async () => {
-        const uow = internalQuery.createUnitOfWork("read").find("fragno_hooks");
+        const uow = internalQuery
+          .createUnitOfWork("read")
+          .findNew("fragno_hooks", (b) => b.whereIndex("primary"));
         await uow.executeRetrieve();
         return (await uow.retrievalPhase)[0];
       })();

--- a/packages/fragno-db/src/query/unit-of-work/query-tree-decoder.ts
+++ b/packages/fragno-db/src/query/unit-of-work/query-tree-decoder.ts
@@ -1,0 +1,113 @@
+import type { DriverConfig } from "../../adapters/generic-sql/driver-config";
+import type { SQLiteStorageMode } from "../../adapters/generic-sql/sqlite-storage";
+import type { NamingResolver } from "../../naming/sql-naming";
+import type { AnyTable } from "../../schema/create";
+import { decodeResult } from "../value-decoding";
+import type { CompiledQueryTreeChildNode, CompiledQueryTreeRootNode } from "./query-tree";
+
+const parseJsonValue = (value: unknown): unknown => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return value;
+  }
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return value;
+  }
+};
+
+const decodeNodeColumns = (
+  row: Record<string, unknown>,
+  table: AnyTable,
+  driverConfig: DriverConfig,
+  sqliteStorageMode?: SQLiteStorageMode,
+  resolver?: NamingResolver,
+): Record<string, unknown> => {
+  const columnOnlyRow: Record<string, unknown> = {};
+
+  for (const key in row) {
+    if (table.columns[key] || key in table.columns) {
+      columnOnlyRow[key] = row[key];
+      continue;
+    }
+
+    if (resolver) {
+      const columnMap = resolver.getColumnNameMap(table);
+      const logicalName = columnMap[key];
+      if (logicalName && table.columns[logicalName]) {
+        columnOnlyRow[key] = row[key];
+      }
+    }
+  }
+
+  return decodeResult(columnOnlyRow, table, driverConfig, sqliteStorageMode, resolver);
+};
+
+const decodeChildNode = (
+  value: unknown,
+  node: CompiledQueryTreeChildNode,
+  driverConfig: DriverConfig,
+  sqliteStorageMode?: SQLiteStorageMode,
+  resolver?: NamingResolver,
+): unknown => {
+  if (value === null || value === undefined) {
+    return node.cardinality === "many" ? [] : null;
+  }
+
+  const parsed = parseJsonValue(value);
+  if (node.cardinality === "many") {
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.map((item) =>
+      decodeQueryTreeRow(
+        item as Record<string, unknown>,
+        node,
+        driverConfig,
+        sqliteStorageMode,
+        resolver,
+      ),
+    );
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+
+  return decodeQueryTreeRow(
+    parsed as Record<string, unknown>,
+    node,
+    driverConfig,
+    sqliteStorageMode,
+    resolver,
+  );
+};
+
+export const decodeQueryTreeRow = (
+  row: Record<string, unknown>,
+  node: CompiledQueryTreeRootNode | CompiledQueryTreeChildNode,
+  driverConfig: DriverConfig,
+  sqliteStorageMode?: SQLiteStorageMode,
+  resolver?: NamingResolver,
+): Record<string, unknown> => {
+  const output = decodeNodeColumns(row, node.table, driverConfig, sqliteStorageMode, resolver);
+
+  for (const child of node.children) {
+    output[child.alias] = decodeChildNode(
+      row[child.alias],
+      child,
+      driverConfig,
+      sqliteStorageMode,
+      resolver,
+    );
+  }
+
+  return output;
+};

--- a/packages/fragno-db/src/query/unit-of-work/query-tree.ts
+++ b/packages/fragno-db/src/query/unit-of-work/query-tree.ts
@@ -1,0 +1,816 @@
+import type { AnyColumn, AnySchema, AnyTable, IdColumn, Index } from "../../schema/create";
+import { createIndexedBuilder, type Condition, type ConditionBuilder } from "../condition-builder";
+import type { Cursor } from "../cursor";
+import type { AnySelectClause, SelectClause, SelectResult } from "../mod";
+
+/**
+ * Extract column names from a single index.
+ */
+type IndexColumns<TIndex extends Index> = TIndex["columnNames"][number];
+
+type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
+type RemoveEmptyObject<T> = T extends object ? (keyof T extends never ? never : T) : never;
+
+type InferIdColumnName<TTable extends AnyTable> = keyof OmitNever<{
+  [K in keyof TTable["columns"]]: TTable["columns"][K] extends IdColumn<
+    infer _,
+    infer __,
+    infer ___
+  >
+    ? K
+    : never;
+}>;
+
+type ColumnsForIndex<
+  TTable extends AnyTable,
+  TIndexName extends QueryTreeValidIndexName<TTable>,
+> = TIndexName extends "primary"
+  ? Pick<TTable["columns"], InferIdColumnName<TTable>>
+  : TIndexName extends keyof TTable["indexes"]
+    ? Pick<TTable["columns"], IndexColumns<TTable["indexes"][TIndexName]>>
+    : never;
+
+export type QueryTreeValidIndexName<TTable extends AnyTable> =
+  | "primary"
+  | (string & keyof TTable["indexes"]);
+
+export class ParentColumnRef<TColumn extends AnyColumn = AnyColumn> {
+  readonly column: TColumn;
+
+  constructor(column: TColumn) {
+    this.column = column;
+  }
+}
+
+export const isParentColumnRef = (value: unknown): value is ParentColumnRef =>
+  value instanceof ParentColumnRef;
+
+type QueryTreeCardinality = "one" | "many";
+
+type MapCardinality<T> = {
+  one: RemoveEmptyObject<T> | null;
+  many: RemoveEmptyObject<T>[];
+};
+
+type CorrelatedConditionValue<TColumn extends AnyColumn> = TColumn["$in"] | ParentColumnRef | null;
+
+export type CorrelatedIndexSpecificConditionBuilder<
+  TChildTable extends AnyTable,
+  TParentTable extends AnyTable,
+  TIndexName extends QueryTreeValidIndexName<TChildTable>,
+> = {
+  <ColName extends keyof ColumnsForIndex<TChildTable, TIndexName>>(
+    a: ColName,
+    operator:
+      | "="
+      | "!="
+      | ">"
+      | ">="
+      | "<"
+      | "<="
+      | "is"
+      | "is not"
+      | "contains"
+      | "starts with"
+      | "ends with"
+      | "not contains"
+      | "not starts with"
+      | "not ends with",
+    b: CorrelatedConditionValue<ColumnsForIndex<TChildTable, TIndexName>[ColName]>,
+  ): Condition;
+
+  <ColName extends keyof ColumnsForIndex<TChildTable, TIndexName>>(
+    a: ColName,
+    operator: "in" | "not in",
+    b: Array<CorrelatedConditionValue<ColumnsForIndex<TChildTable, TIndexName>[ColName]>>,
+  ): Condition;
+
+  <ColName extends keyof ColumnsForIndex<TChildTable, TIndexName>>(a: ColName): Condition;
+
+  and: (...v: (Condition | boolean)[]) => Condition | boolean;
+  or: (...v: (Condition | boolean)[]) => Condition | boolean;
+  not: (v: Condition | boolean) => Condition | boolean;
+  isNull: (a: keyof ColumnsForIndex<TChildTable, TIndexName>) => Condition;
+  isNotNull: (a: keyof ColumnsForIndex<TChildTable, TIndexName>) => Condition;
+  parent: <ColName extends keyof TParentTable["columns"]>(
+    name: ColName,
+  ) => ParentColumnRef<TParentTable["columns"][ColName]>;
+};
+
+const getIndexedColumnNames = (table: AnyTable, indexName: string): Set<string> => {
+  if (indexName === "_primary") {
+    return new Set([table.getIdColumn().name]);
+  }
+
+  const index = table.indexes[indexName];
+  if (!index) {
+    throw new Error(`Index "${indexName}" not found on table "${table.name}".`);
+  }
+
+  return new Set(index.columnNames as readonly string[]);
+};
+
+export function buildCorrelatedCondition<
+  TChildTable extends AnyTable,
+  TParentTable extends AnyTable,
+  TIndexName extends QueryTreeValidIndexName<TChildTable>,
+>(
+  childTable: TChildTable,
+  parentTable: TParentTable,
+  indexName: TIndexName,
+  input: (
+    builder: CorrelatedIndexSpecificConditionBuilder<TChildTable, TParentTable, TIndexName>,
+  ) => Condition | boolean,
+): Condition | boolean {
+  const normalizedIndexName = indexName === "primary" ? "_primary" : indexName;
+  const indexedColumns = getIndexedColumnNames(childTable, normalizedIndexName);
+  const indexedBuilder = createIndexedBuilder(childTable.columns, indexedColumns);
+
+  const builder = indexedBuilder as unknown as CorrelatedIndexSpecificConditionBuilder<
+    TChildTable,
+    TParentTable,
+    TIndexName
+  >;
+
+  builder.parent = ((name) => {
+    const column = parentTable.columns[name as string];
+    if (!column) {
+      throw new Error(`Invalid parent column name ${String(name)}`);
+    }
+    return new ParentColumnRef(column);
+  }) as CorrelatedIndexSpecificConditionBuilder<TChildTable, TParentTable, TIndexName>["parent"];
+
+  return input(builder);
+}
+
+export type QueryTreeOrderBy = {
+  indexName: string;
+  direction: "asc" | "desc";
+};
+
+export interface CompiledQueryTreeChildNode<TTable extends AnyTable = AnyTable> {
+  kind: "child";
+  alias: string;
+  table: TTable;
+  cardinality: QueryTreeCardinality;
+  onIndexName: string;
+  onIndex?: Condition;
+  where?: Condition;
+  select: AnySelectClause;
+  orderByIndex?: QueryTreeOrderBy;
+  pageSize?: number;
+  children: CompiledQueryTreeChildNode[];
+}
+
+export interface CompiledQueryTreeRootNode<TTable extends AnyTable = AnyTable> {
+  kind: "root";
+  table: TTable;
+  useIndex: string;
+  where?: Condition;
+  select: AnySelectClause;
+  orderByIndex?: QueryTreeOrderBy;
+  after?: Cursor | string;
+  before?: Cursor | string;
+  pageSize?: number;
+  children: CompiledQueryTreeChildNode[];
+}
+
+export interface CompiledQueryTreeCountNode<TTable extends AnyTable = AnyTable> {
+  kind: "count";
+  table: TTable;
+  useIndex: string;
+  where?: Condition;
+}
+
+export interface QueryTreeCountBuilderMarker {
+  readonly __queryTreeCount: true;
+}
+
+export type ExtractQueryTreeBuilderCount<T> = T extends QueryTreeCountBuilderMarker ? true : false;
+
+export function getQueryTreeSelectedColumnNames(
+  table: AnyTable,
+  select: AnySelectClause,
+  extraColumnNames: readonly string[] = [],
+): string[] {
+  const selected = Array.isArray(select) ? [...select] : Object.keys(table.columns);
+  const result = new Set<string>(selected);
+
+  for (const extra of extraColumnNames) {
+    result.add(extra);
+  }
+
+  for (const key in table.columns) {
+    if (table.columns[key]?.isHidden) {
+      result.add(key);
+    }
+  }
+
+  return Array.from(result);
+}
+
+export type ExtractQueryTreeBuilderSelect<T> =
+  T extends QueryTreeFindBuilder<infer _, infer __, infer TSelect, infer ___>
+    ? TSelect
+    : T extends QueryTreeJoinBuilder<infer _, infer __, infer ___, infer TSelect, infer ____>
+      ? TSelect
+      : true;
+
+export type ExtractQueryTreeBuilderOut<T> =
+  T extends QueryTreeFindBuilder<infer _, infer __, infer ___, infer TJoinOut>
+    ? TJoinOut
+    : T extends QueryTreeJoinBuilder<infer _, infer __, infer ___, infer ____, infer TJoinOut>
+      ? TJoinOut
+      : {};
+
+export class QueryTreeJoinBuilder<
+  TSchema extends AnySchema,
+  TTable extends AnyTable,
+  TParentTable extends AnyTable,
+  TSelect extends SelectClause<TTable> = true,
+  TJoinOut = {},
+> {
+  readonly #schema: TSchema;
+  readonly #table: TTable;
+  readonly #tableName: string;
+  readonly #parentTable: TParentTable;
+
+  #onIndexName?: string;
+  #onIndexCondition?: Condition;
+  #whereCondition?: Condition;
+  #selectClause?: TSelect;
+  #orderByIndexClause?: QueryTreeOrderBy;
+  #pageSizeValue?: number;
+  #children: CompiledQueryTreeChildNode[] = [];
+
+  constructor(schema: TSchema, tableName: string, table: TTable, parentTable: TParentTable) {
+    this.#schema = schema;
+    this.#tableName = tableName;
+    this.#table = table;
+    this.#parentTable = parentTable;
+  }
+
+  onIndex<TIndexName extends QueryTreeValidIndexName<TTable>>(
+    indexName: TIndexName,
+    condition?: (
+      eb: CorrelatedIndexSpecificConditionBuilder<TTable, TParentTable, TIndexName>,
+    ) => Condition | boolean,
+  ): this {
+    if (indexName !== "primary" && !(indexName in this.#table.indexes)) {
+      throw new Error(
+        `Index "${String(indexName)}" not found on table "${this.#tableName}". ` +
+          `Available indexes: primary, ${Object.keys(this.#table.indexes).join(", ")}`,
+      );
+    }
+
+    this.#onIndexName = indexName === "primary" ? "_primary" : indexName;
+    if (condition) {
+      const compiled = buildCorrelatedCondition(
+        this.#table,
+        this.#parentTable,
+        indexName,
+        condition,
+      );
+      if (compiled === false) {
+        throw new Error(
+          `onIndex() cannot compile to false on table "${this.#tableName}" in query-tree joins.`,
+        );
+      }
+      this.#onIndexCondition = compiled === true ? undefined : compiled;
+    }
+    return this;
+  }
+
+  whereIndex<TIndexName extends QueryTreeValidIndexName<TTable>>(
+    indexName: TIndexName,
+    condition?: (eb: ConditionBuilder<ColumnsForIndex<TTable, TIndexName>>) => Condition | boolean,
+  ): this {
+    if (indexName !== "primary" && !(indexName in this.#table.indexes)) {
+      throw new Error(
+        `Index "${String(indexName)}" not found on table "${this.#tableName}". ` +
+          `Available indexes: primary, ${Object.keys(this.#table.indexes).join(", ")}`,
+      );
+    }
+
+    if (condition) {
+      const normalizedIndexName = indexName === "primary" ? "_primary" : indexName;
+      const indexedColumns = getIndexedColumnNames(this.#table, normalizedIndexName);
+      const compiled = condition(
+        createIndexedBuilder(this.#table.columns, indexedColumns) as unknown as ConditionBuilder<
+          ColumnsForIndex<TTable, TIndexName>
+        >,
+      );
+      if (compiled === false) {
+        throw new Error(
+          `whereIndex() cannot compile to false on table "${this.#tableName}" in query-tree joins.`,
+        );
+      }
+      this.#whereCondition = compiled === true ? undefined : compiled;
+    }
+    return this;
+  }
+
+  select<const TNewSelect extends SelectClause<TTable>>(
+    columns: TNewSelect,
+  ): QueryTreeJoinBuilder<TSchema, TTable, TParentTable, TNewSelect, TJoinOut> {
+    // prettier-ignore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this as any).#selectClause = columns;
+    return this as unknown as QueryTreeJoinBuilder<
+      TSchema,
+      TTable,
+      TParentTable,
+      TNewSelect,
+      TJoinOut
+    >;
+  }
+
+  orderByIndex<TIndexName extends QueryTreeValidIndexName<TTable>>(
+    indexName: TIndexName,
+    direction: "asc" | "desc",
+  ): this {
+    if (indexName !== "primary" && !(indexName in this.#table.indexes)) {
+      throw new Error(
+        `Index "${String(indexName)}" not found on table "${this.#tableName}". ` +
+          `Available indexes: primary, ${Object.keys(this.#table.indexes).join(", ")}`,
+      );
+    }
+
+    this.#orderByIndexClause = {
+      indexName: indexName === "primary" ? "_primary" : indexName,
+      direction,
+    };
+    return this;
+  }
+
+  pageSize(size: number): this {
+    if (!Number.isInteger(size) || size <= 0) {
+      throw new RangeError(`pageSize must be a positive integer, received: ${size}`);
+    }
+    this.#pageSizeValue = size;
+    return this;
+  }
+
+  joinOne<
+    const TAlias extends string,
+    TTableName extends keyof TSchema["tables"] & string,
+    const TBuilderResult,
+  >(
+    alias: TAlias,
+    tableName: TTableName,
+    builderFn: (
+      builder: QueryTreeJoinBuilder<TSchema, TSchema["tables"][TTableName], TTable>,
+    ) => TBuilderResult,
+  ): QueryTreeJoinBuilder<
+    TSchema,
+    TTable,
+    TParentTable,
+    TSelect,
+    TJoinOut & {
+      [P in TAlias]: MapCardinality<
+        SelectResult<
+          TSchema["tables"][TTableName],
+          ExtractQueryTreeBuilderOut<TBuilderResult>,
+          Extract<
+            ExtractQueryTreeBuilderSelect<TBuilderResult>,
+            SelectClause<TSchema["tables"][TTableName]>
+          >
+        >
+      >["one"];
+    }
+  > {
+    this.#children.push(this.#buildChildNode(alias, tableName, "one", builderFn));
+    return this as unknown as QueryTreeJoinBuilder<
+      TSchema,
+      TTable,
+      TParentTable,
+      TSelect,
+      TJoinOut & {
+        [P in TAlias]: MapCardinality<
+          SelectResult<
+            TSchema["tables"][TTableName],
+            ExtractQueryTreeBuilderOut<TBuilderResult>,
+            Extract<
+              ExtractQueryTreeBuilderSelect<TBuilderResult>,
+              SelectClause<TSchema["tables"][TTableName]>
+            >
+          >
+        >["one"];
+      }
+    >;
+  }
+
+  joinMany<
+    const TAlias extends string,
+    TTableName extends keyof TSchema["tables"] & string,
+    const TBuilderResult,
+  >(
+    alias: TAlias,
+    tableName: TTableName,
+    builderFn: (
+      builder: QueryTreeJoinBuilder<TSchema, TSchema["tables"][TTableName], TTable>,
+    ) => TBuilderResult,
+  ): QueryTreeJoinBuilder<
+    TSchema,
+    TTable,
+    TParentTable,
+    TSelect,
+    TJoinOut & {
+      [P in TAlias]: MapCardinality<
+        SelectResult<
+          TSchema["tables"][TTableName],
+          ExtractQueryTreeBuilderOut<TBuilderResult>,
+          Extract<
+            ExtractQueryTreeBuilderSelect<TBuilderResult>,
+            SelectClause<TSchema["tables"][TTableName]>
+          >
+        >
+      >["many"];
+    }
+  > {
+    this.#children.push(this.#buildChildNode(alias, tableName, "many", builderFn));
+    return this as unknown as QueryTreeJoinBuilder<
+      TSchema,
+      TTable,
+      TParentTable,
+      TSelect,
+      TJoinOut & {
+        [P in TAlias]: MapCardinality<
+          SelectResult<
+            TSchema["tables"][TTableName],
+            ExtractQueryTreeBuilderOut<TBuilderResult>,
+            Extract<
+              ExtractQueryTreeBuilderSelect<TBuilderResult>,
+              SelectClause<TSchema["tables"][TTableName]>
+            >
+          >
+        >["many"];
+      }
+    >;
+  }
+
+  #buildChildNode<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    alias: string,
+    tableName: TTableName,
+    cardinality: QueryTreeCardinality,
+    builderFn: (
+      builder: QueryTreeJoinBuilder<TSchema, TSchema["tables"][TTableName], TTable>,
+    ) => TBuilderResult,
+  ): CompiledQueryTreeChildNode {
+    const childTable = this.#schema.tables[tableName];
+    if (!childTable) {
+      throw new Error(`Table ${tableName} not found in schema`);
+    }
+
+    const childBuilder = new QueryTreeJoinBuilder(
+      this.#schema,
+      tableName,
+      childTable as TSchema["tables"][TTableName],
+      this.#table,
+    );
+    builderFn(childBuilder as QueryTreeJoinBuilder<TSchema, TSchema["tables"][TTableName], TTable>);
+    return childBuilder.build(alias, cardinality);
+  }
+
+  build(alias: string, cardinality: QueryTreeCardinality): CompiledQueryTreeChildNode<TTable> {
+    if (!this.#onIndexName) {
+      throw new Error(
+        `Must specify an index using .onIndex() before finalizing query-tree join on table "${this.#tableName}"`,
+      );
+    }
+
+    return {
+      kind: "child",
+      alias,
+      table: this.#table,
+      cardinality,
+      onIndexName: this.#onIndexName,
+      onIndex: this.#onIndexCondition,
+      where: this.#whereCondition,
+      select: (this.#selectClause ?? true) as AnySelectClause,
+      orderByIndex: this.#orderByIndexClause,
+      pageSize: this.#pageSizeValue,
+      children: [...this.#children],
+    };
+  }
+}
+
+export class QueryTreeFindBuilder<
+  TSchema extends AnySchema,
+  TTable extends AnyTable,
+  TSelect extends SelectClause<TTable> = true,
+  TJoinOut = {},
+> {
+  readonly #schema: TSchema;
+  readonly #table: TTable;
+  readonly #tableName: string;
+
+  #indexName?: string;
+  #whereClause?: Condition;
+  #selectClause?: TSelect;
+  #orderByIndexClause?: QueryTreeOrderBy;
+  #afterCursor?: Cursor | string;
+  #beforeCursor?: Cursor | string;
+  #pageSizeValue?: number;
+  #cursorMetadata?: Cursor;
+  #children: CompiledQueryTreeChildNode[] = [];
+  #countMode = false;
+
+  constructor(schema: TSchema, tableName: string, table: TTable) {
+    this.#schema = schema;
+    this.#tableName = tableName;
+    this.#table = table;
+  }
+
+  whereIndex<TIndexName extends QueryTreeValidIndexName<TTable>>(
+    indexName: TIndexName,
+    condition?: (eb: ConditionBuilder<ColumnsForIndex<TTable, TIndexName>>) => Condition | boolean,
+  ): this {
+    if (indexName !== "primary" && !(indexName in this.#table.indexes)) {
+      throw new Error(
+        `Index "${String(indexName)}" not found on table "${this.#tableName}". ` +
+          `Available indexes: primary, ${Object.keys(this.#table.indexes).join(", ")}`,
+      );
+    }
+
+    this.#indexName = indexName === "primary" ? "_primary" : indexName;
+    if (condition) {
+      const indexedColumns = getIndexedColumnNames(this.#table, this.#indexName);
+      const compiled = condition(
+        createIndexedBuilder(this.#table.columns, indexedColumns) as unknown as ConditionBuilder<
+          ColumnsForIndex<TTable, TIndexName>
+        >,
+      );
+      if (compiled === false) {
+        throw new Error(
+          `whereIndex() cannot compile to false on table "${this.#tableName}" in findNew().`,
+        );
+      }
+      this.#whereClause = compiled === true ? undefined : compiled;
+    }
+    return this;
+  }
+
+  select<const TNewSelect extends SelectClause<TTable>>(
+    columns: TNewSelect,
+  ): QueryTreeFindBuilder<TSchema, TTable, TNewSelect, TJoinOut> {
+    if (this.#countMode) {
+      throw new Error(
+        `Cannot call select() after selectCount() on table "${this.#tableName}". ` +
+          `Use either select() or selectCount(), not both.`,
+      );
+    }
+    // prettier-ignore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this as any).#selectClause = columns;
+    return this as unknown as QueryTreeFindBuilder<TSchema, TTable, TNewSelect, TJoinOut>;
+  }
+
+  selectCount(): this & QueryTreeCountBuilderMarker {
+    if (this.#selectClause !== undefined) {
+      throw new Error(
+        `Cannot call selectCount() after select() on table "${this.#tableName}". ` +
+          `Use either select() or selectCount(), not both.`,
+      );
+    }
+    this.#countMode = true;
+    return this as this & QueryTreeCountBuilderMarker;
+  }
+
+  orderByIndex<TIndexName extends QueryTreeValidIndexName<TTable>>(
+    indexName: TIndexName,
+    direction: "asc" | "desc",
+  ): this {
+    if (indexName !== "primary" && !(indexName in this.#table.indexes)) {
+      throw new Error(
+        `Index "${String(indexName)}" not found on table "${this.#tableName}". ` +
+          `Available indexes: primary, ${Object.keys(this.#table.indexes).join(", ")}`,
+      );
+    }
+
+    this.#orderByIndexClause = {
+      indexName: indexName === "primary" ? "_primary" : indexName,
+      direction,
+    };
+    return this;
+  }
+
+  after(cursor: Cursor | string): this {
+    this.#afterCursor = cursor;
+    if (typeof cursor !== "string") {
+      this.#cursorMetadata = cursor;
+    }
+    return this;
+  }
+
+  before(cursor: Cursor | string): this {
+    this.#beforeCursor = cursor;
+    if (typeof cursor !== "string") {
+      this.#cursorMetadata = cursor;
+    }
+    return this;
+  }
+
+  pageSize(size: number): this {
+    if (!Number.isInteger(size) || size <= 0) {
+      throw new RangeError(`pageSize must be a positive integer, received: ${size}`);
+    }
+    this.#pageSizeValue = size;
+    return this;
+  }
+
+  joinOne<
+    const TAlias extends string,
+    TTableName extends keyof TSchema["tables"] & string,
+    const TBuilderResult,
+  >(
+    alias: TAlias,
+    tableName: TTableName,
+    builderFn: (
+      builder: QueryTreeJoinBuilder<TSchema, TSchema["tables"][TTableName], TTable>,
+    ) => TBuilderResult,
+  ): QueryTreeFindBuilder<
+    TSchema,
+    TTable,
+    TSelect,
+    TJoinOut & {
+      [P in TAlias]: MapCardinality<
+        SelectResult<
+          TSchema["tables"][TTableName],
+          ExtractQueryTreeBuilderOut<TBuilderResult>,
+          Extract<
+            ExtractQueryTreeBuilderSelect<TBuilderResult>,
+            SelectClause<TSchema["tables"][TTableName]>
+          >
+        >
+      >["one"];
+    }
+  > {
+    this.#children.push(this.#buildChildNode(alias, tableName, "one", builderFn));
+    return this as unknown as QueryTreeFindBuilder<
+      TSchema,
+      TTable,
+      TSelect,
+      TJoinOut & {
+        [P in TAlias]: MapCardinality<
+          SelectResult<
+            TSchema["tables"][TTableName],
+            ExtractQueryTreeBuilderOut<TBuilderResult>,
+            Extract<
+              ExtractQueryTreeBuilderSelect<TBuilderResult>,
+              SelectClause<TSchema["tables"][TTableName]>
+            >
+          >
+        >["one"];
+      }
+    >;
+  }
+
+  joinMany<
+    const TAlias extends string,
+    TTableName extends keyof TSchema["tables"] & string,
+    const TBuilderResult,
+  >(
+    alias: TAlias,
+    tableName: TTableName,
+    builderFn: (
+      builder: QueryTreeJoinBuilder<TSchema, TSchema["tables"][TTableName], TTable>,
+    ) => TBuilderResult,
+  ): QueryTreeFindBuilder<
+    TSchema,
+    TTable,
+    TSelect,
+    TJoinOut & {
+      [P in TAlias]: MapCardinality<
+        SelectResult<
+          TSchema["tables"][TTableName],
+          ExtractQueryTreeBuilderOut<TBuilderResult>,
+          Extract<
+            ExtractQueryTreeBuilderSelect<TBuilderResult>,
+            SelectClause<TSchema["tables"][TTableName]>
+          >
+        >
+      >["many"];
+    }
+  > {
+    this.#children.push(this.#buildChildNode(alias, tableName, "many", builderFn));
+    return this as unknown as QueryTreeFindBuilder<
+      TSchema,
+      TTable,
+      TSelect,
+      TJoinOut & {
+        [P in TAlias]: MapCardinality<
+          SelectResult<
+            TSchema["tables"][TTableName],
+            ExtractQueryTreeBuilderOut<TBuilderResult>,
+            Extract<
+              ExtractQueryTreeBuilderSelect<TBuilderResult>,
+              SelectClause<TSchema["tables"][TTableName]>
+            >
+          >
+        >["many"];
+      }
+    >;
+  }
+
+  #buildChildNode<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    alias: string,
+    tableName: TTableName,
+    cardinality: QueryTreeCardinality,
+    builderFn: (
+      builder: QueryTreeJoinBuilder<TSchema, TSchema["tables"][TTableName], TTable>,
+    ) => TBuilderResult,
+  ): CompiledQueryTreeChildNode {
+    const childTable = this.#schema.tables[tableName];
+    if (!childTable) {
+      throw new Error(`Table ${tableName} not found in schema`);
+    }
+
+    const childBuilder = new QueryTreeJoinBuilder(
+      this.#schema,
+      tableName,
+      childTable as TSchema["tables"][TTableName],
+      this.#table,
+    );
+    builderFn(childBuilder as QueryTreeJoinBuilder<TSchema, TSchema["tables"][TTableName], TTable>);
+    return childBuilder.build(alias, cardinality);
+  }
+
+  build(): CompiledQueryTreeRootNode<TTable> | CompiledQueryTreeCountNode<TTable> {
+    let indexName = this.#indexName;
+    let orderByIndex = this.#orderByIndexClause;
+    let pageSize = this.#pageSizeValue;
+
+    if (this.#cursorMetadata) {
+      if (!indexName) {
+        indexName = this.#cursorMetadata.indexName;
+      }
+      if (!orderByIndex) {
+        orderByIndex = {
+          indexName: this.#cursorMetadata.indexName,
+          direction: this.#cursorMetadata.orderDirection,
+        };
+      }
+      if (pageSize === undefined) {
+        pageSize = this.#cursorMetadata.pageSize;
+      }
+
+      if (indexName && indexName !== this.#cursorMetadata.indexName) {
+        throw new Error(
+          `Index mismatch: builder specifies "${indexName}" but cursor specifies "${this.#cursorMetadata.indexName}"`,
+        );
+      }
+      if (
+        orderByIndex &&
+        (orderByIndex.indexName !== this.#cursorMetadata.indexName ||
+          orderByIndex.direction !== this.#cursorMetadata.orderDirection)
+      ) {
+        throw new Error(`Order mismatch: builder and cursor specify different ordering`);
+      }
+      if (pageSize !== undefined && pageSize !== this.#cursorMetadata.pageSize) {
+        throw new Error(
+          `Page size mismatch: builder specifies ${pageSize} but cursor specifies ${this.#cursorMetadata.pageSize}`,
+        );
+      }
+    }
+
+    if (!indexName) {
+      throw new Error(
+        `Must specify an index using .whereIndex() before finalizing findNew() on table "${this.#tableName}"`,
+      );
+    }
+
+    if (this.#countMode) {
+      if (this.#children.length > 0) {
+        throw new Error(
+          `Cannot use joinOne() or joinMany() with selectCount() on table "${this.#tableName}".`,
+        );
+      }
+      if (this.#afterCursor !== undefined || this.#beforeCursor !== undefined) {
+        throw new Error(
+          `Cannot use cursor pagination with selectCount() on table "${this.#tableName}".`,
+        );
+      }
+
+      return {
+        kind: "count",
+        table: this.#table,
+        useIndex: indexName,
+        where: this.#whereClause,
+      };
+    }
+
+    return {
+      kind: "root",
+      table: this.#table,
+      useIndex: indexName,
+      where: this.#whereClause,
+      select: (this.#selectClause ?? true) as AnySelectClause,
+      orderByIndex,
+      after: this.#afterCursor,
+      before: this.#beforeCursor,
+      pageSize,
+      children: [...this.#children],
+    };
+  }
+}

--- a/packages/fragno-db/src/query/unit-of-work/query-tree.ts
+++ b/packages/fragno-db/src/query/unit-of-work/query-tree.ts
@@ -543,7 +543,7 @@ export class QueryTreeFindBuilder<
       );
       if (compiled === false) {
         throw new Error(
-          `whereIndex() cannot compile to false on table "${this.#tableName}" in findNew().`,
+          `whereIndex() cannot compile to false on table "${this.#tableName}" in find().`,
         );
       }
       this.#whereClause = compiled === true ? undefined : compiled;
@@ -776,7 +776,7 @@ export class QueryTreeFindBuilder<
 
     if (!indexName) {
       throw new Error(
-        `Must specify an index using .whereIndex() before finalizing findNew() on table "${this.#tableName}"`,
+        `Must specify an index using .whereIndex() before finalizing find() on table "${this.#tableName}"`,
       );
     }
 

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work-coordinator.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work-coordinator.test.ts
@@ -72,7 +72,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
     // Simulate service method 1: adds retrieval operation via child UOW
     const serviceMethod1 = () => {
       const childUow = parentUow.restrict();
-      childUow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+      childUow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
     };
 
     // Simulate service method 2: adds mutation operation via child UOW
@@ -126,7 +126,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
 
       // Await retrieval phase - should not deadlock!
       const [users] = await typedUow.retrievalPhase;
@@ -138,7 +138,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findNew("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+        .find("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
       // Await retrieval phase - should not deadlock!
       const [posts] = await typedUow.retrievalPhase;
@@ -211,7 +211,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
 
       const [users] = await typedUow.retrievalPhase;
       const user = users?.[0];
@@ -228,7 +228,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findNew("orders", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+        .find("orders", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
       const [orders] = await typedUow.retrievalPhase;
       return orders;
@@ -339,7 +339,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
           const childUow2 = childUow1.restrict();
           const typedUow = childUow2
             .forSchema(testSchema)
-            .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+            .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
 
           const [users] = await typedUow.retrievalPhase;
           return users?.[0];
@@ -350,7 +350,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
           const childUow2 = childUow1.restrict();
           const typedUow = childUow2
             .forSchema(testSchema)
-            .findNew("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+            .find("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
           const [posts] = await typedUow.retrievalPhase;
           return posts;
@@ -448,7 +448,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
         const childUow = parentUow.restrict();
         const typedUow = childUow
           .forSchema(testSchema)
-          .findNew("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email)));
+          .find("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email)));
 
         return typedUow.retrievalPhase.then(([users]) => users?.[0] ?? null);
       };
@@ -458,7 +458,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
         const childUow = parentUow.restrict();
         const typedUow = childUow
           .forSchema(testSchema)
-          .findNew("products", (b) => b.whereIndex("primary"));
+          .find("products", (b) => b.whereIndex("primary"));
 
         return typedUow.retrievalPhase.then(([products]) => products?.[0] ?? null);
       };
@@ -569,7 +569,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findNew("accounts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+        .find("accounts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
       const [accounts] = await typedUow.retrievalPhase;
       return accounts?.[0] ?? null;
@@ -660,7 +660,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
 
       const [users] = await typedUow.retrievalPhase;
       const user = users?.[0];
@@ -682,7 +682,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findNew("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+        .find("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
       const [posts] = await typedUow.retrievalPhase;
       return posts;
@@ -796,7 +796,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findNew("settings", (b) => b.whereIndex("unique_key", (eb) => eb("key", "=", key)));
+        .find("settings", (b) => b.whereIndex("unique_key", (eb) => eb("key", "=", key)));
 
       // This is the critical line - accessing retrievalPhase creates a new promise
       // If not cached properly, this new promise won't have a catch handler attached
@@ -950,7 +950,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findFirstNew("totp_secret", (b) =>
+        .findFirst("totp_secret", (b) =>
           b.whereIndex("idx_totp_user", (eb) => eb("userId", "=", userId)),
         );
 
@@ -1029,7 +1029,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findFirstNew("totp_secret", (b) =>
+        .findFirst("totp_secret", (b) =>
           b.whereIndex("idx_totp_user", (eb) => eb("userId", "=", userId)),
         );
 

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work-coordinator.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work-coordinator.test.ts
@@ -539,8 +539,8 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
         .addTable("transactions", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("fromAccountId", referenceColumn())
-            .addColumn("toAccountId", referenceColumn())
+            .addColumn("fromAccountId", referenceColumn({ table: "accounts" }))
+            .addColumn("toAccountId", referenceColumn({ table: "accounts" }))
             .addColumn("amount", "integer"),
         ),
     );

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work-coordinator.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work-coordinator.test.ts
@@ -72,7 +72,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
     // Simulate service method 1: adds retrieval operation via child UOW
     const serviceMethod1 = () => {
       const childUow = parentUow.restrict();
-      childUow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+      childUow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
     };
 
     // Simulate service method 2: adds mutation operation via child UOW
@@ -126,7 +126,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
 
       // Await retrieval phase - should not deadlock!
       const [users] = await typedUow.retrievalPhase;
@@ -138,7 +138,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .find("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+        .findNew("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
       // Await retrieval phase - should not deadlock!
       const [posts] = await typedUow.retrievalPhase;
@@ -211,7 +211,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
 
       const [users] = await typedUow.retrievalPhase;
       const user = users?.[0];
@@ -228,7 +228,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .find("orders", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+        .findNew("orders", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
       const [orders] = await typedUow.retrievalPhase;
       return orders;
@@ -339,7 +339,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
           const childUow2 = childUow1.restrict();
           const typedUow = childUow2
             .forSchema(testSchema)
-            .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+            .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
 
           const [users] = await typedUow.retrievalPhase;
           return users?.[0];
@@ -350,7 +350,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
           const childUow2 = childUow1.restrict();
           const typedUow = childUow2
             .forSchema(testSchema)
-            .find("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+            .findNew("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
           const [posts] = await typedUow.retrievalPhase;
           return posts;
@@ -448,7 +448,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
         const childUow = parentUow.restrict();
         const typedUow = childUow
           .forSchema(testSchema)
-          .find("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email)));
+          .findNew("users", (b) => b.whereIndex("idx_email", (eb) => eb("email", "=", email)));
 
         return typedUow.retrievalPhase.then(([users]) => users?.[0] ?? null);
       };
@@ -458,7 +458,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
         const childUow = parentUow.restrict();
         const typedUow = childUow
           .forSchema(testSchema)
-          .find("products", (b) => b.whereIndex("primary"));
+          .findNew("products", (b) => b.whereIndex("primary"));
 
         return typedUow.retrievalPhase.then(([products]) => products?.[0] ?? null);
       };
@@ -569,7 +569,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .find("accounts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+        .findNew("accounts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
       const [accounts] = await typedUow.retrievalPhase;
       return accounts?.[0] ?? null;
@@ -660,7 +660,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .find("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
+        .findNew("users", (b) => b.whereIndex("primary", (eb) => eb("id", "=", userId)));
 
       const [users] = await typedUow.retrievalPhase;
       const user = users?.[0];
@@ -682,7 +682,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .find("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
+        .findNew("posts", (b) => b.whereIndex("idx_user", (eb) => eb("userId", "=", userId)));
 
       const [posts] = await typedUow.retrievalPhase;
       return posts;
@@ -796,7 +796,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .find("settings", (b) => b.whereIndex("unique_key", (eb) => eb("key", "=", key)));
+        .findNew("settings", (b) => b.whereIndex("unique_key", (eb) => eb("key", "=", key)));
 
       // This is the critical line - accessing retrievalPhase creates a new promise
       // If not cached properly, this new promise won't have a catch handler attached
@@ -950,7 +950,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findFirst("totp_secret", (b) =>
+        .findFirstNew("totp_secret", (b) =>
           b.whereIndex("idx_totp_user", (eb) => eb("userId", "=", userId)),
         );
 
@@ -1029,7 +1029,7 @@ describe("UOW Coordinator - Parent-Child Execution", () => {
       const childUow = parentUow.restrict();
       const typedUow = childUow
         .forSchema(testSchema)
-        .findFirst("totp_secret", (b) =>
+        .findFirstNew("totp_secret", (b) =>
           b.whereIndex("idx_totp_user", (eb) => eb("userId", "=", userId)),
         );
 

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work-types.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work-types.test.ts
@@ -3,7 +3,7 @@ import { describe, expectTypeOf, it } from "vitest";
 import { column, idColumn, referenceColumn, schema } from "../../schema/create";
 import type { FragnoId, FragnoReference } from "../../schema/create";
 import { QueryTreeFindBuilder, QueryTreeJoinBuilder, type ParentColumnRef } from "./query-tree";
-import { JoinFindBuilder, UnitOfWork } from "./unit-of-work";
+import { UnitOfWork } from "./unit-of-work";
 
 type Prettify<T> = {
   [K in keyof T]: T[K];
@@ -18,11 +18,6 @@ type RecursivePrettify<T> = {
         ? RecursivePrettify<T[K]>
         : T[K];
 } & {};
-
-type InferJoinOut<T> =
-  T extends JoinFindBuilder<infer _Table, infer _Select, infer JoinOut> ? JoinOut : never;
-
-type InferJoinOutPrettify<T> = RecursivePrettify<InferJoinOut<T>>;
 
 type InferQueryTreeOut<T> =
   T extends QueryTreeFindBuilder<infer _, infer __, infer ___, infer TJoinOut>
@@ -42,7 +37,7 @@ describe("UnitOfWork type tests", () => {
           .addColumn("name", column("string"))
           .addColumn("email", column("string"))
           .addColumn("age", column("integer").nullable())
-          .addColumn("invitedBy", referenceColumn().nullable())
+          .addColumn("invitedBy", referenceColumn({ table: "users" }).nullable())
           .createIndex("idx_email", ["email"], { unique: true })
           .createIndex("idx_name", ["name"]);
       })
@@ -51,7 +46,7 @@ describe("UnitOfWork type tests", () => {
           .addColumn("id", idColumn())
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
-          .addColumn("userId", referenceColumn())
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .createIndex("idx_user", ["userId"])
           .createIndex("idx_title", ["title"]);
       })
@@ -59,49 +54,19 @@ describe("UnitOfWork type tests", () => {
         return t
           .addColumn("id", idColumn())
           .addColumn("content", column("string"))
-          .addColumn("postId", referenceColumn())
-          .addColumn("authorId", referenceColumn())
+          .addColumn("postId", referenceColumn({ table: "posts" }))
+          .addColumn("authorId", referenceColumn({ table: "users" }))
           .createIndex("idx_post", ["postId"])
           .createIndex("idx_author", ["authorId"]);
       })
       .addTable("likes", (t) => {
         return t
           .addColumn("id", idColumn())
-          .addColumn("postId", referenceColumn())
-          .addColumn("userId", referenceColumn())
+          .addColumn("postId", referenceColumn({ table: "posts" }))
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .addColumn("reaction", column("string"))
           .createIndex("idx_likes_post", ["postId"])
           .createIndex("idx_likes_user", ["userId"]);
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "userId" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("inviter", {
-        type: "one",
-        from: { table: "users", column: "invitedBy" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("post", {
-        type: "one",
-        from: { table: "comments", column: "postId" },
-        to: { table: "posts", column: "id" },
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "comments", column: "authorId" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("posts", {
-        type: "many",
-        from: { table: "users", column: "id" },
-        to: { table: "posts", column: "userId" },
-      })
-      .addReference("comments", {
-        type: "many",
-        from: { table: "posts", column: "id" },
-        to: { table: "comments", column: "postId" },
       });
   });
 
@@ -172,67 +137,6 @@ describe("UnitOfWork type tests", () => {
         name: string;
       } | null;
     }>();
-  });
-
-  it("join builder without join given", () => {
-    const _builder = new JoinFindBuilder("users", testSchema.tables.users);
-    type JoinOut = InferJoinOutPrettify<typeof _builder>;
-    expectTypeOf<JoinOut>().toEqualTypeOf<{}>();
-  });
-
-  it("join builder with join given", () => {
-    const builder = new JoinFindBuilder("users", testSchema.tables.users);
-
-    /*
-    join: (jb) =>           // jb is IndexedJoinBuilder, the thing with relations as key (fns)
-      jb.posts((b) =>       // b is JoinFindBuilder
-        b.whereIndex("primary").select(["id"])
-      )
-    */
-
-    const _builderOut = builder.join((jb) => jb.inviter((ib) => ib.select(["name"])));
-    type _JoinOut = InferJoinOutPrettify<typeof _builderOut>;
-    //    ^?
-
-    type _JoinOutInviter = Prettify<_JoinOut["inviter"]>;
-    //     ^?
-
-    expectTypeOf<_JoinOutInviter>().toEqualTypeOf<{
-      name: string;
-    } | null>();
-  });
-
-  it("join builder with 'many' relationship returns array", () => {
-    const builder = new JoinFindBuilder("users", testSchema.tables.users);
-
-    const _builderOut = builder.join((jb) => jb.posts((ib) => ib.select(["title"])));
-    type _JoinOut = InferJoinOut<typeof _builderOut>;
-    //    ^?
-
-    type _JoinOutPosts = Prettify<_JoinOut["posts"]>;
-    //     ^?
-
-    expectTypeOf<_JoinOutPosts>().toEqualTypeOf<
-      {
-        title: string;
-      }[]
-    >();
-  });
-
-  it("preserves nested select narrowing in join builder", () => {
-    const builder = new JoinFindBuilder("users", testSchema.tables.users);
-
-    const _builderOut = builder.join((jb) =>
-      jb.posts((pb) => pb.select(["title"]).join((jb2) => jb2.author((ab) => ab.select(["name"])))),
-    );
-
-    type JoinOut = InferJoinOutPrettify<typeof _builderOut>;
-    type Post = Prettify<JoinOut["posts"][number]>;
-    type PostTitle = Post["title"];
-    type Author = Prettify<NonNullable<Post["author"]>>;
-
-    expectTypeOf<PostTitle>().toEqualTypeOf<string>();
-    expectTypeOf<Author>().toEqualTypeOf<{ name: string }>();
   });
 
   it("preserves nested select narrowing via UOW find", async () => {

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work-types.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work-types.test.ts
@@ -2,6 +2,7 @@ import { describe, expectTypeOf, it } from "vitest";
 
 import { column, idColumn, referenceColumn, schema } from "../../schema/create";
 import type { FragnoId, FragnoReference } from "../../schema/create";
+import { QueryTreeFindBuilder, QueryTreeJoinBuilder, type ParentColumnRef } from "./query-tree";
 import { JoinFindBuilder, UnitOfWork } from "./unit-of-work";
 
 type Prettify<T> = {
@@ -22,6 +23,15 @@ type InferJoinOut<T> =
   T extends JoinFindBuilder<infer _Table, infer _Select, infer JoinOut> ? JoinOut : never;
 
 type InferJoinOutPrettify<T> = RecursivePrettify<InferJoinOut<T>>;
+
+type InferQueryTreeOut<T> =
+  T extends QueryTreeFindBuilder<infer _, infer __, infer ___, infer TJoinOut>
+    ? TJoinOut
+    : T extends QueryTreeJoinBuilder<infer _, infer __, infer ___, infer ____, infer TJoinOut>
+      ? TJoinOut
+      : never;
+
+type InferQueryTreeOutPrettify<T> = RecursivePrettify<InferQueryTreeOut<T>>;
 
 describe("UnitOfWork type tests", () => {
   const testSchema = schema("test", (s) => {
@@ -53,6 +63,15 @@ describe("UnitOfWork type tests", () => {
           .addColumn("authorId", referenceColumn())
           .createIndex("idx_post", ["postId"])
           .createIndex("idx_author", ["authorId"]);
+      })
+      .addTable("likes", (t) => {
+        return t
+          .addColumn("id", idColumn())
+          .addColumn("postId", referenceColumn())
+          .addColumn("userId", referenceColumn())
+          .addColumn("reaction", column("string"))
+          .createIndex("idx_likes_post", ["postId"])
+          .createIndex("idx_likes_user", ["userId"]);
       })
       .addReference("author", {
         type: "one",
@@ -104,7 +123,7 @@ describe("UnitOfWork type tests", () => {
   it("should type find without joins correctly", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.find("users", (b) => b.whereIndex("primary"));
+    const uow1 = uow.findNew("users", (b) => b.whereIndex("primary"));
     const [_userResult] = await uow1.executeRetrieve();
     type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
 
@@ -120,7 +139,7 @@ describe("UnitOfWork type tests", () => {
   it("should type find with select clause correctly", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.find("users", (b) => b.whereIndex("primary").select(["id", "name"]));
+    const uow1 = uow.findNew("users", (b) => b.whereIndex("primary").select(["id", "name"]));
     const [_userResult] = await uow1.executeRetrieve();
     type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
 
@@ -133,8 +152,12 @@ describe("UnitOfWork type tests", () => {
   it("should type find with joins correctly", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.find("users", (b) =>
-      b.whereIndex("primary").join((jb) => jb.inviter((ib) => ib.select(["name"]))),
+    const uow1 = uow.findNew("users", (b) =>
+      b
+        .whereIndex("primary")
+        .joinOne("inviter", "users", (ib) =>
+          ib.onIndex("primary", (eb) => eb("id", "=", eb.parent("invitedBy"))).select(["name"]),
+        ),
     );
     const [_userResult] = await uow1.executeRetrieve();
     type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
@@ -215,14 +238,15 @@ describe("UnitOfWork type tests", () => {
   it("preserves nested select narrowing via UOW find", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.find("users", (b) =>
-      b
-        .whereIndex("primary")
-        .join((jb) =>
-          jb.posts((pb) =>
-            pb.select(["title"]).join((jb2) => jb2.author((ab) => ab.select(["name"]))),
+    const uow1 = uow.findNew("users", (b) =>
+      b.whereIndex("primary").joinMany("posts", "posts", (pb) =>
+        pb
+          .onIndex("idx_user", (eb) => eb("userId", "=", eb.parent("id")))
+          .select(["title"])
+          .joinOne("author", "users", (ab) =>
+            ab.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).select(["name"]),
           ),
-        ),
+      ),
     );
 
     const [_userResult] = await uow1.executeRetrieve();
@@ -233,5 +257,330 @@ describe("UnitOfWork type tests", () => {
 
     expectTypeOf<PostTitle>().toEqualTypeOf<string>();
     expectTypeOf<Author>().toEqualTypeOf<{ name: string }>();
+  });
+
+  it("should type findNew without joins correctly", async () => {
+    const uow = createTestUOW();
+
+    const uow1 = uow.findNew("users", (b) => b.whereIndex("primary"));
+    const [_userResult] = await uow1.executeRetrieve();
+    type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
+
+    expectTypeOf<UserResult>().toEqualTypeOf<{
+      id: FragnoId;
+      name: string;
+      email: string;
+      age: number | null;
+      invitedBy: FragnoReference | null;
+    }>();
+  });
+
+  it("should type findNew with select clause correctly", async () => {
+    const uow = createTestUOW();
+
+    const uow1 = uow.findNew("users", (b) => b.whereIndex("primary").select(["id", "name"]));
+    const [_userResult] = await uow1.executeRetrieve();
+    type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
+
+    expectTypeOf<UserResult>().toEqualTypeOf<{
+      id: FragnoId;
+      name: string;
+    }>();
+  });
+
+  it("query-tree builder without joins gives empty join output", () => {
+    const _builder = new QueryTreeFindBuilder(
+      testSchema,
+      "users",
+      testSchema.tables.users,
+    ).whereIndex("primary");
+    type JoinOut = InferQueryTreeOutPrettify<typeof _builder>;
+
+    expectTypeOf<JoinOut>().toEqualTypeOf<{}>();
+  });
+
+  it("query-tree builder joinOne returns a nullable object", () => {
+    const _builder = new QueryTreeFindBuilder(testSchema, "users", testSchema.tables.users)
+      .whereIndex("primary")
+      .joinOne("inviter", "users", (joinedUser) =>
+        joinedUser
+          .onIndex("primary", (eb) => eb("id", "=", eb.parent("invitedBy")))
+          .select(["name"]),
+      );
+
+    type JoinOut = InferQueryTreeOutPrettify<typeof _builder>;
+    type Inviter = Prettify<JoinOut["inviter"]>;
+
+    expectTypeOf<Inviter>().toEqualTypeOf<{ name: string } | null>();
+  });
+
+  it("query-tree builder joinMany returns an array", () => {
+    const _builder = new QueryTreeFindBuilder(testSchema, "users", testSchema.tables.users)
+      .whereIndex("primary")
+      .joinMany("postsByUser", "posts", (posts) =>
+        posts.onIndex("idx_user", (eb) => eb("userId", "=", eb.parent("id"))).select(["title"]),
+      );
+
+    type JoinOut = InferQueryTreeOutPrettify<typeof _builder>;
+    type UserPost = Prettify<JoinOut["postsByUser"][number]>;
+
+    expectTypeOf<UserPost>().toEqualTypeOf<{ title: string }>();
+  });
+
+  it("query-tree join builder preserves nested join output types", () => {
+    const _builder = new QueryTreeJoinBuilder(
+      testSchema,
+      "posts",
+      testSchema.tables.posts,
+      testSchema.tables.users,
+    )
+      .onIndex("idx_user", (eb) => eb("userId", "=", eb.parent("id")))
+      .select(["title"])
+      .joinOne("author", "users", (author) =>
+        author.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).select(["name"]),
+      )
+      .joinMany("likes", "likes", (likes) =>
+        likes
+          .onIndex("idx_likes_post", (eb) => eb("postId", "=", eb.parent("id")))
+          .select(["reaction"]),
+      );
+
+    type JoinOut = InferQueryTreeOutPrettify<typeof _builder>;
+    type Author = Prettify<NonNullable<JoinOut["author"]>>;
+    type Like = Prettify<JoinOut["likes"][number]>;
+
+    expectTypeOf<Author>().toEqualTypeOf<{ name: string }>();
+    expectTypeOf<Like>().toEqualTypeOf<{ reaction: string }>();
+  });
+
+  it("preserves nested select narrowing via UOW findNew", async () => {
+    const uow = createTestUOW();
+
+    const uow1 = uow.findNew("users", (b) =>
+      b
+        .whereIndex("primary")
+        .select(["id", "name"])
+        .joinMany("posts", "posts", (posts) =>
+          posts
+            .onIndex("idx_user", (eb) => eb("userId", "=", eb.parent("id")))
+            .select(["title", "id"])
+            .joinMany("comments", "comments", (comments) =>
+              comments
+                .onIndex("idx_post", (eb) => eb("postId", "=", eb.parent("id")))
+                .select(["content", "authorId"])
+                .joinOne("author", "users", (author) =>
+                  author
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId")))
+                    .select(["name"]),
+                ),
+            ),
+        ),
+    );
+
+    const [_userResult] = await uow1.executeRetrieve();
+    type User = RecursivePrettify<(typeof _userResult)[number]>;
+    type Post = Prettify<User["posts"][number]>;
+    type Comment = Prettify<Post["comments"][number]>;
+    type Author = Prettify<NonNullable<Comment["author"]>>;
+
+    expectTypeOf<User>().toEqualTypeOf<{
+      id: FragnoId;
+      name: string;
+      posts: {
+        id: FragnoId;
+        title: string;
+        comments: {
+          content: string;
+          authorId: FragnoReference;
+          author: { name: string } | null;
+        }[];
+      }[];
+    }>();
+    expectTypeOf<Author>().toEqualTypeOf<{ name: string }>();
+  });
+
+  it("supports sibling query-tree joins via UOW findNew", async () => {
+    const uow = createTestUOW();
+
+    const uow1 = uow.findNew("posts", (b) =>
+      b
+        .whereIndex("primary")
+        .select(["id", "title", "userId"])
+        .joinOne("author", "users", (author) =>
+          author
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+            .select(["name", "email"]),
+        )
+        .joinMany("comments", "comments", (comments) =>
+          comments
+            .onIndex("idx_post", (eb) => eb("postId", "=", eb.parent("id")))
+            .select(["content"]),
+        )
+        .joinMany("likes", "likes", (likes) =>
+          likes
+            .onIndex("idx_likes_post", (eb) => eb("postId", "=", eb.parent("id")))
+            .select(["reaction"]),
+        ),
+    );
+
+    const [_postResult] = await uow1.executeRetrieve();
+    type Post = RecursivePrettify<(typeof _postResult)[number]>;
+    type Author = Prettify<NonNullable<Post["author"]>>;
+    type Comment = Prettify<Post["comments"][number]>;
+    type Like = Prettify<Post["likes"][number]>;
+
+    expectTypeOf<Post>().toEqualTypeOf<{
+      id: FragnoId;
+      title: string;
+      userId: FragnoReference;
+      author: { name: string; email: string } | null;
+      comments: { content: string }[];
+      likes: { reaction: string }[];
+    }>();
+    expectTypeOf<Author>().toEqualTypeOf<{ name: string; email: string }>();
+    expectTypeOf<Comment>().toEqualTypeOf<{ content: string }>();
+    expectTypeOf<Like>().toEqualTypeOf<{ reaction: string }>();
+  });
+
+  it("appends findNew results to the typed retrieval tuple", async () => {
+    const uow = createTestUOW();
+
+    const uow1 = uow
+      .findNew("users", (b) => b.whereIndex("primary").select(["id", "name"]))
+      .findNew("posts", (b) =>
+        b
+          .whereIndex("primary")
+          .select(["id", "title", "userId"])
+          .joinOne("author", "users", (author) =>
+            author.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).select(["name"]),
+          ),
+      );
+
+    const results = await uow1.executeRetrieve();
+    type User = RecursivePrettify<(typeof results)[0][number]>;
+    type Post = RecursivePrettify<(typeof results)[1][number]>;
+
+    expectTypeOf<User>().toEqualTypeOf<{ id: FragnoId; name: string }>();
+    expectTypeOf<Post>().toEqualTypeOf<{
+      id: FragnoId;
+      title: string;
+      userId: FragnoReference;
+      author: { name: string } | null;
+    }>();
+  });
+
+  it("restricts findNew whereIndex condition builders to columns of the chosen index", () => {
+    new QueryTreeFindBuilder(testSchema, "users", testSchema.tables.users)
+      .whereIndex("primary", (eb) => {
+        type ColumnName = Parameters<typeof eb>[0];
+        expectTypeOf<ColumnName>().toEqualTypeOf<"id">();
+        return eb("id");
+      })
+      .whereIndex("idx_email", (eb) => {
+        type ColumnName = Parameters<typeof eb>[0];
+        expectTypeOf<ColumnName>().toEqualTypeOf<"email">();
+        return eb("email", "=", "ada@example.com");
+      })
+      .whereIndex("idx_name", (eb) => {
+        type ColumnName = Parameters<typeof eb>[0];
+        expectTypeOf<ColumnName>().toEqualTypeOf<"name">();
+        return eb("name", "=", "Ada");
+      });
+  });
+
+  it("restricts query-tree onIndex child columns and types parent() from the direct parent", () => {
+    new QueryTreeJoinBuilder(
+      testSchema,
+      "posts",
+      testSchema.tables.posts,
+      testSchema.tables.users,
+    ).onIndex("idx_user", (eb) => {
+      type ChildColumn = Parameters<typeof eb>[0];
+      type ParentColumn = Parameters<typeof eb.parent>[0];
+      type ParentIdRef = ReturnType<typeof eb.parent<"id">>;
+
+      expectTypeOf<ChildColumn>().toEqualTypeOf<"userId">();
+      expectTypeOf<ParentColumn>().toEqualTypeOf<"id" | "name" | "email" | "age" | "invitedBy">();
+      expectTypeOf<ParentIdRef>().toExtend<
+        ParentColumnRef<(typeof testSchema.tables.users.columns)["id"]>
+      >();
+
+      return eb.and(eb("userId", "=", eb.parent("id")), eb.not(eb.isNull("userId")));
+    });
+  });
+
+  it("types query-tree child whereIndex separately from onIndex", () => {
+    new QueryTreeJoinBuilder(testSchema, "users", testSchema.tables.users, testSchema.tables.posts)
+      .onIndex("primary", (eb) => {
+        type ChildColumn = Parameters<typeof eb>[0];
+        expectTypeOf<ChildColumn>().toEqualTypeOf<"id">();
+        return eb("id", "=", eb.parent("userId"));
+      })
+      .whereIndex("idx_name", (eb) => {
+        type ChildColumn = Parameters<typeof eb>[0];
+        expectTypeOf<ChildColumn>().toEqualTypeOf<"name">();
+        return eb("name", "=", "Ada");
+      });
+  });
+
+  it("types findNew and findFirstNew count results correctly", async () => {
+    const uow = createTestUOW();
+
+    const uow1 = uow
+      .findNew("users", (b) => b.whereIndex("primary").selectCount())
+      .findFirstNew("users", (b) => b.whereIndex("primary").selectCount());
+
+    const results = await uow1.executeRetrieve();
+    type CountResult = (typeof results)[0];
+    type FirstCountResult = (typeof results)[1];
+
+    expectTypeOf<CountResult>().toEqualTypeOf<number>();
+    expectTypeOf<FirstCountResult>().toEqualTypeOf<number>();
+  });
+
+  it("types findFirstNew and findWithCursorNew results correctly", async () => {
+    const uow = createTestUOW();
+
+    const uow1 = uow
+      .findFirstNew("users", (b) => b.whereIndex("primary").select(["id", "name"]))
+      .findWithCursorNew("users", (b) =>
+        b
+          .whereIndex("idx_name", (eb) => eb("name", "=", "Ada"))
+          .orderByIndex("idx_name", "asc")
+          .pageSize(2)
+          .select(["id", "name"]),
+      );
+
+    const results = await uow1.executeRetrieve();
+    type FirstUser = RecursivePrettify<(typeof results)[0]>;
+    type CursorPage = (typeof results)[1];
+    type CursorUser = RecursivePrettify<CursorPage["items"][number]>;
+
+    expectTypeOf<FirstUser>().toEqualTypeOf<{ id: FragnoId; name: string } | null>();
+    expectTypeOf<CursorUser>().toEqualTypeOf<{ id: FragnoId; name: string }>();
+  });
+
+  it("rejects non-indexed columns in query-tree condition builders", () => {
+    if (process.env["NODE_ENV"] === "__typecheck_only__") {
+      new QueryTreeFindBuilder(testSchema, "users", testSchema.tables.users).whereIndex(
+        "idx_email",
+        (eb) => {
+          // @ts-expect-error age is not part of idx_email
+          eb("age", "=", 123);
+          return eb("email", "=", "ada@example.com");
+        },
+      );
+
+      new QueryTreeJoinBuilder(
+        testSchema,
+        "posts",
+        testSchema.tables.posts,
+        testSchema.tables.users,
+      ).onIndex("idx_user", (eb) => {
+        // @ts-expect-error title is not part of idx_user
+        eb("title", "=", "Hello");
+        return eb("userId", "=", eb.parent("id"));
+      });
+    }
   });
 });

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work-types.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work-types.test.ts
@@ -123,7 +123,7 @@ describe("UnitOfWork type tests", () => {
   it("should type find without joins correctly", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.findNew("users", (b) => b.whereIndex("primary"));
+    const uow1 = uow.find("users", (b) => b.whereIndex("primary"));
     const [_userResult] = await uow1.executeRetrieve();
     type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
 
@@ -139,7 +139,7 @@ describe("UnitOfWork type tests", () => {
   it("should type find with select clause correctly", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.findNew("users", (b) => b.whereIndex("primary").select(["id", "name"]));
+    const uow1 = uow.find("users", (b) => b.whereIndex("primary").select(["id", "name"]));
     const [_userResult] = await uow1.executeRetrieve();
     type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
 
@@ -152,7 +152,7 @@ describe("UnitOfWork type tests", () => {
   it("should type find with joins correctly", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.findNew("users", (b) =>
+    const uow1 = uow.find("users", (b) =>
       b
         .whereIndex("primary")
         .joinOne("inviter", "users", (ib) =>
@@ -238,7 +238,7 @@ describe("UnitOfWork type tests", () => {
   it("preserves nested select narrowing via UOW find", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.findNew("users", (b) =>
+    const uow1 = uow.find("users", (b) =>
       b.whereIndex("primary").joinMany("posts", "posts", (pb) =>
         pb
           .onIndex("idx_user", (eb) => eb("userId", "=", eb.parent("id")))
@@ -259,10 +259,10 @@ describe("UnitOfWork type tests", () => {
     expectTypeOf<Author>().toEqualTypeOf<{ name: string }>();
   });
 
-  it("should type findNew without joins correctly", async () => {
+  it("should type find without joins correctly", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.findNew("users", (b) => b.whereIndex("primary"));
+    const uow1 = uow.find("users", (b) => b.whereIndex("primary"));
     const [_userResult] = await uow1.executeRetrieve();
     type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
 
@@ -275,10 +275,10 @@ describe("UnitOfWork type tests", () => {
     }>();
   });
 
-  it("should type findNew with select clause correctly", async () => {
+  it("should type find with select clause correctly", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.findNew("users", (b) => b.whereIndex("primary").select(["id", "name"]));
+    const uow1 = uow.find("users", (b) => b.whereIndex("primary").select(["id", "name"]));
     const [_userResult] = await uow1.executeRetrieve();
     type UserResult = RecursivePrettify<(typeof _userResult)[number]>;
 
@@ -353,10 +353,10 @@ describe("UnitOfWork type tests", () => {
     expectTypeOf<Like>().toEqualTypeOf<{ reaction: string }>();
   });
 
-  it("preserves nested select narrowing via UOW findNew", async () => {
+  it("preserves nested select narrowing via UOW find", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.findNew("users", (b) =>
+    const uow1 = uow.find("users", (b) =>
       b
         .whereIndex("primary")
         .select(["id", "name"])
@@ -399,10 +399,10 @@ describe("UnitOfWork type tests", () => {
     expectTypeOf<Author>().toEqualTypeOf<{ name: string }>();
   });
 
-  it("supports sibling query-tree joins via UOW findNew", async () => {
+  it("supports sibling query-tree joins via UOW find", async () => {
     const uow = createTestUOW();
 
-    const uow1 = uow.findNew("posts", (b) =>
+    const uow1 = uow.find("posts", (b) =>
       b
         .whereIndex("primary")
         .select(["id", "title", "userId"])
@@ -442,12 +442,12 @@ describe("UnitOfWork type tests", () => {
     expectTypeOf<Like>().toEqualTypeOf<{ reaction: string }>();
   });
 
-  it("appends findNew results to the typed retrieval tuple", async () => {
+  it("appends find results to the typed retrieval tuple", async () => {
     const uow = createTestUOW();
 
     const uow1 = uow
-      .findNew("users", (b) => b.whereIndex("primary").select(["id", "name"]))
-      .findNew("posts", (b) =>
+      .find("users", (b) => b.whereIndex("primary").select(["id", "name"]))
+      .find("posts", (b) =>
         b
           .whereIndex("primary")
           .select(["id", "title", "userId"])
@@ -469,7 +469,7 @@ describe("UnitOfWork type tests", () => {
     }>();
   });
 
-  it("restricts findNew whereIndex condition builders to columns of the chosen index", () => {
+  it("restricts find whereIndex condition builders to columns of the chosen index", () => {
     new QueryTreeFindBuilder(testSchema, "users", testSchema.tables.users)
       .whereIndex("primary", (eb) => {
         type ColumnName = Parameters<typeof eb>[0];
@@ -523,12 +523,12 @@ describe("UnitOfWork type tests", () => {
       });
   });
 
-  it("types findNew and findFirstNew count results correctly", async () => {
+  it("types find and findFirst count results correctly", async () => {
     const uow = createTestUOW();
 
     const uow1 = uow
-      .findNew("users", (b) => b.whereIndex("primary").selectCount())
-      .findFirstNew("users", (b) => b.whereIndex("primary").selectCount());
+      .find("users", (b) => b.whereIndex("primary").selectCount())
+      .findFirst("users", (b) => b.whereIndex("primary").selectCount());
 
     const results = await uow1.executeRetrieve();
     type CountResult = (typeof results)[0];
@@ -538,12 +538,12 @@ describe("UnitOfWork type tests", () => {
     expectTypeOf<FirstCountResult>().toEqualTypeOf<number>();
   });
 
-  it("types findFirstNew and findWithCursorNew results correctly", async () => {
+  it("types findFirst and findWithCursor results correctly", async () => {
     const uow = createTestUOW();
 
     const uow1 = uow
-      .findFirstNew("users", (b) => b.whereIndex("primary").select(["id", "name"]))
-      .findWithCursorNew("users", (b) =>
+      .findFirst("users", (b) => b.whereIndex("primary").select(["id", "name"]))
+      .findWithCursor("users", (b) =>
         b
           .whereIndex("idx_name", (eb) => eb("name", "=", "Ada"))
           .orderByIndex("idx_name", "asc")

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work.test.ts
@@ -289,12 +289,7 @@ describe("FindBuilder", () => {
             .addColumn("userId", column("string"))
             .addColumn("title", "string")
             .createIndex("idx_user", ["userId"]),
-        )
-        .addReference("user", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
@@ -327,12 +322,7 @@ describe("FindBuilder", () => {
             .addColumn("userId", column("string"))
             .addColumn("title", "string")
             .createIndex("idx_user", ["userId"]),
-        )
-        .addReference("user", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
@@ -371,12 +361,7 @@ describe("FindBuilder", () => {
             .addColumn("userId", column("string"))
             .addColumn("title", "string")
             .createIndex("idx_user", ["userId"]),
-        )
-        .addReference("user", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
@@ -415,12 +400,7 @@ describe("FindBuilder", () => {
             .addColumn("userId", column("string"))
             .addColumn("title", "string")
             .createIndex("idx_user", ["userId"]),
-        )
-        .addReference("user", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
@@ -458,12 +438,7 @@ describe("FindBuilder", () => {
             .addColumn("userId", column("string"))
             .addColumn("title", "string")
             .createIndex("idx_user", ["userId"]),
-        )
-        .addReference("user", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
@@ -495,12 +470,7 @@ describe("FindBuilder", () => {
             .addColumn("userId", column("string"))
             .addColumn("title", "string")
             .createIndex("idx_user", ["userId"]),
-        )
-        .addReference("user", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
@@ -561,17 +531,7 @@ describe("FindBuilder", () => {
             .addColumn("postId", column("string"))
             .addColumn("text", "string")
             .createIndex("idx_post", ["postId"]),
-        )
-        .addReference("user", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        })
-        .addReference("post", {
-          type: "one",
-          from: { table: "comments", column: "postId" },
-          to: { table: "posts", column: "id" },
-        }),
+        ),
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
@@ -1752,6 +1712,30 @@ describe("findFirst convenience method", () => {
     // Result should be a single object, not an array
     const [user] = results;
     expect(user).toEqual({ id: "mock-id", name: "Mock User", email: "mock@example.com" });
+    expect(Array.isArray(user)).toBe(false);
+  });
+
+  it("executeRetrieve returns filtered typed results for findFirst", async () => {
+    const executor = {
+      executeRetrievalPhase: async () => {
+        return [
+          [{ id: "user-1", name: "User 1", email: "user1@example.com" }],
+          [{ id: "post-1", userId: "user-1", title: "Post 1" }],
+        ];
+      },
+      executeMutationPhase: async () => ({ success: true, createdInternalIds: [] }),
+    };
+
+    const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
+
+    const userUow = uow.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).find("posts", (b) => b.whereIndex("primary"));
+
+    const results = await userUow.executeRetrieve();
+    const [user] = results;
+
+    expect(results).toHaveLength(1);
+    expect(user).toEqual({ id: "user-1", name: "User 1", email: "user1@example.com" });
     expect(Array.isArray(user)).toBe(false);
   });
 

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work.test.ts
@@ -52,7 +52,7 @@ describe("FindBuilder", () => {
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
-    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -73,7 +73,7 @@ describe("FindBuilder", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
     uow
       .forSchema(testSchema)
-      .find("users", (b) =>
+      .findNew("users", (b) =>
         b.whereIndex("idx_email", (eb) => eb("email", "=", "test@example.com")),
       );
 
@@ -92,7 +92,7 @@ describe("FindBuilder", () => {
     const cursor = "eyJpbmRleFZhbHVlcyI6eyJpZCI6InVzZXIxMjMifSwiZGlyZWN0aW9uIjoiZm9yd2FyZCJ9";
     uow
       .forSchema(testSchema)
-      .find("users", (b) => b.whereIndex("primary").after(cursor).pageSize(10));
+      .findNew("users", (b) => b.whereIndex("primary").after(cursor).pageSize(10));
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -112,7 +112,7 @@ describe("FindBuilder", () => {
     const cursor = "eyJpbmRleFZhbHVlcyI6eyJpZCI6InVzZXI0NTYifSwiZGlyZWN0aW9uIjoiYmFja3dhcmQifQ==";
     uow
       .forSchema(testSchema)
-      .find("users", (b) => b.whereIndex("primary").before(cursor).pageSize(5));
+      .findNew("users", (b) => b.whereIndex("primary").before(cursor).pageSize(5));
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -130,15 +130,15 @@ describe("FindBuilder", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(0));
+      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(0));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(-1));
+      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(-1));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(-10));
+      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(-10));
     }).toThrow(RangeError);
   });
 
@@ -150,19 +150,19 @@ describe("FindBuilder", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(1.5));
+      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(1.5));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(3.14));
+      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(3.14));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(NaN));
+      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(NaN));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(Infinity));
+      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(Infinity));
     }).toThrow(RangeError);
   });
 
@@ -173,7 +173,7 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("nonexistent" as "primary"));
+      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("nonexistent" as "primary"));
     }).toThrow('Index "nonexistent" not found on table "users"');
   });
 
@@ -184,13 +184,13 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
     expect(() => {
-      uow.forSchema(testSchema).find("users", (b) => b);
+      uow.forSchema(testSchema).findNew("users", (b) => b);
     }).toThrow(
-      'Must specify an index using .whereIndex() before finalizing find operation on table "users"',
+      'Must specify an index using .whereIndex() before finalizing findNew() on table "users"',
     );
   });
 
-  it("should support count operations", () => {
+  it("should support count operations in findNew and findFirstNew", () => {
     const testSchema = schema("test", (s) =>
       s.addTable("users", (t) =>
         t.addColumn("id", idColumn()).addColumn("name", "string").addColumn("age", "integer"),
@@ -198,11 +198,18 @@ describe("FindBuilder", () => {
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
-    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").selectCount());
+    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").selectCount());
+
+    const uow2 = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
+    uow2.forSchema(testSchema).findFirstNew("users", (b) => b.whereIndex("primary").selectCount());
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
     expect(ops[0]?.type).toBe("count");
+
+    const ops2 = uow2.getRetrievalOperations();
+    expect(ops2).toHaveLength(1);
+    expect(ops2[0]?.type).toBe("count");
   });
 
   it("should throw when using both select and selectCount", () => {
@@ -216,7 +223,7 @@ describe("FindBuilder", () => {
     expect(() => {
       uow
         .forSchema(testSchema)
-        .find("users", (b) => b.whereIndex("primary").select(["name"]).selectCount());
+        .findNew("users", (b) => b.whereIndex("primary").select(["name"]).selectCount());
     }).toThrow(/cannot call selectCount/i);
 
     // selectCount() then select()
@@ -224,8 +231,23 @@ describe("FindBuilder", () => {
     expect(() => {
       uow2
         .forSchema(testSchema)
-        .find("users", (b) => b.whereIndex("primary").selectCount().select(["name"]));
+        .findNew("users", (b) => b.whereIndex("primary").selectCount().select(["name"]));
     }).toThrow(/cannot call select/i);
+  });
+
+  it("should throw when using selectCount with findWithCursorNew", () => {
+    const testSchema = schema("test", (s) =>
+      s.addTable("users", (t) =>
+        t.addColumn("id", idColumn()).addColumn("name", "string").createIndex("idx_name", ["name"]),
+      ),
+    );
+
+    const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
+    expect(() => {
+      uow
+        .forSchema(testSchema)
+        .findWithCursorNew("users", (b) => b.whereIndex("primary").selectCount());
+    }).toThrow(/does not support selectCount/i);
   });
 
   it("should support orderByIndex", () => {
@@ -242,7 +264,7 @@ describe("FindBuilder", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
     uow
       .forSchema(testSchema)
-      .find("users", (b) => b.whereIndex("primary").orderByIndex("idx_created", "desc"));
+      .findNew("users", (b) => b.whereIndex("primary").orderByIndex("idx_created", "desc"));
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -279,16 +301,20 @@ describe("FindBuilder", () => {
 
     uow
       .forSchema(testSchema)
-      .find("posts", (b) =>
-        b.whereIndex("primary").join((jb) => jb["user"]((builder) => builder.select(["name"]))),
+      .findNew("posts", (b) =>
+        b
+          .whereIndex("primary")
+          .joinOne("user", "users", (builder) =>
+            builder.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).select(["name"]),
+          ),
       );
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
     const op = ops[0];
     assert(op.type === "find");
-    expect(op.options.joins).toBeDefined();
-    expect(op.options.joins).toHaveLength(1);
+    expect(op.options.queryTree).toBeDefined();
+    expect(op.options.queryTree?.children).toHaveLength(1);
   });
 
   it("should support join operations without builder function", () => {
@@ -311,18 +337,23 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
-    // Join without builder function should use default options
-    uow.forSchema(testSchema).find("posts", (b) => b.whereIndex("primary").join((jb) => jb.user()));
+    uow
+      .forSchema(testSchema)
+      .findNew("posts", (b) =>
+        b
+          .whereIndex("primary")
+          .joinOne("user", "users", (builder) =>
+            builder.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
+          ),
+      );
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
     const op = ops[0];
     assert(op.type === "find");
-    expect(op.options.joins).toBeDefined();
-    expect(op.options.joins).toHaveLength(1);
-    const joinOptions = op.options.joins![0]!.options;
-    assert(joinOptions !== false);
-    expect(joinOptions.select).toBe(true); // Should default to selecting all columns
+    expect(op.options.queryTree).toBeDefined();
+    expect(op.options.queryTree?.children).toHaveLength(1);
+    expect(op.options.queryTree?.children[0]?.select).toBe(true); // Should default to selecting all columns
   });
 
   it("should support join with whereIndex", () => {
@@ -350,27 +381,22 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
-    uow
-      .forSchema(testSchema)
-      .find("posts", (b) =>
-        b
-          .whereIndex("primary")
-          .join((jb) =>
-            jb["user"]((builder) =>
-              builder.whereIndex("idx_name", (eb) => eb("name", "=", "Alice")).select(["name"]),
-            ),
-          ),
-      );
+    uow.forSchema(testSchema).findNew("posts", (b) =>
+      b.whereIndex("primary").joinOne("user", "users", (builder) =>
+        builder
+          .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+          .whereIndex("idx_name", (eb) => eb("name", "=", "Alice"))
+          .select(["name"]),
+      ),
+    );
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
     const op = ops[0];
     assert(op.type === "find");
-    expect(op.options.joins).toBeDefined();
-    expect(op.options.joins).toHaveLength(1);
-    const joinOptions = op.options.joins![0]!.options;
-    assert(joinOptions !== false);
-    expect(joinOptions.where).toBeDefined();
+    expect(op.options.queryTree).toBeDefined();
+    expect(op.options.queryTree?.children).toHaveLength(1);
+    expect(op.options.queryTree?.children[0]?.where).toBeDefined();
   });
 
   it("should support join with orderByIndex", () => {
@@ -401,21 +427,25 @@ describe("FindBuilder", () => {
 
     uow
       .forSchema(testSchema)
-      .find("posts", (b) =>
+      .findNew("posts", (b) =>
         b
           .whereIndex("primary")
-          .join((jb) => jb["user"]((builder) => builder.orderByIndex("idx_created", "desc"))),
+          .joinOne("user", "users", (builder) =>
+            builder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+              .orderByIndex("idx_created", "desc"),
+          ),
       );
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
     const op = ops[0];
     assert(op.type === "find");
-    expect(op.options.joins).toBeDefined();
-    const joinOptions = op.options.joins![0]!.options;
-    assert(joinOptions !== false);
-    expect(joinOptions.orderBy).toBeDefined();
-    expect(joinOptions.orderBy).toHaveLength(1);
+    expect(op.options.queryTree).toBeDefined();
+    expect(op.options.queryTree?.children[0]?.orderByIndex).toEqual({
+      indexName: "idx_created",
+      direction: "desc",
+    });
   });
 
   it("should support join with pageSize", () => {
@@ -440,17 +470,19 @@ describe("FindBuilder", () => {
 
     uow
       .forSchema(testSchema)
-      .find("posts", (b) =>
-        b.whereIndex("primary").join((jb) => jb["user"]((builder) => builder.pageSize(5))),
+      .findNew("posts", (b) =>
+        b
+          .whereIndex("primary")
+          .joinOne("user", "users", (builder) =>
+            builder.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).pageSize(5),
+          ),
       );
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
     const op = ops[0];
     assert(op.type === "find");
-    const joinOptions = op.options.joins![0]!.options;
-    assert(joinOptions !== false);
-    expect(joinOptions.limit).toBe(5);
+    expect(op.options.queryTree?.children[0]?.pageSize).toBe(5);
   });
 
   it("should throw RangeError for invalid pageSize in join", () => {
@@ -476,24 +508,36 @@ describe("FindBuilder", () => {
     expect(() => {
       uow
         .forSchema(testSchema)
-        .find("posts", (b) =>
-          b.whereIndex("primary").join((jb) => jb["user"]((builder) => builder.pageSize(0))),
+        .findNew("posts", (b) =>
+          b
+            .whereIndex("primary")
+            .joinOne("user", "users", (builder) =>
+              builder.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).pageSize(0),
+            ),
         );
     }).toThrow(RangeError);
 
     expect(() => {
       uow
         .forSchema(testSchema)
-        .find("posts", (b) =>
-          b.whereIndex("primary").join((jb) => jb["user"]((builder) => builder.pageSize(-5))),
+        .findNew("posts", (b) =>
+          b
+            .whereIndex("primary")
+            .joinOne("user", "users", (builder) =>
+              builder.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).pageSize(-5),
+            ),
         );
     }).toThrow(RangeError);
 
     expect(() => {
       uow
         .forSchema(testSchema)
-        .find("posts", (b) =>
-          b.whereIndex("primary").join((jb) => jb["user"]((builder) => builder.pageSize(2.5))),
+        .findNew("posts", (b) =>
+          b
+            .whereIndex("primary")
+            .joinOne("user", "users", (builder) =>
+              builder.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))).pageSize(2.5),
+            ),
         );
     }).toThrow(RangeError);
   });
@@ -532,35 +576,31 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
-    uow
-      .forSchema(testSchema)
-      .find("comments", (b) =>
-        b
-          .whereIndex("primary")
-          .join((jb) =>
-            jb["post"]((postBuilder) =>
-              postBuilder
-                .select(["title"])
-                .join((jb2) => jb2["user"]((userBuilder) => userBuilder.select(["name"]))),
-            ),
+    uow.forSchema(testSchema).findNew("comments", (b) =>
+      b.whereIndex("primary").joinOne("post", "posts", (postBuilder) =>
+        postBuilder
+          .onIndex("primary", (eb) => eb("id", "=", eb.parent("postId")))
+          .select(["title"])
+          .joinOne("user", "users", (userBuilder) =>
+            userBuilder
+              .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
+              .select(["name"]),
           ),
-      );
+      ),
+    );
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
     const op = ops[0];
     assert(op.type === "find");
-    expect(op.options.joins).toBeDefined();
-    expect(op.options.joins).toHaveLength(1);
+    expect(op.options.queryTree).toBeDefined();
+    expect(op.options.queryTree?.children).toHaveLength(1);
 
-    const postJoin = op.options.joins![0]!;
-    assert(postJoin.options !== false);
-    expect(postJoin.options.join).toBeDefined();
-    expect(postJoin.options.join).toHaveLength(1);
+    const postJoin = op.options.queryTree?.children[0];
+    expect(postJoin?.children).toHaveLength(1);
 
-    const userJoin = postJoin.options.join![0]!;
-    assert(userJoin.options !== false);
-    expect(userJoin.relation.name).toBe("user");
+    const userJoin = postJoin?.children[0];
+    expect(userJoin?.alias).toBe("user");
   });
 });
 
@@ -744,7 +784,7 @@ describe("IndexedConditionBuilder", () => {
 
       expectTypeOf<Parameters<typeof uow.find>[0]>().toEqualTypeOf<"users">();
 
-      uow.find("users", (b) =>
+      uow.findNew("users", (b) =>
         b.whereIndex("primary", (eb) => {
           type _EbFirstParameter = Parameters<typeof eb>[0];
           expectTypeOf<_EbFirstParameter>().toEqualTypeOf<"id">();
@@ -752,14 +792,14 @@ describe("IndexedConditionBuilder", () => {
         }),
       );
 
-      uow.find("users", (b) =>
+      uow.findNew("users", (b) =>
         b.whereIndex("idx_email", (eb) => {
           expectTypeOf(eb).parameter(0).toEqualTypeOf<"email">();
           return eb("email", "=", "123");
         }),
       );
 
-      uow.find("users", (b) =>
+      uow.findNew("users", (b) =>
         b.whereIndex("idx_name_age", (eb) => {
           expectTypeOf(eb).parameter(0).toEqualTypeOf<"name" | "age">();
           return eb("name", "=", "123");
@@ -1061,13 +1101,13 @@ describe("Phase promises with multiple views", () => {
     );
 
     // Add a find operation via a schema1 view (but don't keep a reference to this view)
-    parentUow.forSchema(schema1).find("users", (b) => b.whereIndex("primary"));
+    parentUow.forSchema(schema1).findNew("users", (b) => b.whereIndex("primary"));
 
     // Create a view for schema1 and add another find operation
-    const view1 = parentUow.forSchema(schema1).find("users", (b) => b.whereIndex("primary"));
+    const view1 = parentUow.forSchema(schema1).findNew("users", (b) => b.whereIndex("primary"));
 
     // Create a view for schema2 and add a find operation
-    const view2 = parentUow.forSchema(schema2).find("posts", (b) => b.whereIndex("primary"));
+    const view2 = parentUow.forSchema(schema2).findNew("posts", (b) => b.whereIndex("primary"));
 
     // Execute retrieval phase on parent
     const parentResults = await parentUow.executeRetrieve();
@@ -1117,9 +1157,9 @@ describe("Phase promises with multiple views", () => {
     );
 
     // Simulate what happens in db-fragment-definition-builder when getUnitOfWork(schema) is called twice
-    const view1 = parentUow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    const view1 = parentUow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
-    const view2 = parentUow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    const view2 = parentUow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
     // Execute retrieval
     await parentUow.executeRetrieve();
@@ -1320,7 +1360,7 @@ describe("Instrumentation", () => {
     });
 
     const typed = uow.forSchema(testSchema);
-    typed.find("users", (b) => b.whereIndex("primary"));
+    typed.findNew("users", (b) => b.whereIndex("primary"));
     typed.create("users", { name: "Alice", email: "alice@example.com" });
 
     await uow.executeRetrieve();
@@ -1380,7 +1420,7 @@ describe("Instrumentation", () => {
       },
     });
 
-    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
     await expect(uow.executeRetrieve()).rejects.toThrow("Injected failure");
     expect(retrievalExecuted).toBe(false);
@@ -1403,7 +1443,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
     await expect(uow.executeRetrieve()).rejects.toThrow("Database connection failed");
   });
@@ -1431,7 +1471,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
     // Start executing (this will fail)
     const executePromise = uow.executeRetrieve().catch((e) => {
@@ -1488,7 +1528,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
     // Access the retrievalPhase promise but don't await it
     // This simulates the internal coordination promise that might not be awaited
@@ -1548,7 +1588,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
     // Don't access retrievalPhase at all - this is the most common case
     // The internal coordination promise should not cause unhandled rejection
@@ -1601,7 +1641,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
 
     // First attempt fails
     const errorResolver = Promise.withResolvers<void>();
@@ -1703,7 +1743,9 @@ describe("findFirst convenience method", () => {
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
 
     // Use findFirst instead of find
-    const typedUow = uow.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary"));
+    const typedUow = uow
+      .forSchema(testSchema)
+      .findFirstNew("users", (b) => b.whereIndex("primary"));
 
     // Execute retrieval
     await uow.executeRetrieve();
@@ -1728,7 +1770,9 @@ describe("findFirst convenience method", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), emptyExecutor, createMockDecoder());
 
-    const typedUow = uow.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary"));
+    const typedUow = uow
+      .forSchema(testSchema)
+      .findFirstNew("users", (b) => b.whereIndex("primary"));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1741,7 +1785,7 @@ describe("findFirst convenience method", () => {
   it("should automatically set pageSize to 1", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
-    uow.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findFirstNew("users", (b) => b.whereIndex("primary"));
 
     // Check that pageSize was set to 1 in the operation
     const ops = uow.getRetrievalOperations();
@@ -1764,7 +1808,7 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirst("users", (b) => b.whereIndex("primary").select(["id", "name"] as const));
+      .findFirstNew("users", (b) => b.whereIndex("primary").select(["id", "name"] as const));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1787,7 +1831,7 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirst("users", (b) =>
+      .findFirstNew("users", (b) =>
         b.whereIndex("idx_email", (eb) => eb("email", "=", "test@example.com")),
       );
 
@@ -1813,8 +1857,8 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirst("users", (b) => b.whereIndex("primary"))
-      .findFirst("posts", (b) => b.whereIndex("primary"));
+      .findFirstNew("users", (b) => b.whereIndex("primary"))
+      .findFirstNew("posts", (b) => b.whereIndex("primary"));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1845,8 +1889,8 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirst("users", (b) => b.whereIndex("primary")) // Single result
-      .find("posts", (b) => b.whereIndex("primary")); // Array of results
+      .findFirstNew("users", (b) => b.whereIndex("primary")) // Single result
+      .findNew("posts", (b) => b.whereIndex("primary")); // Array of results
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1873,7 +1917,7 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirst("users", (b) => b.whereIndex("idx_name").orderByIndex("idx_name", "asc"));
+      .findFirstNew("users", (b) => b.whereIndex("idx_name").orderByIndex("idx_name", "asc"));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1883,7 +1927,7 @@ describe("findFirst convenience method", () => {
     expect(Array.isArray(user)).toBe(false);
   });
 
-  it("should work without explicit builder function", async () => {
+  it("should work with an explicit primary-index builder", async () => {
     const executor = {
       executeRetrievalPhase: async () => {
         return [[{ id: "user-1", name: "User 1", email: "user1@example.com" }]];
@@ -1893,8 +1937,9 @@ describe("findFirst convenience method", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
 
-    // findFirst without builder function should use primary index by default
-    const typedUow = uow.forSchema(testSchema).findFirst("users");
+    const typedUow = uow
+      .forSchema(testSchema)
+      .findFirstNew("users", (b) => b.whereIndex("primary"));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work.test.ts
@@ -52,7 +52,7 @@ describe("FindBuilder", () => {
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
-    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -73,7 +73,7 @@ describe("FindBuilder", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
     uow
       .forSchema(testSchema)
-      .findNew("users", (b) =>
+      .find("users", (b) =>
         b.whereIndex("idx_email", (eb) => eb("email", "=", "test@example.com")),
       );
 
@@ -92,7 +92,7 @@ describe("FindBuilder", () => {
     const cursor = "eyJpbmRleFZhbHVlcyI6eyJpZCI6InVzZXIxMjMifSwiZGlyZWN0aW9uIjoiZm9yd2FyZCJ9";
     uow
       .forSchema(testSchema)
-      .findNew("users", (b) => b.whereIndex("primary").after(cursor).pageSize(10));
+      .find("users", (b) => b.whereIndex("primary").after(cursor).pageSize(10));
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -112,7 +112,7 @@ describe("FindBuilder", () => {
     const cursor = "eyJpbmRleFZhbHVlcyI6eyJpZCI6InVzZXI0NTYifSwiZGlyZWN0aW9uIjoiYmFja3dhcmQifQ==";
     uow
       .forSchema(testSchema)
-      .findNew("users", (b) => b.whereIndex("primary").before(cursor).pageSize(5));
+      .find("users", (b) => b.whereIndex("primary").before(cursor).pageSize(5));
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -130,15 +130,15 @@ describe("FindBuilder", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(0));
+      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(0));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(-1));
+      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(-1));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(-10));
+      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(-10));
     }).toThrow(RangeError);
   });
 
@@ -150,19 +150,19 @@ describe("FindBuilder", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(1.5));
+      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(1.5));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(3.14));
+      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(3.14));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(NaN));
+      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(NaN));
     }).toThrow(RangeError);
 
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").pageSize(Infinity));
+      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").pageSize(Infinity));
     }).toThrow(RangeError);
   });
 
@@ -173,7 +173,7 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("nonexistent" as "primary"));
+      uow.forSchema(testSchema).find("users", (b) => b.whereIndex("nonexistent" as "primary"));
     }).toThrow('Index "nonexistent" not found on table "users"');
   });
 
@@ -184,13 +184,13 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
     expect(() => {
-      uow.forSchema(testSchema).findNew("users", (b) => b);
+      uow.forSchema(testSchema).find("users", (b) => b);
     }).toThrow(
-      'Must specify an index using .whereIndex() before finalizing findNew() on table "users"',
+      'Must specify an index using .whereIndex() before finalizing find() on table "users"',
     );
   });
 
-  it("should support count operations in findNew and findFirstNew", () => {
+  it("should support count operations in find and findFirst", () => {
     const testSchema = schema("test", (s) =>
       s.addTable("users", (t) =>
         t.addColumn("id", idColumn()).addColumn("name", "string").addColumn("age", "integer"),
@@ -198,10 +198,10 @@ describe("FindBuilder", () => {
     );
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
-    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary").selectCount());
+    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary").selectCount());
 
     const uow2 = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
-    uow2.forSchema(testSchema).findFirstNew("users", (b) => b.whereIndex("primary").selectCount());
+    uow2.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary").selectCount());
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -223,7 +223,7 @@ describe("FindBuilder", () => {
     expect(() => {
       uow
         .forSchema(testSchema)
-        .findNew("users", (b) => b.whereIndex("primary").select(["name"]).selectCount());
+        .find("users", (b) => b.whereIndex("primary").select(["name"]).selectCount());
     }).toThrow(/cannot call selectCount/i);
 
     // selectCount() then select()
@@ -231,11 +231,11 @@ describe("FindBuilder", () => {
     expect(() => {
       uow2
         .forSchema(testSchema)
-        .findNew("users", (b) => b.whereIndex("primary").selectCount().select(["name"]));
+        .find("users", (b) => b.whereIndex("primary").selectCount().select(["name"]));
     }).toThrow(/cannot call select/i);
   });
 
-  it("should throw when using selectCount with findWithCursorNew", () => {
+  it("should throw when using selectCount with findWithCursor", () => {
     const testSchema = schema("test", (s) =>
       s.addTable("users", (t) =>
         t.addColumn("id", idColumn()).addColumn("name", "string").createIndex("idx_name", ["name"]),
@@ -246,7 +246,7 @@ describe("FindBuilder", () => {
     expect(() => {
       uow
         .forSchema(testSchema)
-        .findWithCursorNew("users", (b) => b.whereIndex("primary").selectCount());
+        .findWithCursor("users", (b) => b.whereIndex("primary").selectCount());
     }).toThrow(/does not support selectCount/i);
   });
 
@@ -264,7 +264,7 @@ describe("FindBuilder", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
     uow
       .forSchema(testSchema)
-      .findNew("users", (b) => b.whereIndex("primary").orderByIndex("idx_created", "desc"));
+      .find("users", (b) => b.whereIndex("primary").orderByIndex("idx_created", "desc"));
 
     const ops = uow.getRetrievalOperations();
     expect(ops).toHaveLength(1);
@@ -301,7 +301,7 @@ describe("FindBuilder", () => {
 
     uow
       .forSchema(testSchema)
-      .findNew("posts", (b) =>
+      .find("posts", (b) =>
         b
           .whereIndex("primary")
           .joinOne("user", "users", (builder) =>
@@ -339,7 +339,7 @@ describe("FindBuilder", () => {
 
     uow
       .forSchema(testSchema)
-      .findNew("posts", (b) =>
+      .find("posts", (b) =>
         b
           .whereIndex("primary")
           .joinOne("user", "users", (builder) =>
@@ -381,7 +381,7 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
-    uow.forSchema(testSchema).findNew("posts", (b) =>
+    uow.forSchema(testSchema).find("posts", (b) =>
       b.whereIndex("primary").joinOne("user", "users", (builder) =>
         builder
           .onIndex("primary", (eb) => eb("id", "=", eb.parent("userId")))
@@ -427,7 +427,7 @@ describe("FindBuilder", () => {
 
     uow
       .forSchema(testSchema)
-      .findNew("posts", (b) =>
+      .find("posts", (b) =>
         b
           .whereIndex("primary")
           .joinOne("user", "users", (builder) =>
@@ -470,7 +470,7 @@ describe("FindBuilder", () => {
 
     uow
       .forSchema(testSchema)
-      .findNew("posts", (b) =>
+      .find("posts", (b) =>
         b
           .whereIndex("primary")
           .joinOne("user", "users", (builder) =>
@@ -508,7 +508,7 @@ describe("FindBuilder", () => {
     expect(() => {
       uow
         .forSchema(testSchema)
-        .findNew("posts", (b) =>
+        .find("posts", (b) =>
           b
             .whereIndex("primary")
             .joinOne("user", "users", (builder) =>
@@ -520,7 +520,7 @@ describe("FindBuilder", () => {
     expect(() => {
       uow
         .forSchema(testSchema)
-        .findNew("posts", (b) =>
+        .find("posts", (b) =>
           b
             .whereIndex("primary")
             .joinOne("user", "users", (builder) =>
@@ -532,7 +532,7 @@ describe("FindBuilder", () => {
     expect(() => {
       uow
         .forSchema(testSchema)
-        .findNew("posts", (b) =>
+        .find("posts", (b) =>
           b
             .whereIndex("primary")
             .joinOne("user", "users", (builder) =>
@@ -576,7 +576,7 @@ describe("FindBuilder", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
-    uow.forSchema(testSchema).findNew("comments", (b) =>
+    uow.forSchema(testSchema).find("comments", (b) =>
       b.whereIndex("primary").joinOne("post", "posts", (postBuilder) =>
         postBuilder
           .onIndex("primary", (eb) => eb("id", "=", eb.parent("postId")))
@@ -784,7 +784,7 @@ describe("IndexedConditionBuilder", () => {
 
       expectTypeOf<Parameters<typeof uow.find>[0]>().toEqualTypeOf<"users">();
 
-      uow.findNew("users", (b) =>
+      uow.find("users", (b) =>
         b.whereIndex("primary", (eb) => {
           type _EbFirstParameter = Parameters<typeof eb>[0];
           expectTypeOf<_EbFirstParameter>().toEqualTypeOf<"id">();
@@ -792,14 +792,14 @@ describe("IndexedConditionBuilder", () => {
         }),
       );
 
-      uow.findNew("users", (b) =>
+      uow.find("users", (b) =>
         b.whereIndex("idx_email", (eb) => {
           expectTypeOf(eb).parameter(0).toEqualTypeOf<"email">();
           return eb("email", "=", "123");
         }),
       );
 
-      uow.findNew("users", (b) =>
+      uow.find("users", (b) =>
         b.whereIndex("idx_name_age", (eb) => {
           expectTypeOf(eb).parameter(0).toEqualTypeOf<"name" | "age">();
           return eb("name", "=", "123");
@@ -1101,13 +1101,13 @@ describe("Phase promises with multiple views", () => {
     );
 
     // Add a find operation via a schema1 view (but don't keep a reference to this view)
-    parentUow.forSchema(schema1).findNew("users", (b) => b.whereIndex("primary"));
+    parentUow.forSchema(schema1).find("users", (b) => b.whereIndex("primary"));
 
     // Create a view for schema1 and add another find operation
-    const view1 = parentUow.forSchema(schema1).findNew("users", (b) => b.whereIndex("primary"));
+    const view1 = parentUow.forSchema(schema1).find("users", (b) => b.whereIndex("primary"));
 
     // Create a view for schema2 and add a find operation
-    const view2 = parentUow.forSchema(schema2).findNew("posts", (b) => b.whereIndex("primary"));
+    const view2 = parentUow.forSchema(schema2).find("posts", (b) => b.whereIndex("primary"));
 
     // Execute retrieval phase on parent
     const parentResults = await parentUow.executeRetrieve();
@@ -1157,9 +1157,9 @@ describe("Phase promises with multiple views", () => {
     );
 
     // Simulate what happens in db-fragment-definition-builder when getUnitOfWork(schema) is called twice
-    const view1 = parentUow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    const view1 = parentUow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
-    const view2 = parentUow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    const view2 = parentUow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
     // Execute retrieval
     await parentUow.executeRetrieve();
@@ -1360,7 +1360,7 @@ describe("Instrumentation", () => {
     });
 
     const typed = uow.forSchema(testSchema);
-    typed.findNew("users", (b) => b.whereIndex("primary"));
+    typed.find("users", (b) => b.whereIndex("primary"));
     typed.create("users", { name: "Alice", email: "alice@example.com" });
 
     await uow.executeRetrieve();
@@ -1420,7 +1420,7 @@ describe("Instrumentation", () => {
       },
     });
 
-    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
     await expect(uow.executeRetrieve()).rejects.toThrow("Injected failure");
     expect(retrievalExecuted).toBe(false);
@@ -1443,7 +1443,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
     await expect(uow.executeRetrieve()).rejects.toThrow("Database connection failed");
   });
@@ -1471,7 +1471,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
     // Start executing (this will fail)
     const executePromise = uow.executeRetrieve().catch((e) => {
@@ -1528,7 +1528,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
     // Access the retrievalPhase promise but don't await it
     // This simulates the internal coordination promise that might not be awaited
@@ -1588,7 +1588,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
     // Don't access retrievalPhase at all - this is the most common case
     // The internal coordination promise should not cause unhandled rejection
@@ -1641,7 +1641,7 @@ describe("Error Handling", () => {
     };
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
-    uow.forSchema(testSchema).findNew("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).find("users", (b) => b.whereIndex("primary"));
 
     // First attempt fails
     const errorResolver = Promise.withResolvers<void>();
@@ -1743,9 +1743,7 @@ describe("findFirst convenience method", () => {
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
 
     // Use findFirst instead of find
-    const typedUow = uow
-      .forSchema(testSchema)
-      .findFirstNew("users", (b) => b.whereIndex("primary"));
+    const typedUow = uow.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary"));
 
     // Execute retrieval
     await uow.executeRetrieve();
@@ -1770,9 +1768,7 @@ describe("findFirst convenience method", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), emptyExecutor, createMockDecoder());
 
-    const typedUow = uow
-      .forSchema(testSchema)
-      .findFirstNew("users", (b) => b.whereIndex("primary"));
+    const typedUow = uow.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary"));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1785,7 +1781,7 @@ describe("findFirst convenience method", () => {
   it("should automatically set pageSize to 1", () => {
     const uow = createUnitOfWork(createMockCompiler(), createMockExecutor(), createMockDecoder());
 
-    uow.forSchema(testSchema).findFirstNew("users", (b) => b.whereIndex("primary"));
+    uow.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary"));
 
     // Check that pageSize was set to 1 in the operation
     const ops = uow.getRetrievalOperations();
@@ -1808,7 +1804,7 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirstNew("users", (b) => b.whereIndex("primary").select(["id", "name"] as const));
+      .findFirst("users", (b) => b.whereIndex("primary").select(["id", "name"] as const));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1831,7 +1827,7 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirstNew("users", (b) =>
+      .findFirst("users", (b) =>
         b.whereIndex("idx_email", (eb) => eb("email", "=", "test@example.com")),
       );
 
@@ -1857,8 +1853,8 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirstNew("users", (b) => b.whereIndex("primary"))
-      .findFirstNew("posts", (b) => b.whereIndex("primary"));
+      .findFirst("users", (b) => b.whereIndex("primary"))
+      .findFirst("posts", (b) => b.whereIndex("primary"));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1889,8 +1885,8 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirstNew("users", (b) => b.whereIndex("primary")) // Single result
-      .findNew("posts", (b) => b.whereIndex("primary")); // Array of results
+      .findFirst("users", (b) => b.whereIndex("primary")) // Single result
+      .find("posts", (b) => b.whereIndex("primary")); // Array of results
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1917,7 +1913,7 @@ describe("findFirst convenience method", () => {
 
     const typedUow = uow
       .forSchema(testSchema)
-      .findFirstNew("users", (b) => b.whereIndex("idx_name").orderByIndex("idx_name", "asc"));
+      .findFirst("users", (b) => b.whereIndex("idx_name").orderByIndex("idx_name", "asc"));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;
@@ -1937,9 +1933,7 @@ describe("findFirst convenience method", () => {
 
     const uow = createUnitOfWork(createMockCompiler(), executor, createMockDecoder());
 
-    const typedUow = uow
-      .forSchema(testSchema)
-      .findFirstNew("users", (b) => b.whereIndex("primary"));
+    const typedUow = uow.forSchema(testSchema).findFirst("users", (b) => b.whereIndex("primary"));
 
     await uow.executeRetrieve();
     const results = await typedUow.retrievalPhase;

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
@@ -24,6 +24,13 @@ import type {
   ExtractSelect,
   ExtractJoinOut,
 } from "../mod";
+import {
+  QueryTreeFindBuilder,
+  type CompiledQueryTreeRootNode,
+  type ExtractQueryTreeBuilderCount,
+  type ExtractQueryTreeBuilderOut,
+  type ExtractQueryTreeBuilderSelect,
+} from "./query-tree";
 
 /**
  * Extract column names from a single index
@@ -37,6 +44,22 @@ type ExtractJoinBuilderSelect<T> =
 
 type ExtractJoinBuilderOut<T> =
   T extends JoinFindBuilder<infer _Table, infer _Select, infer TJoinOut> ? TJoinOut : {};
+
+type QueryTreeSelectedRow<TTable extends AnyTable, TBuilderResult> = SelectResult<
+  TTable,
+  ExtractQueryTreeBuilderOut<TBuilderResult>,
+  Extract<ExtractQueryTreeBuilderSelect<TBuilderResult>, SelectClause<TTable>>
+>;
+
+type QueryTreeFindResult<TTable extends AnyTable, TBuilderResult> =
+  ExtractQueryTreeBuilderCount<TBuilderResult> extends true
+    ? number
+    : QueryTreeSelectedRow<TTable, TBuilderResult>[];
+
+type QueryTreeFindFirstResult<TTable extends AnyTable, TBuilderResult> =
+  ExtractQueryTreeBuilderCount<TBuilderResult> extends true
+    ? number
+    : QueryTreeSelectedRow<TTable, TBuilderResult> | null;
 
 /**
  * Extract all indexed column names from a table's indexes
@@ -140,6 +163,10 @@ type FindOptions<
    * Join operations to include related data
    */
   joins?: CompiledJoin[];
+  /**
+   * New query-tree based join representation used by findNew().
+   */
+  queryTree?: CompiledQueryTreeRootNode<TTable>;
 };
 
 /**
@@ -2073,6 +2100,208 @@ export class TypedUnitOfWork<
     this.#operationIndices.push(operationIndex);
 
     // Safe: return type is correctly specified in the method signature
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this as any;
+  }
+
+  findNew<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    tableName: TTableName,
+    builderFn: (
+      builder: Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">,
+    ) => TBuilderResult,
+  ): TypedUnitOfWork<
+    TSchema,
+    [...TRetrievalResults, QueryTreeFindResult<TSchema["tables"][TTableName], TBuilderResult>],
+    TRawInput,
+    THooks
+  >;
+  findNew<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    tableName: TTableName,
+    builderFn: (
+      builder: Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">,
+    ) => TBuilderResult,
+  ): TypedUnitOfWork<
+    TSchema,
+    [...TRetrievalResults, QueryTreeFindResult<TSchema["tables"][TTableName], TBuilderResult>],
+    TRawInput,
+    THooks
+  > {
+    const table = this.#schema.tables[tableName];
+    if (!table) {
+      throw new Error(`Table ${tableName} not found in schema`);
+    }
+
+    const builder = new QueryTreeFindBuilder(
+      this.#schema,
+      tableName,
+      table as TSchema["tables"][TTableName],
+    );
+    builderFn(builder);
+    const queryTree = builder.build();
+
+    const operationIndex =
+      queryTree.kind === "count"
+        ? this.#uow.addRetrievalOperation({
+            type: "count",
+            schema: this.#schema,
+            namespace: this.#namespace,
+            table: table as TSchema["tables"][TTableName],
+            indexName: queryTree.useIndex,
+            options: {
+              useIndex: queryTree.useIndex,
+              where: () => queryTree.where ?? true,
+            },
+          })
+        : this.#uow.addRetrievalOperation({
+            type: "find",
+            schema: this.#schema,
+            namespace: this.#namespace,
+            table: table as TSchema["tables"][TTableName],
+            indexName: queryTree.useIndex,
+            options: {
+              useIndex: queryTree.useIndex,
+              select: queryTree.select,
+              orderByIndex: queryTree.orderByIndex,
+              after: queryTree.after,
+              before: queryTree.before,
+              pageSize: queryTree.pageSize,
+              queryTree,
+            } as unknown as FindOptions<AnyTable, SelectClause<AnyTable>>,
+            readTracking: this.#uow.readTrackingEnabled,
+          });
+
+    this.#operationIndices.push(operationIndex);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this as any;
+  }
+
+  findFirstNew<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    tableName: TTableName,
+    builderFn: (
+      builder: Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">,
+    ) => TBuilderResult,
+  ): TypedUnitOfWork<
+    TSchema,
+    [...TRetrievalResults, QueryTreeFindFirstResult<TSchema["tables"][TTableName], TBuilderResult>],
+    TRawInput,
+    THooks
+  > {
+    const table = this.#schema.tables[tableName];
+    if (!table) {
+      throw new Error(`Table ${tableName} not found in schema`);
+    }
+
+    const builder = new QueryTreeFindBuilder(
+      this.#schema,
+      tableName,
+      table as TSchema["tables"][TTableName],
+    );
+    builderFn(builder);
+    builder.pageSize(1);
+    const queryTree = builder.build();
+
+    const operationIndex =
+      queryTree.kind === "count"
+        ? this.#uow.addRetrievalOperation({
+            type: "count",
+            schema: this.#schema,
+            namespace: this.#namespace,
+            table: table as TSchema["tables"][TTableName],
+            indexName: queryTree.useIndex,
+            options: {
+              useIndex: queryTree.useIndex,
+              where: () => queryTree.where ?? true,
+            },
+          })
+        : this.#uow.addRetrievalOperation({
+            type: "find",
+            schema: this.#schema,
+            namespace: this.#namespace,
+            table: table as TSchema["tables"][TTableName],
+            indexName: queryTree.useIndex,
+            options: {
+              useIndex: queryTree.useIndex,
+              select: queryTree.select,
+              orderByIndex: queryTree.orderByIndex,
+              after: queryTree.after,
+              before: queryTree.before,
+              pageSize: queryTree.pageSize,
+              queryTree,
+            } as unknown as FindOptions<AnyTable, SelectClause<AnyTable>>,
+            withSingleResult: true,
+            readTracking: this.#uow.readTrackingEnabled,
+          });
+
+    this.#operationIndices.push(operationIndex);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this as any;
+  }
+
+  findWithCursorNew<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    tableName: TTableName,
+    builderFn: (
+      builder: Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">,
+    ) => TBuilderResult,
+  ): TypedUnitOfWork<
+    TSchema,
+    [
+      ...TRetrievalResults,
+      CursorResult<
+        SelectResult<
+          TSchema["tables"][TTableName],
+          ExtractQueryTreeBuilderOut<TBuilderResult>,
+          Extract<
+            ExtractQueryTreeBuilderSelect<TBuilderResult>,
+            SelectClause<TSchema["tables"][TTableName]>
+          >
+        >
+      >,
+    ],
+    TRawInput,
+    THooks
+  > {
+    const table = this.#schema.tables[tableName];
+    if (!table) {
+      throw new Error(`Table ${tableName} not found in schema`);
+    }
+
+    const builder = new QueryTreeFindBuilder(
+      this.#schema,
+      tableName,
+      table as TSchema["tables"][TTableName],
+    );
+    builderFn(builder);
+    const queryTree = builder.build();
+    if (queryTree.kind === "count") {
+      throw new Error(
+        `findWithCursorNew() does not support selectCount() on table "${tableName}". ` +
+          `Use findNew() or findFirstNew() instead.`,
+      );
+    }
+
+    const operationIndex = this.#uow.addRetrievalOperation({
+      type: "find",
+      schema: this.#schema,
+      namespace: this.#namespace,
+      table: table as TSchema["tables"][TTableName],
+      indexName: queryTree.useIndex,
+      options: {
+        useIndex: queryTree.useIndex,
+        select: queryTree.select,
+        orderByIndex: queryTree.orderByIndex,
+        after: queryTree.after,
+        before: queryTree.before,
+        pageSize: queryTree.pageSize,
+        queryTree,
+      } as unknown as FindOptions<AnyTable, SelectClause<AnyTable>>,
+      withCursor: true,
+      readTracking: this.#uow.readTrackingEnabled,
+    });
+
+    this.#operationIndices.push(operationIndex);
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this as any;
   }

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
@@ -16,14 +16,7 @@ import type { CursorResult } from "../cursor";
 import { Cursor } from "../cursor";
 import { dbInterval, dbNow, type DbInterval, type DbIntervalInput, type DbNow } from "../db-now";
 import type { CompiledJoin } from "../find-options";
-import type {
-  SelectClause,
-  TableToInsertValues,
-  TableToUpdateValues,
-  SelectResult,
-  ExtractSelect,
-  ExtractJoinOut,
-} from "../mod";
+import type { SelectClause, TableToInsertValues, TableToUpdateValues, SelectResult } from "../mod";
 import {
   QueryTreeFindBuilder,
   type CompiledQueryTreeRootNode,
@@ -164,7 +157,7 @@ type FindOptions<
    */
   joins?: CompiledJoin[];
   /**
-   * New query-tree based join representation used by findNew().
+   * New query-tree based join representation used by find().
    */
   queryTree?: CompiledQueryTreeRootNode<TTable>;
 };
@@ -2031,82 +2024,6 @@ export class TypedUnitOfWork<
   find<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
     tableName: TTableName,
     builderFn: (
-      builder: Omit<FindBuilder<TSchema["tables"][TTableName]>, "build">,
-    ) => TBuilderResult,
-  ): TypedUnitOfWork<
-    TSchema,
-    [
-      ...TRetrievalResults,
-      SelectResult<
-        TSchema["tables"][TTableName],
-        ExtractJoinOut<TBuilderResult>,
-        Extract<ExtractSelect<TBuilderResult>, SelectClause<TSchema["tables"][TTableName]>>
-      >[],
-    ],
-    TRawInput,
-    THooks
-  >;
-  find<TTableName extends keyof TSchema["tables"] & string>(
-    tableName: TTableName,
-  ): TypedUnitOfWork<
-    TSchema,
-    [...TRetrievalResults, SelectResult<TSchema["tables"][TTableName], {}, true>[]],
-    TRawInput,
-    THooks
-  >;
-  find<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
-    tableName: TTableName,
-    builderFn?: (
-      builder: Omit<FindBuilder<TSchema["tables"][TTableName]>, "build">,
-    ) => TBuilderResult,
-  ): TypedUnitOfWork<
-    TSchema,
-    [
-      ...TRetrievalResults,
-      SelectResult<
-        TSchema["tables"][TTableName],
-        ExtractJoinOut<TBuilderResult>,
-        Extract<ExtractSelect<TBuilderResult>, SelectClause<TSchema["tables"][TTableName]>>
-      >[],
-    ],
-    TRawInput,
-    THooks
-  > {
-    const table = this.#schema.tables[tableName];
-    if (!table) {
-      throw new Error(`Table ${tableName} not found in schema`);
-    }
-
-    const builder = new FindBuilder(tableName, table as TSchema["tables"][TTableName]);
-    if (builderFn) {
-      builderFn(builder);
-    } else {
-      builder.whereIndex("primary");
-    }
-    const { indexName, options, type } = builder.build();
-
-    const operationIndex = this.#uow.addRetrievalOperation({
-      type,
-      schema: this.#schema,
-      namespace: this.#namespace,
-      table: table as TSchema["tables"][TTableName],
-      indexName,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      options: options as any,
-      readTracking: this.#uow.readTrackingEnabled,
-    });
-
-    // Track which operation index belongs to this view
-    this.#operationIndices.push(operationIndex);
-
-    // Safe: return type is correctly specified in the method signature
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return this as any;
-  }
-
-  findNew<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
-    tableName: TTableName,
-    builderFn: (
       builder: Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">,
     ) => TBuilderResult,
   ): TypedUnitOfWork<
@@ -2115,7 +2032,7 @@ export class TypedUnitOfWork<
     TRawInput,
     THooks
   >;
-  findNew<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+  find<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
     tableName: TTableName,
     builderFn: (
       builder: Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">,
@@ -2176,7 +2093,7 @@ export class TypedUnitOfWork<
     return this as any;
   }
 
-  findFirstNew<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+  findFirst<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
     tableName: TTableName,
     builderFn: (
       builder: Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">,
@@ -2239,7 +2156,7 @@ export class TypedUnitOfWork<
     return this as any;
   }
 
-  findWithCursorNew<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+  findWithCursor<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
     tableName: TTableName,
     builderFn: (
       builder: Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">,
@@ -2276,8 +2193,8 @@ export class TypedUnitOfWork<
     const queryTree = builder.build();
     if (queryTree.kind === "count") {
       throw new Error(
-        `findWithCursorNew() does not support selectCount() on table "${tableName}". ` +
-          `Use findNew() or findFirstNew() instead.`,
+        `findWithCursor() does not support selectCount() on table "${tableName}". ` +
+          `Use find() or findFirst() instead.`,
       );
     }
 
@@ -2302,134 +2219,6 @@ export class TypedUnitOfWork<
 
     this.#operationIndices.push(operationIndex);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return this as any;
-  }
-
-  findFirst<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
-    tableName: TTableName,
-    builderFn: (
-      builder: Omit<FindBuilder<TSchema["tables"][TTableName]>, "build">,
-    ) => TBuilderResult,
-  ): TypedUnitOfWork<
-    TSchema,
-    [
-      ...TRetrievalResults,
-      SelectResult<
-        TSchema["tables"][TTableName],
-        ExtractJoinOut<TBuilderResult>,
-        Extract<ExtractSelect<TBuilderResult>, SelectClause<TSchema["tables"][TTableName]>>
-      > | null,
-    ],
-    TRawInput,
-    THooks
-  >;
-  findFirst<TTableName extends keyof TSchema["tables"] & string>(
-    tableName: TTableName,
-  ): TypedUnitOfWork<
-    TSchema,
-    [...TRetrievalResults, SelectResult<TSchema["tables"][TTableName], {}, true> | null],
-    TRawInput,
-    THooks
-  >;
-  findFirst<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
-    tableName: TTableName,
-    builderFn?: (
-      builder: Omit<FindBuilder<TSchema["tables"][TTableName]>, "build">,
-    ) => TBuilderResult,
-  ): TypedUnitOfWork<
-    TSchema,
-    [
-      ...TRetrievalResults,
-      SelectResult<
-        TSchema["tables"][TTableName],
-        ExtractJoinOut<TBuilderResult>,
-        Extract<ExtractSelect<TBuilderResult>, SelectClause<TSchema["tables"][TTableName]>>
-      > | null,
-    ],
-    TRawInput,
-    THooks
-  > {
-    const table = this.#schema.tables[tableName];
-    if (!table) {
-      throw new Error(`Table ${tableName} not found in schema`);
-    }
-
-    const builder = new FindBuilder(tableName, table as TSchema["tables"][TTableName]);
-    if (builderFn) {
-      builderFn(builder);
-    } else {
-      builder.whereIndex("primary");
-    }
-    // Automatically set pageSize to 1 for findFirst
-    builder.pageSize(1);
-    const { indexName, options, type } = builder.build();
-
-    const operationIndex = this.#uow.addRetrievalOperation({
-      type,
-      schema: this.#schema,
-      namespace: this.#namespace,
-      table: table as TSchema["tables"][TTableName],
-      indexName,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      options: options as any,
-      withSingleResult: true,
-      readTracking: this.#uow.readTrackingEnabled,
-    });
-
-    // Track which operation index belongs to this view
-    this.#operationIndices.push(operationIndex);
-
-    // Safe: return type is correctly specified in the method signature
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return this as any;
-  }
-
-  findWithCursor<TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
-    tableName: TTableName,
-    builderFn: (
-      builder: Omit<FindBuilder<TSchema["tables"][TTableName]>, "build">,
-    ) => TBuilderResult,
-  ): TypedUnitOfWork<
-    TSchema,
-    [
-      ...TRetrievalResults,
-      CursorResult<
-        SelectResult<
-          TSchema["tables"][TTableName],
-          ExtractJoinOut<TBuilderResult>,
-          Extract<ExtractSelect<TBuilderResult>, SelectClause<TSchema["tables"][TTableName]>>
-        >
-      >,
-    ],
-    TRawInput,
-    THooks
-  > {
-    const table = this.#schema.tables[tableName];
-    if (!table) {
-      throw new Error(`Table ${tableName} not found in schema`);
-    }
-
-    const builder = new FindBuilder(tableName, table as TSchema["tables"][TTableName]);
-    builderFn(builder);
-    const { indexName, options, type } = builder.build();
-
-    const operationIndex = this.#uow.addRetrievalOperation({
-      type,
-      schema: this.#schema,
-      namespace: this.#namespace,
-      table: table as TSchema["tables"][TTableName],
-      indexName,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      options: options as any,
-      withCursor: true,
-      readTracking: this.#uow.readTrackingEnabled,
-    });
-
-    // Track which operation index belongs to this view
-    this.#operationIndices.push(operationIndex);
-
-    // Safe: return type is correctly specified in the method signature
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this as any;
   }
@@ -2607,3 +2396,22 @@ export class TypedUnitOfWork<
     return this.#uow.getTriggeredHooks();
   }
 }
+
+export {
+  ParentColumnRef,
+  QueryTreeFindBuilder,
+  QueryTreeJoinBuilder,
+  getQueryTreeSelectedColumnNames,
+  isParentColumnRef,
+} from "./query-tree";
+export type {
+  CompiledQueryTreeChildNode,
+  CompiledQueryTreeCountNode,
+  CompiledQueryTreeRootNode,
+  ExtractQueryTreeBuilderCount,
+  ExtractQueryTreeBuilderOut,
+  ExtractQueryTreeBuilderSelect,
+  QueryTreeCountBuilderMarker,
+  QueryTreeOrderBy,
+  QueryTreeValidIndexName,
+} from "./query-tree";

--- a/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
+++ b/packages/fragno-db/src/query/unit-of-work/unit-of-work.ts
@@ -1,13 +1,6 @@
 import type { TriggeredHook, TriggerHookOptions, HooksMap, HookPayload } from "../../hooks/hooks";
-import type {
-  AnySchema,
-  AnyTable,
-  Index,
-  IdColumn,
-  AnyColumn,
-  Relation,
-} from "../../schema/create";
-import { FragnoId } from "../../schema/create";
+import type { AnySchema, AnyTable, Index, IdColumn, AnyColumn } from "../../schema/create";
+import { FragnoId, getTableRelations } from "../../schema/create";
 import { generateId } from "../../schema/generate-id";
 import type { Prettify } from "../../util/types";
 import type { Condition, ConditionBuilder } from "../condition-builder";
@@ -29,14 +22,6 @@ import {
  * Extract column names from a single index
  */
 export type IndexColumns<TIndex extends Index> = TIndex["columnNames"][number];
-
-type RemoveEmptyObject<T> = T extends object ? (keyof T extends never ? never : T) : never;
-
-type ExtractJoinBuilderSelect<T> =
-  T extends JoinFindBuilder<infer _Table, infer TSelect, infer _JoinOut> ? TSelect : true;
-
-type ExtractJoinBuilderOut<T> =
-  T extends JoinFindBuilder<infer _Table, infer _Select, infer TJoinOut> ? TJoinOut : {};
 
 type QueryTreeSelectedRow<TTable extends AnyTable, TBuilderResult> = SelectResult<
   TTable,
@@ -824,42 +809,11 @@ export class JoinFindBuilder<
   }
 }
 
-interface MapRelationType<T> {
-  // FIXME: Not sure why we need the RemoveEmptyObject, we should somehow fix at the source where it's added to the union
-  one: RemoveEmptyObject<T> | null;
-  many: RemoveEmptyObject<T>[];
-}
-
 /**
- * Join builder with indexed-only where clauses for Unit of Work
- * TJoinOut accumulates the types of all joined relations
+ * Legacy relation-key-driven join builder removed.
+ * Query-tree joins are the only supported public join API.
  */
-export type IndexedJoinBuilder<TTable extends AnyTable, TJoinOut> = {
-  [K in keyof TTable["relations"]]: TTable["relations"][K] extends Relation<
-    infer TRelationType,
-    infer TTargetTable
-  >
-    ? <
-        TBuilderFn extends (builder: JoinFindBuilder<TTable["relations"][K]["table"]>) => unknown =
-          (
-            builder: JoinFindBuilder<TTable["relations"][K]["table"]>,
-          ) => JoinFindBuilder<TTable["relations"][K]["table"]>,
-      >(
-        builderFn?: TBuilderFn,
-      ) => IndexedJoinBuilder<
-        TTable,
-        TJoinOut & {
-          [P in K]: MapRelationType<
-            SelectResult<
-              TTargetTable,
-              ExtractJoinBuilderOut<ReturnType<TBuilderFn>>,
-              ExtractJoinBuilderSelect<ReturnType<TBuilderFn>>
-            >
-          >[TRelationType];
-        }
-      >
-    : never;
-};
+export type IndexedJoinBuilder<_TTable extends AnyTable, _TJoinOut> = never;
 
 /**
  * Build join operations with indexed-only where clauses for Unit of Work
@@ -872,8 +826,10 @@ export function buildJoinIndexed<TTable extends AnyTable, TJoinOut>(
   const compiled: CompiledJoin[] = [];
   const builder: Record<string, unknown> = {};
 
-  for (const name in table.relations) {
-    const relation = table.relations[name]!;
+  const relations = getTableRelations(table);
+
+  for (const name in relations) {
+    const relation = relations[name]!;
 
     builder[name] = (builderFn?: (b: JoinFindBuilder<AnyTable>) => JoinFindBuilder<AnyTable>) => {
       // Create join builder for this relation's table
@@ -1965,7 +1921,8 @@ export class TypedUnitOfWork<
   }
 
   async executeRetrieve(): Promise<TRetrievalResults> {
-    return this.#uow.executeRetrieve() as Promise<TRetrievalResults>;
+    await this.#uow.executeRetrieve();
+    return this.retrievalPhase;
   }
 
   async executeMutations(): Promise<{ success: boolean }> {

--- a/packages/fragno-db/src/query/value-decoding.test.ts
+++ b/packages/fragno-db/src/query/value-decoding.test.ts
@@ -26,19 +26,9 @@ describe("decodeResult", () => {
           .addColumn("id", idColumn())
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
-          .addColumn("userId", referenceColumn())
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .addColumn("viewCount", column("integer"))
           .addColumn("publishedAt", column("timestamp").nullable());
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "userId" },
-        to: { table: "users", column: "id" },
-      })
-      .addReference("posts", {
-        type: "many",
-        from: { table: "users", column: "id" },
-        to: { table: "posts", column: "userId" },
       });
   });
 
@@ -144,9 +134,9 @@ describe("decodeResult", () => {
         {
           id: "post1",
           title: "My Post",
-          "author:id": "user1",
-          "author:name": "Alice",
-          "author:email": "alice@example.com",
+          "user:id": "user1",
+          "user:name": "Alice",
+          "user:email": "alice@example.com",
         },
         postsTable,
         sqliteConfig,
@@ -155,7 +145,7 @@ describe("decodeResult", () => {
       expect(result).toEqual({
         id: "post1",
         title: "My Post",
-        author: {
+        user: {
           id: "user1",
           name: "Alice",
           email: "alice@example.com",
@@ -169,15 +159,15 @@ describe("decodeResult", () => {
         {
           id: "post1",
           title: "My Post",
-          "author:id": "user1",
-          "author:isActive": 1,
-          "author:createdAt": timestamp,
+          "user:id": "user1",
+          "user:isActive": 1,
+          "user:createdAt": timestamp,
         },
         postsTable,
         sqliteConfig,
       );
 
-      expect(result["author"]).toEqual({
+      expect(result["user"]).toEqual({
         id: "user1",
         isActive: true,
         createdAt: new Date(timestamp),
@@ -206,8 +196,8 @@ describe("decodeResult", () => {
         {
           id: "post1",
           title: "My Post",
-          "author:id": "user1",
-          "author:unknownField": "value",
+          "user:id": "user1",
+          "user:unknownField": "value",
         },
         postsTable,
         sqliteConfig,
@@ -216,7 +206,7 @@ describe("decodeResult", () => {
       expect(result).toEqual({
         id: "post1",
         title: "My Post",
-        author: {
+        user: {
           id: "user1",
         },
       });
@@ -235,18 +225,8 @@ describe("decodeResult", () => {
             return t
               .addColumn("id", idColumn())
               .addColumn("title", column("string"))
-              .addColumn("userId", referenceColumn())
-              .addColumn("categoryId", referenceColumn());
-          })
-          .addReference("author", {
-            type: "one",
-            from: { table: "posts", column: "userId" },
-            to: { table: "users", column: "id" },
-          })
-          .addReference("category", {
-            type: "one",
-            from: { table: "posts", column: "categoryId" },
-            to: { table: "categories", column: "id" },
+              .addColumn("userId", referenceColumn({ table: "users" }))
+              .addColumn("categoryId", referenceColumn({ table: "categories" }));
           });
       });
 
@@ -254,8 +234,8 @@ describe("decodeResult", () => {
         {
           id: "post1",
           title: "My Post",
-          "author:id": "user1",
-          "author:name": "Alice",
+          "user:id": "user1",
+          "user:name": "Alice",
           "category:id": "cat1",
           "category:name": "Technology",
         },
@@ -266,7 +246,7 @@ describe("decodeResult", () => {
       expect(result).toEqual({
         id: "post1",
         title: "My Post",
-        author: {
+        user: {
           id: "user1",
           name: "Alice",
         },
@@ -284,10 +264,10 @@ describe("decodeResult", () => {
           _internalId: BigInt(100),
           _version: 0,
           title: "My Post",
-          "author:id": "user1",
-          "author:_internalId": BigInt(200),
-          "author:_version": 0,
-          "author:name": "Alice",
+          "user:id": "user1",
+          "user:_internalId": BigInt(200),
+          "user:_version": 0,
+          "user:name": "Alice",
         },
         postsTable,
         sqliteConfig,
@@ -299,12 +279,12 @@ describe("decodeResult", () => {
       expect(result["id"].internalId).toBe(BigInt(100));
 
       // Relation id should also be FragnoId (THIS IS THE BUG WE'RE FIXING)
-      expect(result["author"]).toBeDefined();
-      const author = result["author"] as Record<string, unknown>;
-      assert(author["id"] instanceof FragnoId);
-      expect(author["id"].externalId).toBe("user1");
-      expect(author["id"].internalId).toBe(BigInt(200));
-      expect(author["name"]).toBe("Alice");
+      expect(result["user"]).toBeDefined();
+      const user = result["user"] as Record<string, unknown>;
+      assert(user["id"] instanceof FragnoId);
+      expect(user["id"].externalId).toBe("user1");
+      expect(user["id"].internalId).toBe(BigInt(200));
+      expect(user["name"]).toBe("Alice");
     });
 
     it("should return null for missing one relations when internal id is null", () => {
@@ -312,10 +292,10 @@ describe("decodeResult", () => {
         {
           id: "post1",
           title: "My Post",
-          "author:id": null,
-          "author:_internalId": null,
-          "author:_version": null,
-          "author:name": null,
+          "user:id": null,
+          "user:_internalId": null,
+          "user:_version": null,
+          "user:name": null,
         },
         postsTable,
         sqliteConfig,
@@ -324,11 +304,11 @@ describe("decodeResult", () => {
       expect(result).toEqual({
         id: "post1",
         title: "My Post",
-        author: null,
+        user: null,
       });
     });
 
-    it("should return empty array for missing many relations when internal id is null", () => {
+    it("skips relation payloads for unknown aliases", () => {
       const result = decodeResult(
         {
           id: "user1",
@@ -345,7 +325,6 @@ describe("decodeResult", () => {
       expect(result).toEqual({
         id: "user1",
         name: "Alice",
-        posts: [],
       });
     });
   });
@@ -387,15 +366,15 @@ describe("decodeResult", () => {
     it("should handle result with only relation data", () => {
       const result = decodeResult(
         {
-          "author:id": "user1",
-          "author:name": "Alice",
+          "user:id": "user1",
+          "user:name": "Alice",
         },
         postsTable,
         sqliteConfig,
       );
 
       expect(result).toEqual({
-        author: {
+        user: {
           id: "user1",
           name: "Alice",
         },
@@ -410,8 +389,8 @@ describe("decodeResult", () => {
           title: "My Post",
           viewCount: 100,
           publishedAt: timestamp,
-          "author:id": "user1",
-          "author:name": "Alice",
+          "user:id": "user1",
+          "user:name": "Alice",
         },
         postsTable,
         sqliteConfig,
@@ -422,7 +401,7 @@ describe("decodeResult", () => {
         title: "My Post",
         viewCount: 100,
         publishedAt: new Date(timestamp),
-        author: {
+        user: {
           id: "user1",
           name: "Alice",
         },
@@ -512,10 +491,10 @@ describe("decodeResult", () => {
         {
           id: "post1",
           title: "My Post",
-          "author:id": "user123",
-          "author:_internalId": 456,
-          "author:_version": 0,
-          "author:name": "Alice",
+          "user:id": "user123",
+          "user:_internalId": 456,
+          "user:_version": 0,
+          "user:name": "Alice",
         },
         postsTable,
         postgresqlConfig,
@@ -524,11 +503,11 @@ describe("decodeResult", () => {
       expect(result["id"]).toBe("post1");
       expect(result["title"]).toBe("My Post");
       // Relations now correctly create FragnoId objects when both IDs are present (thanks to recursive decoding)
-      const author: Record<string, unknown> = result["author"] as Record<string, unknown>;
-      assert(author["id"] instanceof FragnoId);
-      expect(author["id"].externalId).toBe("user123");
-      expect(author["id"].internalId).toBe(456n);
-      expect(author["name"]).toBe("Alice");
+      const user: Record<string, unknown> = result["user"] as Record<string, unknown>;
+      assert(user["id"] instanceof FragnoId);
+      expect(user["id"].externalId).toBe("user123");
+      expect(user["id"].internalId).toBe(456n);
+      expect(user["name"]).toBe("Alice");
     });
 
     it("should return regular string in relation data when internal ID missing", () => {
@@ -536,8 +515,8 @@ describe("decodeResult", () => {
         {
           id: "post1",
           title: "My Post",
-          "author:id": "user123",
-          "author:name": "Alice",
+          "user:id": "user123",
+          "user:name": "Alice",
         },
         postsTable,
         postgresqlConfig,
@@ -546,13 +525,13 @@ describe("decodeResult", () => {
       expect(result).toEqual({
         id: "post1",
         title: "My Post",
-        author: {
+        user: {
           id: "user123",
           name: "Alice",
         },
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((result["author"] as any)["id"]).not.toBeInstanceOf(FragnoId);
+      expect((result["user"] as any)["id"]).not.toBeInstanceOf(FragnoId);
     });
 
     it("should handle complete record with FragnoId creation", () => {

--- a/packages/fragno-db/src/query/value-decoding.ts
+++ b/packages/fragno-db/src/query/value-decoding.ts
@@ -2,7 +2,7 @@ import type { DriverConfig } from "../adapters/generic-sql/driver-config";
 import type { SQLiteStorageMode } from "../adapters/generic-sql/sqlite-storage";
 import type { NamingResolver } from "../naming/sql-naming";
 import type { AnyTable } from "../schema/create";
-import { FragnoId, FragnoReference } from "../schema/create";
+import { FragnoId, FragnoReference, getTableRelations } from "../schema/create";
 import { createSQLSerializer } from "./serialize/create-sql-serializer";
 
 const isNullish = (value: unknown): value is null | undefined =>
@@ -70,7 +70,7 @@ export function decodeResult(
     const relationName = k.slice(0, colonIndex);
     const remainder = k.slice(colonIndex + 1);
 
-    const relation = table.relations[relationName];
+    const relation = getTableRelations(table)[relationName];
     if (relation === undefined) {
       continue;
     }
@@ -82,7 +82,7 @@ export function decodeResult(
 
   // Process each relation's data recursively
   for (const relationName in relationData) {
-    const relation = table.relations[relationName];
+    const relation = getTableRelations(table)[relationName];
     if (!relation) {
       continue;
     }

--- a/packages/fragno-db/src/query/value-encoding.test.ts
+++ b/packages/fragno-db/src/query/value-encoding.test.ts
@@ -31,14 +31,9 @@ describe("encodeValues", () => {
         return t
           .addColumn("id", idColumn())
           .addColumn("title", column("string"))
-          .addColumn("userId", referenceColumn())
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .addColumn("viewCount", column("integer").defaultTo(0))
           .addColumn("publishedAt", column("timestamp").nullable());
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "userId" },
-        to: { table: "users", column: "id" },
       });
   });
 

--- a/packages/fragno-db/src/query/value-encoding.ts
+++ b/packages/fragno-db/src/query/value-encoding.ts
@@ -1,6 +1,6 @@
 import type { NamingResolver } from "../naming/sql-naming";
 import type { AnyTable, AnyColumn } from "../schema/create";
-import { FragnoId, FragnoReference } from "../schema/create";
+import { FragnoId, FragnoReference, getTableForeignKey } from "../schema/create";
 import {
   generateDatabaseDefault,
   generateRuntimeDefault,
@@ -156,12 +156,10 @@ export function encodeValues(
         }
 
         if (needsSubquery) {
-          const relation = Object.values(table.relations).find((rel) =>
-            rel.on.some(([localCol]) => localCol === k),
-          );
-          if (relation) {
+          const foreignKey = getTableForeignKey(table, k);
+          if (foreignKey) {
             result[physicalColumnName] = new ReferenceSubquery(
-              relation.table,
+              foreignKey.referencedTable,
               externalIdForSubquery!,
             );
             continue;

--- a/packages/fragno-db/src/schema-output/drizzle.test.ts
+++ b/packages/fragno-db/src/schema-output/drizzle.test.ts
@@ -21,15 +21,10 @@ describe("generateDrizzleSchema", () => {
           .addColumn("id", idColumn())
           .addColumn("title", column("string"))
           .addColumn("content", column("string"))
-          .addColumn("userId", referenceColumn())
+          .addColumn("userId", referenceColumn({ table: "users" }))
           .addColumn("viewCount", column("integer").defaultTo(0))
           .createIndex("idx_user", ["userId"])
           .createIndex("idx_title", ["title"]);
-      })
-      .addReference("author", {
-        type: "one",
-        from: { table: "posts", column: "userId" },
-        to: { table: "users", column: "id" },
       });
   });
 
@@ -94,7 +89,7 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.userId],
             foreignColumns: [users_test._internalId],
-            name: "fk_posts_users_author"
+            name: "fk_posts_users_posts_userId_fk"
           }),
           index("idx_user").on(table.userId),
           index("idx_title").on(table.title)
@@ -102,13 +97,13 @@ describe("generateDrizzleSchema", () => {
 
         export const users_testRelations = relations(users_test, ({ many }) => ({
           postsList: many(posts_test, {
-            relationName: "posts_users"
+            relationName: "posts_userId"
           })
         }));
 
         export const posts_testRelations = relations(posts_test, ({ one }) => ({
-          author: one(users_test, {
-            relationName: "posts_users",
+          user: one(users_test, {
+            relationName: "posts_userId",
             fields: [posts_test.userId],
             references: [users_test._internalId]
           })
@@ -123,7 +118,7 @@ describe("generateDrizzleSchema", () => {
           posts_testRelations: posts_testRelations,
           posts: posts_test,
           postsRelations: posts_testRelations,
-          schemaVersion: 3
+          schemaVersion: 2
         }"
       `);
     });
@@ -165,7 +160,7 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.userId],
             foreignColumns: [users_test._internalId],
-            name: "fk_posts_users_author_test_8d48035c"
+            name: "fk_posts_users_posts_userId_fk_test_21435475"
           }),
           index("idx_posts_idx_user_test_4a5c5c19").on(table.userId),
           index("idx_posts_idx_title_test_00e97ff4").on(table.title)
@@ -173,13 +168,13 @@ describe("generateDrizzleSchema", () => {
 
         export const users_testRelations = relations(users_test, ({ many }) => ({
           postsList: many(posts_test, {
-            relationName: "posts_users"
+            relationName: "posts_userId"
           })
         }));
 
         export const posts_testRelations = relations(posts_test, ({ one }) => ({
-          author: one(users_test, {
-            relationName: "posts_users",
+          user: one(users_test, {
+            relationName: "posts_userId",
             fields: [posts_test.userId],
             references: [users_test._internalId]
           })
@@ -194,7 +189,7 @@ describe("generateDrizzleSchema", () => {
           posts_testRelations: posts_testRelations,
           posts: posts_test,
           postsRelations: posts_testRelations,
-          schemaVersion: 3
+          schemaVersion: 2
         }"
       `);
     });
@@ -240,7 +235,7 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.userId],
             foreignColumns: [users_test._internalId],
-            name: "fk_posts_users_author_test_8d48035c"
+            name: "fk_posts_users_posts_userId_fk_test_21435475"
           }),
           index("idx_posts_idx_user_test_4a5c5c19").on(table.userId),
           index("idx_posts_idx_title_test_00e97ff4").on(table.title),
@@ -249,13 +244,13 @@ describe("generateDrizzleSchema", () => {
 
         export const users_testRelations = relations(users_test, ({ many }) => ({
           postsList: many(posts_test, {
-            relationName: "posts_users"
+            relationName: "posts_userId"
           })
         }));
 
         export const posts_testRelations = relations(posts_test, ({ one }) => ({
-          author: one(users_test, {
-            relationName: "posts_users",
+          user: one(users_test, {
+            relationName: "posts_userId",
             fields: [posts_test.userId],
             references: [users_test._internalId]
           })
@@ -270,7 +265,7 @@ describe("generateDrizzleSchema", () => {
           posts_testRelations: posts_testRelations,
           posts: posts_test,
           postsRelations: posts_testRelations,
-          schemaVersion: 3
+          schemaVersion: 2
         }"
       `);
     });
@@ -420,18 +415,8 @@ describe("generateDrizzleSchema", () => {
           return t
             .addColumn("id", idColumn())
             .addColumn("title", column("string"))
-            .addColumn("userId", referenceColumn())
+            .addColumn("userId", referenceColumn({ table: "users" }))
             .createIndex("idx_user", ["userId"]);
-        })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "userId" },
-          to: { table: "users", column: "id" },
-        })
-        .addReference("posts", {
-          type: "many",
-          from: { table: "users", column: "id" },
-          to: { table: "posts", column: "userId" },
         });
     });
 
@@ -468,23 +453,20 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.userId],
             foreignColumns: [users_test._internalId],
-            name: "fk_posts_users_author"
+            name: "fk_posts_users_posts_userId_fk"
           }),
           index("idx_user").on(table.userId)
         ])
 
         export const users_testRelations = relations(users_test, ({ many }) => ({
-          posts: many(posts_test, {
-            relationName: "users_posts"
-          }),
           postsList: many(posts_test, {
-            relationName: "posts_users"
+            relationName: "posts_userId"
           })
         }));
 
         export const posts_testRelations = relations(posts_test, ({ one }) => ({
-          author: one(users_test, {
-            relationName: "posts_users",
+          user: one(users_test, {
+            relationName: "posts_userId",
             fields: [posts_test.userId],
             references: [users_test._internalId]
           })
@@ -499,7 +481,7 @@ describe("generateDrizzleSchema", () => {
           posts_testRelations: posts_testRelations,
           posts: posts_test,
           postsRelations: posts_testRelations,
-          schemaVersion: 4
+          schemaVersion: 2
         }"
       `);
     });
@@ -535,23 +517,20 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.userId],
             foreignColumns: [users_test._internalId],
-            name: "fk_posts_users_author_test_8d48035c"
+            name: "fk_posts_users_posts_userId_fk_test_21435475"
           }),
           index("idx_posts_idx_user_test_4a5c5c19").on(table.userId)
         ])
 
         export const users_testRelations = relations(users_test, ({ many }) => ({
-          posts: many(posts_test, {
-            relationName: "users_posts"
-          }),
           postsList: many(posts_test, {
-            relationName: "posts_users"
+            relationName: "posts_userId"
           })
         }));
 
         export const posts_testRelations = relations(posts_test, ({ one }) => ({
-          author: one(users_test, {
-            relationName: "posts_users",
+          user: one(users_test, {
+            relationName: "posts_userId",
             fields: [posts_test.userId],
             references: [users_test._internalId]
           })
@@ -566,7 +545,7 @@ describe("generateDrizzleSchema", () => {
           posts_testRelations: posts_testRelations,
           posts: posts_test,
           postsRelations: posts_testRelations,
-          schemaVersion: 4
+          schemaVersion: 2
         }"
       `);
     });
@@ -604,24 +583,21 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.userId],
             foreignColumns: [users_test._internalId],
-            name: "fk_posts_users_author_test_8d48035c"
+            name: "fk_posts_users_posts_userId_fk_test_21435475"
           }),
           index("idx_posts_idx_user_test_4a5c5c19").on(table.userId),
           uniqueIndex("uidx_posts_idx_posts_external_id_test_80487638").on(table.id)
         ])
 
         export const users_testRelations = relations(users_test, ({ many }) => ({
-          posts: many(posts_test, {
-            relationName: "users_posts"
-          }),
           postsList: many(posts_test, {
-            relationName: "posts_users"
+            relationName: "posts_userId"
           })
         }));
 
         export const posts_testRelations = relations(posts_test, ({ one }) => ({
-          author: one(users_test, {
-            relationName: "posts_users",
+          user: one(users_test, {
+            relationName: "posts_userId",
             fields: [posts_test.userId],
             references: [users_test._internalId]
           })
@@ -636,7 +612,7 @@ describe("generateDrizzleSchema", () => {
           posts_testRelations: posts_testRelations,
           posts: posts_test,
           postsRelations: posts_testRelations,
-          schemaVersion: 4
+          schemaVersion: 2
         }"
       `);
     });
@@ -651,12 +627,7 @@ describe("generateDrizzleSchema", () => {
             return t
               .addColumn("id", idColumn())
               .addColumn("name", column("string"))
-              .addColumn("categoryId", referenceColumn());
-          })
-          .addReference("products", {
-            type: "many",
-            from: { table: "categories", column: "id" },
-            to: { table: "products", column: "categoryId" },
+              .addColumn("categoryId", referenceColumn({ table: "categories" }));
           });
       });
 
@@ -675,12 +646,12 @@ describe("generateDrizzleSchema", () => {
       expect(generated).toContain(
         "export const categories_testRelations = relations(categories_test, ({ many }) => ({",
       );
-      expect(generated).toContain("products: many(products_test");
+      expect(generated).toContain("productsList: many(products_test");
 
       // Should have schema export
       expect(generated).toContain("export const test_schema = {");
       expect(generated).toMatchInlineSnapshot(`
-        "import { pgSchema, varchar, text, bigserial, integer, bigint } from "drizzle-orm/pg-core"
+        "import { pgSchema, varchar, text, bigserial, integer, bigint, foreignKey } from "drizzle-orm/pg-core"
         import { createId } from "@fragno-dev/db/id"
         import { relations } from "drizzle-orm"
 
@@ -703,11 +674,25 @@ describe("generateDrizzleSchema", () => {
           categoryId: bigint("categoryId", { mode: "number" }).notNull(),
           _internalId: bigserial("_internalId", { mode: "number" }).primaryKey().notNull(),
           _version: integer("_version").notNull().default(0)
-        })
+        }, (table) => [
+          foreignKey({
+            columns: [table.categoryId],
+            foreignColumns: [categories_test._internalId],
+            name: "fk_products_categories_products_categoryId_fk"
+          })
+        ])
 
         export const categories_testRelations = relations(categories_test, ({ many }) => ({
-          products: many(products_test, {
-            relationName: "categories_products"
+          productsList: many(products_test, {
+            relationName: "products_categoryId"
+          })
+        }));
+
+        export const products_testRelations = relations(products_test, ({ one }) => ({
+          category: one(categories_test, {
+            relationName: "products_categoryId",
+            fields: [products_test.categoryId],
+            references: [categories_test._internalId]
           })
         }));
 
@@ -717,31 +702,22 @@ describe("generateDrizzleSchema", () => {
           categories: categories_test,
           categoriesRelations: categories_testRelations,
           products_test: products_test,
+          products_testRelations: products_testRelations,
           products: products_test,
-          schemaVersion: 3
+          productsRelations: products_testRelations,
+          schemaVersion: 2
         }"
       `);
     });
 
     it("should handle self-referencing many relations", () => {
       const selfManySchema = schema("selfmany", (s) => {
-        return s
-          .addTable("category", (t) => {
-            return t
-              .addColumn("id", idColumn())
-              .addColumn("name", column("string"))
-              .addColumn("parentId", referenceColumn().nullable());
-          })
-          .addReference("parent", {
-            type: "one",
-            from: { table: "category", column: "parentId" },
-            to: { table: "category", column: "id" },
-          })
-          .addReference("children", {
-            type: "many",
-            from: { table: "category", column: "id" },
-            to: { table: "category", column: "parentId" },
-          });
+        return s.addTable("category", (t) => {
+          return t
+            .addColumn("id", idColumn())
+            .addColumn("name", column("string"))
+            .addColumn("parentId", referenceColumn({ table: "category" }).nullable());
+        });
       });
 
       const generated = generateDrizzleSchema(
@@ -751,7 +727,7 @@ describe("generateDrizzleSchema", () => {
 
       // Should have both one and many relations
       expect(generated).toContain("parent: one(category_test");
-      expect(generated).toContain("children: many(category_test");
+      expect(generated).toContain("categoryList: many(category_test");
 
       // Should only have one foreign key (from the "one" relation)
       const fkMatches = generated.match(/foreignKey\(/g);
@@ -778,21 +754,18 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.parentId],
             foreignColumns: [table._internalId],
-            name: "fk_category_category_parent"
+            name: "fk_category_category_category_parentId_fk"
           })
         ])
 
         export const category_testRelations = relations(category_test, ({ one, many }) => ({
           parent: one(category_test, {
-            relationName: "category_category",
+            relationName: "category_parentId",
             fields: [category_test.parentId],
             references: [category_test._internalId]
           }),
-          children: many(category_test, {
-            relationName: "category_category"
-          }),
           categoryList: many(category_test, {
-            relationName: "category_category"
+            relationName: "category_parentId"
           })
         }));
 
@@ -801,7 +774,7 @@ describe("generateDrizzleSchema", () => {
           category_testRelations: category_testRelations,
           category: category_test,
           categoryRelations: category_testRelations,
-          schemaVersion: 3
+          schemaVersion: 1
         }"
       `);
     });
@@ -821,12 +794,6 @@ describe("generateDrizzleSchema", () => {
             .addColumn("id", idColumn())
             .addColumn("email", column("string"))
             .createIndex("idx_inv_email", ["email"]);
-        })
-        .addReference("invitedUser", {
-          type: "one",
-          from: { table: "invitations", column: "email" },
-          to: { table: "users", column: "email" },
-          foreignKey: false,
         });
     });
 
@@ -841,19 +808,13 @@ describe("generateDrizzleSchema", () => {
 
   describe("self-referencing foreign keys", () => {
     const selfRefSchema = schema("selfref", (s) => {
-      return s
-        .addTable("comment", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("content", column("string"))
-            .addColumn("parentId", referenceColumn().nullable())
-            .createIndex("idx_parent", ["parentId"]);
-        })
-        .addReference("parent", {
-          type: "one",
-          from: { table: "comment", column: "parentId" },
-          to: { table: "comment", column: "id" },
-        });
+      return s.addTable("comment", (t) => {
+        return t
+          .addColumn("id", idColumn())
+          .addColumn("content", column("string"))
+          .addColumn("parentId", referenceColumn({ table: "comment" }).nullable())
+          .createIndex("idx_parent", ["parentId"]);
+      });
     });
 
     it("should generate PostgreSQL self-referencing foreign key using table parameter", () => {
@@ -882,19 +843,19 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.parentId],
             foreignColumns: [table._internalId],
-            name: "fk_comment_comment_parent"
+            name: "fk_comment_comment_comment_parentId_fk"
           }),
           index("idx_parent").on(table.parentId)
         ])
 
         export const comment_testRelations = relations(comment_test, ({ one, many }) => ({
           parent: one(comment_test, {
-            relationName: "comment_comment",
+            relationName: "comment_parentId",
             fields: [comment_test.parentId],
             references: [comment_test._internalId]
           }),
           commentList: many(comment_test, {
-            relationName: "comment_comment"
+            relationName: "comment_parentId"
           })
         }));
 
@@ -903,7 +864,7 @@ describe("generateDrizzleSchema", () => {
           comment_testRelations: comment_testRelations,
           comment: comment_test,
           commentRelations: comment_testRelations,
-          schemaVersion: 2
+          schemaVersion: 1
         }"
       `);
     });
@@ -932,19 +893,19 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.parentId],
             foreignColumns: [table._internalId],
-            name: "fk_comment_comment_parent_test_af0d05a4"
+            name: "fk_comment_comment_comment_parentId_fk_test_ae280411"
           }),
           index("idx_comment_idx_parent_test_3c264dbc").on(table.parentId)
         ])
 
         export const comment_testRelations = relations(comment_test, ({ one, many }) => ({
           parent: one(comment_test, {
-            relationName: "comment_comment",
+            relationName: "comment_parentId",
             fields: [comment_test.parentId],
             references: [comment_test._internalId]
           }),
           commentList: many(comment_test, {
-            relationName: "comment_comment"
+            relationName: "comment_parentId"
           })
         }));
 
@@ -953,7 +914,7 @@ describe("generateDrizzleSchema", () => {
           comment_testRelations: comment_testRelations,
           comment: comment_test,
           commentRelations: comment_testRelations,
-          schemaVersion: 2
+          schemaVersion: 1
         }"
       `);
     });
@@ -982,7 +943,7 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.parentId],
             foreignColumns: [table._internalId],
-            name: "fk_comment_comment_parent_test_af0d05a4"
+            name: "fk_comment_comment_comment_parentId_fk_test_ae280411"
           }),
           index("idx_comment_idx_parent_test_3c264dbc").on(table.parentId),
           uniqueIndex("uidx_comment_idx_comment_external_id_test_6a1c2b8f").on(table.id)
@@ -990,12 +951,12 @@ describe("generateDrizzleSchema", () => {
 
         export const comment_testRelations = relations(comment_test, ({ one, many }) => ({
           parent: one(comment_test, {
-            relationName: "comment_comment",
+            relationName: "comment_parentId",
             fields: [comment_test.parentId],
             references: [comment_test._internalId]
           }),
           commentList: many(comment_test, {
-            relationName: "comment_comment"
+            relationName: "comment_parentId"
           })
         }));
 
@@ -1004,7 +965,7 @@ describe("generateDrizzleSchema", () => {
           comment_testRelations: comment_testRelations,
           comment: comment_test,
           commentRelations: comment_testRelations,
-          schemaVersion: 2
+          schemaVersion: 1
         }"
       `);
     });
@@ -1027,7 +988,7 @@ describe("generateDrizzleSchema", () => {
       expect(generated).toContain('schema_auth_db.table("posts"');
 
       // Foreign key name should use the original namespace with hashed naming
-      expect(generated).toMatch(/name: "fk_posts_users_author"/);
+      expect(generated).toMatch(/name: "fk_posts_users_posts_userId_fk"/);
 
       // Relations should reference sanitized table names
       expect(generated).toContain("foreignColumns: [users_auth_db._internalId]");
@@ -1077,7 +1038,7 @@ describe("generateDrizzleSchema", () => {
       expect(generated).toContain("foreignColumns: [users_my_fragment_v2._internalId]");
 
       // Relations should also use sanitized names
-      expect(generated).toContain("author: one(users_my_fragment_v2");
+      expect(generated).toContain("user: one(users_my_fragment_v2");
       expect(generated).toContain("fields: [posts_my_fragment_v2.userId]");
       expect(generated).toContain("references: [users_my_fragment_v2._internalId]");
 
@@ -1121,7 +1082,7 @@ describe("generateDrizzleSchema", () => {
           foreignKey({
             columns: [table.userId],
             foreignColumns: [users_my_fragment_v2._internalId],
-            name: "fk_posts_users_author"
+            name: "fk_posts_users_posts_userId_fk"
           }),
           index("idx_user").on(table.userId),
           index("idx_title").on(table.title)
@@ -1129,13 +1090,13 @@ describe("generateDrizzleSchema", () => {
 
         export const users_my_fragment_v2Relations = relations(users_my_fragment_v2, ({ many }) => ({
           postsList: many(posts_my_fragment_v2, {
-            relationName: "posts_users"
+            relationName: "posts_userId"
           })
         }));
 
         export const posts_my_fragment_v2Relations = relations(posts_my_fragment_v2, ({ one }) => ({
-          author: one(users_my_fragment_v2, {
-            relationName: "posts_users",
+          user: one(users_my_fragment_v2, {
+            relationName: "posts_userId",
             fields: [posts_my_fragment_v2.userId],
             references: [users_my_fragment_v2._internalId]
           })
@@ -1150,7 +1111,7 @@ describe("generateDrizzleSchema", () => {
           posts_my_fragment_v2Relations: posts_my_fragment_v2Relations,
           posts: posts_my_fragment_v2,
           postsRelations: posts_my_fragment_v2Relations,
-          schemaVersion: 3
+          schemaVersion: 2
         }"
       `);
     });

--- a/packages/fragno-db/src/schema-output/drizzle.ts
+++ b/packages/fragno-db/src/schema-output/drizzle.ts
@@ -15,6 +15,8 @@ import {
   type AnyTable,
   type Relation,
   InternalIdColumn,
+  getTableForeignKey,
+  getTableRelations,
 } from "../schema/create";
 import { createSQLTypeMapper } from "../schema/type-conversion/create-sql-type-mapper";
 import { type DatabaseTypeLiteral } from "../schema/type-conversion/type-mapping";
@@ -366,7 +368,7 @@ function generateForeignKeys(
 ): string[] {
   const keys: string[] = [];
 
-  for (const relation of Object.values(table.relations)) {
+  for (const relation of Object.values(getTableRelations(table))) {
     // Only "one" relations generate foreign keys
     // "many" relations don't have foreign keys (they're on the other side)
     if (relation.type === "many" || relation.foreignKey === false) {
@@ -394,14 +396,17 @@ function generateForeignKeys(
     }
 
     ctx.imports.addImport("foreignKey", ctx.importSource);
+    const localColumnName = relation.on[0]?.[0];
+    const foreignKey = localColumnName ? getTableForeignKey(table, localColumnName) : undefined;
+    const referenceName = foreignKey?.name ?? relation.name;
     // Include namespace in FK name to avoid collisions
     const fkName = resolver
       ? resolver.getForeignKeyName({
           logicalTable: table.name,
           logicalReferencedTable: relation.table.name,
-          referenceName: relation.name,
+          referenceName,
         })
-      : `${table.name}_${relation.table.name}_${relation.name}_fk`;
+      : `${table.name}_${relation.table.name}_${referenceName}`;
 
     keys.push(`foreignKey({
   columns: [${columns.join(", ")}],
@@ -523,7 +528,7 @@ function generateRelation(
   let hasMany = false;
 
   // Generate explicit relations defined on this table
-  for (const relation of Object.values(table.relations)) {
+  for (const relation of Object.values(getTableRelations(table))) {
     if (relation.foreignKey === false) {
       continue;
     }
@@ -741,7 +746,7 @@ export function generateDrizzleSchema(
     // This is needed for Drizzle's relational query API to work correctly
     const inverseRelations = new Map<string, Array<{ fromTable: AnyTable; relation: Relation }>>();
     for (const table of Object.values(schema.tables)) {
-      for (const relation of Object.values(table.relations)) {
+      for (const relation of Object.values(getTableRelations(table))) {
         if (relation.foreignKey === false) {
           continue;
         }

--- a/packages/fragno-db/src/schema-output/prisma.test.ts
+++ b/packages/fragno-db/src/schema-output/prisma.test.ts
@@ -19,37 +19,17 @@ const blogSchema = schema("blog", (s) => {
         .addColumn("profile", column("json").nullable())
         .addColumn("bigScore", column("bigint"))
         .addColumn("reputation", column("decimal"))
-        .addColumn("invitedBy", referenceColumn().nullable())
+        .addColumn("invitedBy", referenceColumn({ table: "users" }).nullable())
         .createIndex("idx_email", ["email"], { unique: true });
     })
     .addTable("posts", (t) => {
       return t
         .addColumn("id", idColumn())
         .addColumn("title", column("string"))
-        .addColumn("authorId", referenceColumn())
-        .addColumn("editorId", referenceColumn().nullable())
+        .addColumn("authorId", referenceColumn({ table: "users" }))
+        .addColumn("editorId", referenceColumn({ table: "users" }).nullable())
         .addColumn("publishedAt", column("timestamp").nullable())
         .createIndex("idx_title", ["title"]);
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("editor", {
-      type: "one",
-      from: { table: "posts", column: "editorId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("inviter", {
-      type: "one",
-      from: { table: "users", column: "invitedBy" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("posts", {
-      type: "many",
-      from: { table: "users", column: "id" },
-      to: { table: "posts", column: "authorId" },
     });
 });
 
@@ -71,60 +51,20 @@ const relationNamingSchema = schema("relationnaming", (s) => {
     .addTable("posts", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("author_id", referenceColumn())
-        .addColumn("editor_id", referenceColumn().nullable());
+        .addColumn("author_id", referenceColumn({ table: "users" }))
+        .addColumn("editor_id", referenceColumn({ table: "users" }).nullable());
     })
     .addTable("comments", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("post_id", referenceColumn())
-        .addColumn("parent_id", referenceColumn().nullable());
+        .addColumn("post_id", referenceColumn({ table: "posts" }))
+        .addColumn("parent_id", referenceColumn({ table: "comments" }).nullable());
     })
     .addTable("follows", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("follower_id", referenceColumn())
-        .addColumn("followee_id", referenceColumn());
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "author_id" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("editor", {
-      type: "one",
-      from: { table: "posts", column: "editor_id" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("post", {
-      type: "one",
-      from: { table: "comments", column: "post_id" },
-      to: { table: "posts", column: "id" },
-    })
-    .addReference("parent", {
-      type: "one",
-      from: { table: "comments", column: "parent_id" },
-      to: { table: "comments", column: "id" },
-    })
-    .addReference("follower", {
-      type: "one",
-      from: { table: "follows", column: "follower_id" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("followee", {
-      type: "one",
-      from: { table: "follows", column: "followee_id" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("posts", {
-      type: "many",
-      from: { table: "users", column: "id" },
-      to: { table: "posts", column: "author_id" },
-    })
-    .addReference("editedPosts", {
-      type: "many",
-      from: { table: "users", column: "id" },
-      to: { table: "posts", column: "editor_id" },
+        .addColumn("follower_id", referenceColumn({ table: "users" }))
+        .addColumn("followee_id", referenceColumn({ table: "users" }));
     });
 });
 
@@ -272,8 +212,8 @@ describe("generatePrismaSchema", () => {
         publishedAt DateTime?
         _internalId Int @id @default(autoincrement())
         _version Int @default(0)
-        author Users_blog @relation("blog_posts_author_users", fields: [authorId], references: [_internalId], map: "fk_posts_users_author_blog_d01fe02e")
-        editor Users_blog? @relation("blog_posts_editor_users", fields: [editorId], references: [_internalId], map: "fk_posts_users_editor_blog_d7abc235")
+        author Users_blog @relation("blog_posts_author_users", fields: [authorId], references: [_internalId], map: "fk_posts_users_posts_authorId_fk_blog_7969e40f")
+        editor Users_blog? @relation("blog_posts_editor_users", fields: [editorId], references: [_internalId], map: "fk_posts_users_posts_editorId_fk_blog_3e07e080")
         @@index([title], map: "idx_posts_idx_title_blog_f90cbb7e")
         @@map("posts_blog")
       }
@@ -289,10 +229,10 @@ describe("generatePrismaSchema", () => {
         invitedBy Int?
         _internalId Int @id @default(autoincrement())
         _version Int @default(0)
-        inviter Users_blog? @relation("blog_users_inviter_users", fields: [invitedBy], references: [_internalId], map: "fk_users_users_inviter_blog_631afc1c")
+        invitedBy_1 Users_blog? @relation("blog_users_invitedBy_users", fields: [invitedBy], references: [_internalId], map: "fk_users_users_users_invitedBy_fk_blog_2f6bd5fd")
         posts Posts_blog[] @relation("blog_posts_author_users")
         posts_editor Posts_blog[] @relation("blog_posts_editor_users")
-        users Users_blog[] @relation("blog_users_inviter_users")
+        users Users_blog[] @relation("blog_users_invitedBy_users")
         @@unique([email], map: "uidx_users_idx_email_blog_4468050e")
         @@map("users_blog")
       }"
@@ -421,8 +361,8 @@ describe("generatePrismaSchema", () => {
         publishedAt Int?
         _internalId Int @id @default(autoincrement())
         _version Int @default(0)
-        author Users_blog @relation("blog_posts_author_users", fields: [authorId], references: [_internalId], map: "fk_posts_users_author_blog_d01fe02e")
-        editor Users_blog? @relation("blog_posts_editor_users", fields: [editorId], references: [_internalId], map: "fk_posts_users_editor_blog_d7abc235")
+        author Users_blog @relation("blog_posts_author_users", fields: [authorId], references: [_internalId], map: "fk_posts_users_posts_authorId_fk_blog_7969e40f")
+        editor Users_blog? @relation("blog_posts_editor_users", fields: [editorId], references: [_internalId], map: "fk_posts_users_posts_editorId_fk_blog_3e07e080")
         @@index([title], map: "idx_posts_idx_title_blog_f90cbb7e")
         @@map("posts_blog")
       }
@@ -438,10 +378,10 @@ describe("generatePrismaSchema", () => {
         invitedBy Int?
         _internalId Int @id @default(autoincrement())
         _version Int @default(0)
-        inviter Users_blog? @relation("blog_users_inviter_users", fields: [invitedBy], references: [_internalId], map: "fk_users_users_inviter_blog_631afc1c")
+        invitedBy_1 Users_blog? @relation("blog_users_invitedBy_users", fields: [invitedBy], references: [_internalId], map: "fk_users_users_users_invitedBy_fk_blog_2f6bd5fd")
         posts Posts_blog[] @relation("blog_posts_author_users")
         posts_editor Posts_blog[] @relation("blog_posts_editor_users")
-        users Users_blog[] @relation("blog_users_inviter_users")
+        users Users_blog[] @relation("blog_users_invitedBy_users")
         @@unique([email], map: "uidx_users_idx_email_blog_4468050e")
         @@map("users_blog")
       }"
@@ -462,12 +402,6 @@ describe("generatePrismaSchema", () => {
             .addColumn("id", idColumn())
             .addColumn("email", column("string"))
             .createIndex("idx_inv_email", ["email"]);
-        })
-        .addReference("invitedUser", {
-          type: "one",
-          from: { table: "invitations", column: "email" },
-          to: { table: "users", column: "email" },
-          foreignKey: false,
         });
     });
 
@@ -581,8 +515,8 @@ describe("generatePrismaSchema", () => {
         publishedAt DateTime?
         _internalId BigInt @id @default(autoincrement())
         _version Int @default(0)
-        author Users_blog @relation("blog_posts_author_users", fields: [authorId], references: [_internalId], map: "fk_posts_users_author")
-        editor Users_blog? @relation("blog_posts_editor_users", fields: [editorId], references: [_internalId], map: "fk_posts_users_editor")
+        author Users_blog @relation("blog_posts_author_users", fields: [authorId], references: [_internalId], map: "fk_posts_users_posts_authorId_fk")
+        editor Users_blog? @relation("blog_posts_editor_users", fields: [editorId], references: [_internalId], map: "fk_posts_users_posts_editorId_fk")
         @@index([title], map: "idx_title")
         @@map("posts")
       }
@@ -598,10 +532,10 @@ describe("generatePrismaSchema", () => {
         invitedBy BigInt?
         _internalId BigInt @id @default(autoincrement())
         _version Int @default(0)
-        inviter Users_blog? @relation("blog_users_inviter_users", fields: [invitedBy], references: [_internalId], map: "fk_users_users_inviter")
+        invitedBy_1 Users_blog? @relation("blog_users_invitedBy_users", fields: [invitedBy], references: [_internalId], map: "fk_users_users_users_invitedBy_fk")
         posts Posts_blog[] @relation("blog_posts_author_users")
         posts_editor Posts_blog[] @relation("blog_posts_editor_users")
-        users Users_blog[] @relation("blog_users_inviter_users")
+        users Users_blog[] @relation("blog_users_invitedBy_users")
         @@unique([email], map: "idx_email")
         @@map("users")
       }"
@@ -663,7 +597,7 @@ describe("generatePrismaSchema", () => {
     );
 
     expect(generated).toContain('posts Posts_test[] @relation("test_posts_author_users")');
-    expect(generated).toContain('editedPosts Posts_test[] @relation("test_posts_editor_users")');
+    expect(generated).toContain('posts_editor Posts_test[] @relation("test_posts_editor_users")');
     expect(generated).toContain('comments Comments_test[] @relation("test_comments_post_posts")');
     expect(generated).toContain(
       'comments Comments_test[] @relation("test_comments_parent_comments")',
@@ -681,7 +615,7 @@ describe("generatePrismaSchema", () => {
     );
 
     expect(generated).toContain('posts Posts_test[] @relation("test_posts_author_users")');
-    expect(generated).toContain('editedPosts Posts_test[] @relation("test_posts_editor_users")');
+    expect(generated).toContain('posts_editor Posts_test[] @relation("test_posts_editor_users")');
     expect(generated).toContain('comments Comments_test[] @relation("test_comments_post_posts")');
     expect(generated).toContain(
       'comments Comments_test[] @relation("test_comments_parent_comments")',

--- a/packages/fragno-db/src/schema-output/prisma.ts
+++ b/packages/fragno-db/src/schema-output/prisma.ts
@@ -12,6 +12,7 @@ import {
   type SqlNamingStrategy,
 } from "../naming/sql-naming";
 import type { AnyColumn, AnySchema, AnyTable, Relation } from "../schema/create";
+import { getTableForeignKey, getTableRelations } from "../schema/create";
 import { parseVarchar } from "../util/parse";
 
 export interface GeneratePrismaSchemaOptions {
@@ -91,14 +92,18 @@ function getForeignKeyMapName(
   _namespace: string | null,
   resolver?: NamingResolver,
 ): string {
+  const localColumnName = relation.on[0]?.[0];
+  const foreignKey = localColumnName ? getTableForeignKey(table, localColumnName) : undefined;
+  const referenceName = foreignKey?.name ?? relation.name;
+
   if (resolver) {
     return resolver.getForeignKeyName({
       logicalTable: table.name,
       logicalReferencedTable: relation.table.name,
-      referenceName: relation.name,
+      referenceName,
     });
   }
-  return `${table.name}_${relation.table.name}_${relation.name}_fk`;
+  return `${table.name}_${relation.table.name}_${referenceName}`;
 }
 
 function getIndexMapName(
@@ -282,7 +287,7 @@ function areInverseRelations(one: Relation, many: Relation): boolean {
 }
 
 function findMatchingManyRelation(one: Relation): Relation | undefined {
-  for (const relation of Object.values(one.table.relations)) {
+  for (const relation of Object.values(getTableRelations(one.table))) {
     if (relation.type !== "many") {
       continue;
     }
@@ -297,7 +302,7 @@ function findMatchingManyRelation(one: Relation): Relation | undefined {
 }
 
 function findMatchingOneRelation(many: Relation): Relation | undefined {
-  for (const relation of Object.values(many.table.relations)) {
+  for (const relation of Object.values(getTableRelations(many.table))) {
     if (relation.type !== "one") {
       continue;
     }
@@ -367,7 +372,7 @@ function generateRelationFields(
 ): string[] {
   const lines: string[] = [];
   const usedNames = new Set<string>(fieldNameByColumn.values());
-  const relations = Object.values(table.relations)
+  const relations = Object.values(getTableRelations(table))
     .slice()
     .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -434,7 +439,7 @@ function generateRelationFields(
 
   const inverseCandidates: Relation[] = [];
   for (const sourceTable of fieldNameByTableColumn.keys()) {
-    for (const rel of Object.values(sourceTable.relations)) {
+    for (const rel of Object.values(getTableRelations(sourceTable))) {
       if (rel.type === "one" && rel.table === table && rel.foreignKey !== false) {
         inverseCandidates.push(rel);
       }

--- a/packages/fragno-db/src/schema/create.test.ts
+++ b/packages/fragno-db/src/schema/create.test.ts
@@ -10,6 +10,9 @@ import {
   column,
   FragnoId,
   FragnoReference,
+  getTableForeignKey,
+  getTableForeignKeys,
+  getTableRelations,
   idColumn,
   referenceColumn,
   schema,
@@ -205,7 +208,6 @@ describe("create", () => {
   });
 
   it("should demonstrate manual many-to-many relation setup", () => {
-    // For many-to-many, create a junction table manually
     const userSchema = schema("user", (s) => {
       return s
         .addTable("users", (t) => {
@@ -217,47 +219,29 @@ describe("create", () => {
         .addTable("user_tags", (t) => {
           return t
             .addColumn("id", idColumn())
-            .addColumn("userId", referenceColumn())
-            .addColumn("tagId", referenceColumn());
-        })
-        .addReference("user", {
-          type: "one",
-          from: { table: "user_tags", column: "userId" },
-          to: { table: "users", column: "id" },
-        })
-        .addReference("tag", {
-          type: "one",
-          from: { table: "user_tags", column: "tagId" },
-          to: { table: "tags", column: "id" },
+            .addColumn("userId", referenceColumn({ table: "users" }))
+            .addColumn("tagId", referenceColumn({ table: "tags" }));
         });
     });
 
     const junctionTable = userSchema.tables.user_tags;
+    const relations = getTableRelations(junctionTable);
+    const foreignKeys = getTableForeignKeys(junctionTable);
 
-    // Verify the junction table has both relations
-    expect(junctionTable.relations["user"]).toBeDefined();
-    expect(junctionTable.relations["tag"]).toBeDefined();
+    expect(relations["user"]).toBeDefined();
+    expect(relations["tag"]).toBeDefined();
+    expect(foreignKeys["userId"]?.referencedTable).toBe(userSchema.tables.users);
+    expect(foreignKeys["tagId"]?.referencedTable).toBe(userSchema.tables.tags);
 
-    // Verify both foreign keys were created as operations
-    const addReferenceOps = userSchema.operations.filter((op) => op.type === "add-reference");
-    expect(addReferenceOps).toHaveLength(2);
-
-    const userRef = addReferenceOps.find((op) => op.referenceName === "user");
-    expect(userRef).toBeDefined();
-    expect(userRef!.tableName).toBe("user_tags");
-    expect(userRef!.config.type).toBe("one");
-    expect(userRef!.config.from).toEqual({ table: "user_tags", column: "userId" });
-    expect(userRef!.config.to).toEqual({ table: "users", column: "_internalId" });
-
-    const tagRef = addReferenceOps.find((op) => op.referenceName === "tag");
-    expect(tagRef).toBeDefined();
-    expect(tagRef!.tableName).toBe("user_tags");
-    expect(tagRef!.config.type).toBe("one");
-    expect(tagRef!.config.from).toEqual({ table: "user_tags", column: "tagId" });
-    expect(tagRef!.config.to).toEqual({ table: "tags", column: "_internalId" });
+    const addTableOp = userSchema.operations.find(
+      (op): op is Extract<(typeof userSchema.operations)[number], { type: "add-table" }> =>
+        op.type === "add-table" && op.tableName === "user_tags",
+    );
+    expect(addTableOp).toBeDefined();
+    expect(addTableOp?.operations.filter((op) => op.type === "add-foreign-key")).toHaveLength(2);
   });
 
-  it("should create a foreign key reference using addReference", () => {
+  it("should derive foreign key metadata from reference columns", () => {
     const userSchema = schema("user", (s) => {
       return s
         .addTable("users", (t) => {
@@ -267,167 +251,42 @@ describe("create", () => {
           return t
             .addColumn("id", idColumn())
             .addColumn("title", column("string"))
-            .addColumn("authorId", referenceColumn());
-        })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
+            .addColumn("authorId", referenceColumn({ table: "users" }));
         });
     });
 
     const postsTable = userSchema.tables.posts;
+    const authorRelation = getTableRelations(postsTable)["author"];
+    const authorForeignKey = getTableForeignKey(postsTable, "authorId");
 
-    // Verify the authorId column is marked as a reference
     expect(postsTable.columns.authorId.role).toBe("reference");
-
-    // Verify the relation exists
-    const authorRelation = postsTable.relations["author"];
     expect(authorRelation).toBeDefined();
-    expect(authorRelation.type).toBe("one");
-    expect(authorRelation.table).toBe(userSchema.tables.users);
-    expect(authorRelation.on).toEqual([["authorId", "id"]]);
-
-    // Verify the foreign key was created as an operation
-    const addReferenceOps = userSchema.operations.filter((op) => op.type === "add-reference");
-    expect(addReferenceOps).toHaveLength(1);
-    expect(addReferenceOps[0].tableName).toBe("posts");
-    expect(addReferenceOps[0].referenceName).toBe("author");
-    expect(addReferenceOps[0].config.type).toBe("one");
-    expect(addReferenceOps[0].config.from).toEqual({ table: "posts", column: "authorId" });
-    expect(addReferenceOps[0].config.to).toEqual({ table: "users", column: "_internalId" });
+    expect(authorRelation?.type).toBe("one");
+    expect(authorRelation?.table).toBe(userSchema.tables.users);
+    expect(authorRelation?.on).toEqual([["authorId", "id"]]);
+    expect(authorForeignKey?.referencedTable).toBe(userSchema.tables.users);
+    expect(authorForeignKey?.referencedColumnName).toBe("_internalId");
   });
 
-  it("should coerce external-id target columns to _internalId in addReference operations", () => {
+  it("should target referenced internal ids for foreign keys", () => {
     const catalogSchema = schema("catalog", (s) => {
       return s
         .addTable("products", (t) => {
           return t.addColumn("productId", idColumn()).addColumn("name", column("string"));
         })
         .addTable("orders", (t) => {
-          return t.addColumn("id", idColumn()).addColumn("productRef", referenceColumn());
-        })
-        .addReference("product", {
-          type: "one",
-          from: { table: "orders", column: "productRef" },
-          to: { table: "products", column: "productId" },
+          return t
+            .addColumn("id", idColumn())
+            .addColumn("productRef", referenceColumn({ table: "products" }));
         });
     });
 
-    const addReferenceOps = catalogSchema.operations.filter((op) => op.type === "add-reference");
-    expect(addReferenceOps).toHaveLength(1);
-    expect(addReferenceOps[0].config.to).toEqual({ table: "products", column: "_internalId" });
+    const productRef = getTableForeignKey(catalogSchema.tables.orders, "productRef");
+    expect(productRef?.referencedTable).toBe(catalogSchema.tables.products);
+    expect(productRef?.referencedColumnName).toBe("_internalId");
   });
 
-  it("should support join-only references with foreignKey:false", () => {
-    const userSchema = schema("user", (s) => {
-      return s
-        .addTable("users", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("email", column("string"))
-            .createIndex("idx_users_email", ["email"]);
-        })
-        .addTable("invitations", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("email", column("string"))
-            .createIndex("idx_inv_email", ["email"]);
-        })
-        .addReference("invitedUser", {
-          type: "one",
-          from: { table: "invitations", column: "email" },
-          to: { table: "users", column: "email" },
-          foreignKey: false,
-        });
-    });
-
-    const invitationsTable = userSchema.tables.invitations;
-    const invitedRelation = invitationsTable.relations["invitedUser"];
-    expect(invitedRelation).toBeDefined();
-    expect(invitedRelation.foreignKey).toBe(false);
-    expect(invitedRelation.on).toEqual([["email", "email"]]);
-
-    const addReferenceOps = userSchema.operations.filter((op) => op.type === "add-reference");
-    expect(addReferenceOps).toHaveLength(1);
-    expect(addReferenceOps[0].config.to).toEqual({ table: "users", column: "email" });
-    expect(addReferenceOps[0].config.foreignKey).toBe(false);
-  });
-
-  it("should coerce id to _internalId for join-only references", () => {
-    const userSchema = schema("user", (s) => {
-      return s
-        .addTable("users", (t) => {
-          return t.addColumn("id", idColumn()).addColumn("name", column("string"));
-        })
-        .addTable("sessions", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("userId", referenceColumn())
-            .createIndex("idx_sessions_user", ["userId"]);
-        })
-        .addReference("sessionUser", {
-          type: "one",
-          from: { table: "sessions", column: "userId" },
-          to: { table: "users", column: "id" },
-          foreignKey: false,
-        });
-    });
-
-    const addReferenceOps = userSchema.operations.filter((op) => op.type === "add-reference");
-    expect(addReferenceOps).toHaveLength(1);
-    expect(addReferenceOps[0].config.to).toEqual({ table: "users", column: "_internalId" });
-  });
-
-  it("should coerce left-side id to _internalId for join-only references", () => {
-    const userSchema = schema("user", (s) => {
-      return s
-        .addTable("users", (t) => {
-          return t.addColumn("id", idColumn()).addColumn("name", column("string"));
-        })
-        .addTable("memberships", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("userId", referenceColumn())
-            .createIndex("idx_memberships_user", ["userId"]);
-        })
-        .addReference("memberships", {
-          type: "many",
-          from: { table: "users", column: "id" },
-          to: { table: "memberships", column: "userId" },
-          foreignKey: false,
-        });
-    });
-
-    const addReferenceOps = userSchema.operations.filter((op) => op.type === "add-reference");
-    expect(addReferenceOps).toHaveLength(1);
-    expect(addReferenceOps[0].config.from).toEqual({ table: "users", column: "_internalId" });
-
-    const userRelation = userSchema.tables.users.relations["memberships"];
-    expect(userRelation.on).toEqual([["_internalId", "userId"]]);
-  });
-
-  it("should require indexes for join-only references", () => {
-    expect(() =>
-      schema("user", (s) => {
-        return s
-          .addTable("users", (t) => {
-            return t.addColumn("id", idColumn()).addColumn("email", column("string"));
-          })
-          .addTable("invitations", (t) => {
-            return t.addColumn("id", idColumn()).addColumn("email", column("string"));
-          })
-          .addReference("invitedUser", {
-            type: "one",
-            from: { table: "invitations", column: "email" },
-            to: { table: "users", column: "email" },
-            foreignKey: false,
-          });
-      }),
-    ).toThrow(/indexed join columns/);
-  });
-
-  it("should support multiple references by calling addReference multiple times", () => {
+  it("should support multiple reference columns in one table", () => {
     const userSchema = schema("user", (s) => {
       return s
         .addTable("users", (t) => {
@@ -440,79 +299,43 @@ describe("create", () => {
           return t
             .addColumn("id", idColumn())
             .addColumn("title", column("string"))
-            .addColumn("authorId", referenceColumn())
-            .addColumn("categoryId", referenceColumn());
-        })
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        })
-        .addReference("category", {
-          type: "one",
-          from: { table: "posts", column: "categoryId" },
-          to: { table: "categories", column: "id" },
+            .addColumn("authorId", referenceColumn({ table: "users" }))
+            .addColumn("categoryId", referenceColumn({ table: "categories" }));
         });
     });
 
     const postsTable = userSchema.tables.posts;
+    const relations = getTableRelations(postsTable);
 
-    // Verify both relations exist
-    expect(postsTable.relations["author"]).toBeDefined();
-    expect(postsTable.relations["category"]).toBeDefined();
-
-    // Verify both foreign keys were created as operations
-    const addReferenceOps = userSchema.operations.filter((op) => op.type === "add-reference");
-    expect(addReferenceOps).toHaveLength(2);
-
-    const authorRef = addReferenceOps.find((op) => op.referenceName === "author");
-    expect(authorRef).toBeDefined();
-    expect(authorRef!.tableName).toBe("posts");
-    expect(authorRef!.config.type).toBe("one");
-    expect(authorRef!.config.from).toEqual({ table: "posts", column: "authorId" });
-    expect(authorRef!.config.to).toEqual({ table: "users", column: "_internalId" });
-
-    const categoryRef = addReferenceOps.find((op) => op.referenceName === "category");
-    expect(categoryRef).toBeDefined();
-    expect(categoryRef!.tableName).toBe("posts");
-    expect(categoryRef!.config.type).toBe("one");
-    expect(categoryRef!.config.from).toEqual({ table: "posts", column: "categoryId" });
-    expect(categoryRef!.config.to).toEqual({ table: "categories", column: "_internalId" });
+    expect(relations["author"]).toBeDefined();
+    expect(relations["category"]).toBeDefined();
+    expect(getTableForeignKey(postsTable, "authorId")?.referencedTable).toBe(
+      userSchema.tables.users,
+    );
+    expect(getTableForeignKey(postsTable, "categoryId")?.referencedTable).toBe(
+      userSchema.tables.categories,
+    );
   });
 
   it("should support self-referencing foreign keys", () => {
     const userSchema = schema("user", (s) => {
-      return s
-        .addTable("users", (t) => {
-          return t
-            .addColumn("id", idColumn())
-            .addColumn("name", column("string"))
-            .addColumn("invitedBy", referenceColumn().nullable());
-        })
-        .addReference("inviter", {
-          type: "one",
-          from: { table: "users", column: "invitedBy" },
-          to: { table: "users", column: "id" },
-        });
+      return s.addTable("users", (t) => {
+        return t
+          .addColumn("id", idColumn())
+          .addColumn("name", column("string"))
+          .addColumn("invitedBy", referenceColumn({ table: "users" }).nullable());
+      });
     });
 
     const usersTable = userSchema.tables.users;
+    const inviterRelation = getTableRelations(usersTable)["invitedBy"];
+    const inviterForeignKey = getTableForeignKey(usersTable, "invitedBy");
 
-    // Verify the self-referencing relation exists
-    const inviterRelation = usersTable.relations["inviter"];
     expect(inviterRelation).toBeDefined();
-    expect(inviterRelation.type).toBe("one");
-    expect(inviterRelation.table).toBe(usersTable);
-    expect(inviterRelation.on).toEqual([["invitedBy", "id"]]);
-
-    // Verify the foreign key was created as an operation
-    const addReferenceOps = userSchema.operations.filter((op) => op.type === "add-reference");
-    expect(addReferenceOps).toHaveLength(1);
-    expect(addReferenceOps[0].tableName).toBe("users");
-    expect(addReferenceOps[0].referenceName).toBe("inviter");
-    expect(addReferenceOps[0].config.type).toBe("one");
-    expect(addReferenceOps[0].config.from).toEqual({ table: "users", column: "invitedBy" });
-    expect(addReferenceOps[0].config.to).toEqual({ table: "users", column: "_internalId" });
+    expect(inviterRelation?.type).toBe("one");
+    expect(inviterRelation?.table).toBe(usersTable);
+    expect(inviterRelation?.on).toEqual([["invitedBy", "id"]]);
+    expect(inviterForeignKey?.referencedTable).toBe(usersTable);
   });
 
   it("should allow altering an existing table to add columns", () => {
@@ -830,7 +653,7 @@ describe("idColumn", () => {
 
 describe("referenceColumn", () => {
   it("should create a table with a reference column", () => {
-    const _referenceCol = referenceColumn();
+    const _referenceCol = referenceColumn({ table: "users" });
     type _In = typeof _referenceCol.$in;
     type _Out = typeof _referenceCol.$out;
     expectTypeOf<_In>().toEqualTypeOf<string | bigint | FragnoId | FragnoReference>();
@@ -875,13 +698,15 @@ describe("SchemaBuilder with existing schema", () => {
       })
       .build();
 
-    expect(extendedSchema.operations).toHaveLength(3);
-    expect(extendedSchema.operations[0].type).toBe("add-table");
-    expect(extendedSchema.operations[0].tableName).toBe("users");
-    expect(extendedSchema.operations[1].type).toBe("add-table");
-    expect(extendedSchema.operations[1].tableName).toBe("posts");
-    expect(extendedSchema.operations[2].type).toBe("add-table");
-    expect(extendedSchema.operations[2].tableName).toBe("comments");
+    const addTableOps = extendedSchema.operations.filter(
+      (op): op is Extract<(typeof extendedSchema.operations)[number], { type: "add-table" }> =>
+        op.type === "add-table",
+    );
+
+    expect(addTableOps).toHaveLength(3);
+    expect(addTableOps[0]?.tableName).toBe("users");
+    expect(addTableOps[1]?.tableName).toBe("posts");
+    expect(addTableOps[2]?.tableName).toBe("comments");
   });
 
   it("should merge multiple schemas using mergeWithExistingSchema", () => {
@@ -1028,10 +853,15 @@ describe("SchemaBuilder with existing schema", () => {
       .mergeWithExistingSchema(schema2)
       .build();
 
-    expect(mergedSchema.operations).toHaveLength(3);
-    expect(mergedSchema.operations[0].tableName).toBe("users");
-    expect(mergedSchema.operations[1].tableName).toBe("posts");
-    expect(mergedSchema.operations[2].tableName).toBe("categories");
+    const addTableOps = mergedSchema.operations.filter(
+      (op): op is Extract<(typeof mergedSchema.operations)[number], { type: "add-table" }> =>
+        op.type === "add-table",
+    );
+
+    expect(addTableOps).toHaveLength(3);
+    expect(addTableOps[0]?.tableName).toBe("users");
+    expect(addTableOps[1]?.tableName).toBe("posts");
+    expect(addTableOps[2]?.tableName).toBe("categories");
     expect(mergedSchema.version).toBe(3); // 1 from schema1 + 2 from schema2
   });
 

--- a/packages/fragno-db/src/schema/create.ts
+++ b/packages/fragno-db/src/schema/create.ts
@@ -60,15 +60,8 @@ export type SchemaOperation =
       operations: TableSubOperation[]; // Ordered list of sub-operations
     }
   | {
-      type: "add-reference";
-      tableName: string; // The table that has the foreign key
-      referenceName: string;
-      config: {
-        type: "one" | "many";
-        from: { table: string; column: string };
-        to: { table: string; column: string };
-        foreignKey?: boolean;
-      };
+      type: "no-op";
+      reason?: string;
     };
 
 export interface ForeignKey {
@@ -78,30 +71,6 @@ export interface ForeignKey {
 
   referencedTable: AnyTable;
   referencedColumns: AnyColumn[];
-}
-
-class RelationInit<
-  TRelationType extends RelationType,
-  TTables extends Record<string, AnyTable>,
-  TTableName extends keyof TTables,
-> {
-  type: TRelationType;
-  referencedTable: TTables[TTableName];
-  referencer: AnyTable;
-  on: [string, string][] = [];
-  foreignKey: boolean;
-
-  constructor(
-    type: TRelationType,
-    referencedTable: TTables[TTableName],
-    referencer: AnyTable,
-    options?: { foreignKey?: boolean },
-  ) {
-    this.type = type;
-    this.referencedTable = referencedTable;
-    this.referencer = referencer;
-    this.foreignKey = options?.foreignKey ?? true;
-  }
 }
 
 export interface Index<
@@ -114,39 +83,38 @@ export interface Index<
   unique: boolean;
 }
 
-export class ExplicitRelationInit<
-  TRelationType extends RelationType,
-  TTables extends Record<string, AnyTable>,
-  TTableName extends keyof TTables,
-> extends RelationInit<TRelationType, TTables, TTableName> {
-  init(name: string): Relation<TRelationType, TTables[TTableName]> {
-    const id = `${this.referencer.name}_${this.referencedTable.name}`;
-
-    return {
-      id,
-      on: this.on,
-      name,
-      referencer: this.referencer,
-      table: this.referencedTable,
-      type: this.type,
-      foreignKey: this.foreignKey,
-    };
-  }
-}
-
-export interface Relation<
-  TRelationType extends RelationType = RelationType,
-  TTable extends AnyTable = AnyTable,
-> {
+export interface Relation<TRelationType extends RelationType = RelationType> {
   id: string;
   name: string;
   type: TRelationType;
   foreignKey?: boolean;
 
-  table: TTable;
+  table: AnyTable;
   referencer: AnyTable;
 
   on: [string, string][];
+}
+
+export interface TableForeignKey {
+  name: string;
+  columnName: string;
+  referencedTable: AnyTable;
+  referencedColumnName: string;
+}
+
+export function getTableForeignKeys(table: AnyTable): Record<string, TableForeignKey> {
+  return table.foreignKeys;
+}
+
+export function getTableForeignKey(
+  table: AnyTable,
+  columnName: string,
+): TableForeignKey | undefined {
+  return getTableForeignKeys(table)[columnName];
+}
+
+export function getTableRelations(table: AnyTable): Record<string, AnyRelation> {
+  return table.relations;
 }
 
 type PickNullable<T> = {
@@ -176,7 +144,6 @@ export type TableValidationOptions = {
 
 export interface Table<
   TColumns extends Record<string, AnyColumn> = Record<string, AnyColumn>,
-  TRelations extends Record<string, AnyRelation> = Record<string, AnyRelation>,
   TIndexes extends Record<string, Index> = Record<string, Index>,
 > {
   /**
@@ -189,8 +156,9 @@ export interface Table<
   name: string;
 
   columns: TColumns;
-  relations: TRelations;
   indexes: TIndexes;
+  foreignKeys: Record<string, TableForeignKey>;
+  relations: Record<string, AnyRelation>;
 
   /**
    * Validate insert values at runtime.
@@ -278,6 +246,7 @@ export class Column<TType extends keyof TypeMap, TIn = unknown, TOut = unknown> 
     | { runtime: "cuid" | "now" | (() => TypeMap[TType]) };
 
   tableName: string = "";
+  referenceTableName?: string;
 
   constructor(type: TType) {
     this.type = type;
@@ -323,6 +292,9 @@ export class Column<TType extends keyof TypeMap, TIn = unknown, TOut = unknown> 
   defaultTo$(
     value: TypeMap[TType] | ((builder: RuntimeDefaultBuilder) => RuntimeSpecial | TypeMap[TType]),
   ): Column<TType, TIn | null, TOut> {
+    if (this.role === "reference") {
+      throw new Error("referenceColumn({ table }) does not support defaults.");
+    }
     if (typeof value === "function") {
       const fn = value as (builder: RuntimeDefaultBuilder) => RuntimeSpecial | TypeMap[TType];
       const result = fn(runtimeDefaultBuilder);
@@ -369,6 +341,9 @@ export class Column<TType extends keyof TypeMap, TIn = unknown, TOut = unknown> 
   defaultTo(
     value: TypeMap[TType] | ((builder: DefaultBuilder) => DBSpecial | TypeMap[TType]),
   ): Column<TType, TIn | null, TOut> {
+    if (this.role === "reference") {
+      throw new Error("referenceColumn({ table }) does not support defaults.");
+    }
     if (typeof value === "function") {
       const fn = value as (builder: DefaultBuilder) => DBSpecial | TypeMap[TType];
       const result = fn(defaultBuilder);
@@ -504,6 +479,7 @@ function cloneColumn<TColumn extends AnyColumn>(col: TColumn): TColumn {
   clonedCol.isHidden = col.isHidden;
   clonedCol.default = col.default;
   clonedCol.tableName = col.tableName;
+  clonedCol.referenceTableName = col.referenceTableName;
 
   return clonedCol as TColumn;
 }
@@ -523,15 +499,18 @@ export function column<TType extends keyof TypeMap>(
  * This is used for foreign key relationships.
  * Always uses bigint to match the internal ID type.
  */
-export function referenceColumn(): Column<
-  "bigint",
-  string | bigint | FragnoId | FragnoReference,
-  FragnoReference
-> {
+export function referenceColumn(options: {
+  table: string;
+}): Column<"bigint", string | bigint | FragnoId | FragnoReference, FragnoReference> {
+  if (!options.table || options.table.trim().length === 0) {
+    throw new Error("referenceColumn({ table }) requires a non-empty target table name.");
+  }
+
   const col = new Column<"bigint", string | bigint | FragnoId | FragnoReference, FragnoReference>(
     "bigint",
   );
   col.role = "reference";
+  col.referenceTableName = options.table;
   return col;
 }
 
@@ -674,31 +653,84 @@ const validationClasses = { FragnoId, FragnoReference };
 
 type RelationType = "one" | "many";
 
+function getForeignKeyOperationName(tableName: string, columnName: string): string {
+  return `${tableName}_${columnName}_fk`;
+}
+
+function isReferenceColumn(column: AnyColumn): boolean {
+  return column.role === "reference" && column.referenceTableName !== undefined;
+}
+
+function createForeignKeySubOperation(
+  tableName: string,
+  columnName: string,
+  column: AnyColumn,
+): TableSubOperation {
+  if (!isReferenceColumn(column)) {
+    throw new Error(`Column ${tableName}.${columnName} is not a reference column.`);
+  }
+
+  return {
+    type: "add-foreign-key",
+    name: getForeignKeyOperationName(tableName, columnName),
+    columns: [columnName],
+    referencedTable: column.referenceTableName!,
+    referencedColumns: ["_internalId"],
+  };
+}
+
+function setTableForeignKeys(table: AnyTable, foreignKeys: Record<string, TableForeignKey>): void {
+  table.foreignKeys = foreignKeys;
+}
+
+function setTableRelations(table: AnyTable, relations: Record<string, AnyRelation>): void {
+  table.relations = relations;
+}
+
+function deriveForwardRelationBaseName(columnName: string): string {
+  if (columnName.endsWith("Id") && columnName.length > 2) {
+    return columnName.slice(0, -2);
+  }
+  if (columnName.endsWith("_id") && columnName.length > 3) {
+    return columnName.slice(0, -3);
+  }
+  return columnName;
+}
+
+function ensureUniqueRelationName(baseName: string, usedNames: Set<string>): string {
+  if (!usedNames.has(baseName)) {
+    usedNames.add(baseName);
+    return baseName;
+  }
+
+  let index = 2;
+  let candidate = `${baseName}${index}`;
+  while (usedNames.has(candidate)) {
+    index += 1;
+    candidate = `${baseName}${index}`;
+  }
+  usedNames.add(candidate);
+  return candidate;
+}
+
 export class TableBuilder<
   TColumns extends Record<string, AnyColumn> = Record<string, AnyColumn>,
-  TRelations extends Record<string, AnyRelation> = Record<string, AnyRelation>,
   TIndexes extends Record<string, Index> = Record<string, Index>,
 > {
   #name: string;
   #columns: TColumns;
-  #relations: TRelations;
   #indexes: TIndexes;
   #columnOrder: string[] = [];
 
   constructor(name: string) {
     this.#name = name;
     this.#columns = {} as TColumns;
-    this.#relations = {} as TRelations;
     this.#indexes = {} as TIndexes;
   }
 
   // For alterTable to set existing state
   setColumns(columns: TColumns): void {
     this.#columns = { ...columns };
-  }
-
-  setRelations(relations: TRelations): void {
-    this.#relations = { ...relations };
   }
 
   setIndexes(indexes: TIndexes): void {
@@ -720,7 +752,7 @@ export class TableBuilder<
   addColumn<TColumnName extends string, TColumn extends AnyColumn>(
     name: TColumnName,
     col: TColumn,
-  ): TableBuilder<TColumns & Record<TColumnName, TColumn>, TRelations, TIndexes>;
+  ): TableBuilder<TColumns & Record<TColumnName, TColumn>, TIndexes>;
 
   /**
    * Add a column to the table with simplified syntax.
@@ -730,14 +762,13 @@ export class TableBuilder<
     type: TType,
   ): TableBuilder<
     TColumns & Record<TColumnName, Column<TType, ColumnInput<TType>, TypeMap[TType]>>,
-    TRelations,
     TIndexes
   >;
 
   addColumn<TColumnName extends string, TColumn extends AnyColumn, TType extends keyof TypeMap>(
     name: TColumnName,
     colOrType: TColumn | TType,
-  ): TableBuilder<TColumns & Record<TColumnName, TColumn>, TRelations, TIndexes> {
+  ): TableBuilder<TColumns & Record<TColumnName, TColumn>, TIndexes> {
     // Create the column if a type string was provided
     const col = typeof colOrType === "string" ? column(colOrType) : colOrType;
 
@@ -748,11 +779,7 @@ export class TableBuilder<
     this.#columns[name] = col as unknown as TColumns[TColumnName];
     this.#columnOrder.push(name);
 
-    return this as unknown as TableBuilder<
-      TColumns & Record<TColumnName, TColumn>,
-      TRelations,
-      TIndexes
-    >;
+    return this as unknown as TableBuilder<TColumns & Record<TColumnName, TColumn>, TIndexes>;
   }
 
   /**
@@ -760,7 +787,7 @@ export class TableBuilder<
    */
   alterColumn<TColumnName extends NonIdColumnName<TColumns>>(
     name: TColumnName,
-  ): ColumnAlterer<TColumns, TRelations, TIndexes, TColumnName> {
+  ): ColumnAlterer<TColumns, TIndexes, TColumnName> {
     return {
       nullable: <TNullable extends boolean = true>(nullable?: TNullable) => {
         const column = this.#columns[name];
@@ -774,7 +801,6 @@ export class TableBuilder<
 
         return this as unknown as TableBuilder<
           UpdateColumn<TColumns, TColumnName, NullableColumn<TColumns[TColumnName], TNullable>>,
-          TRelations,
           TIndexes
         >;
       },
@@ -793,7 +819,6 @@ export class TableBuilder<
     options?: { unique?: boolean },
   ): TableBuilder<
     TColumns,
-    TRelations,
     TIndexes & Record<TIndexName, Index<ColumnsToTuple<TColumns, TColumnNames>, TColumnNames>>
   > {
     const cols = columns.map((colName) => {
@@ -815,7 +840,6 @@ export class TableBuilder<
 
     return this as unknown as TableBuilder<
       TColumns,
-      TRelations,
       TIndexes & Record<TIndexName, Index<ColumnsToTuple<TColumns, TColumnNames>, TColumnNames>>
     >;
   }
@@ -823,7 +847,7 @@ export class TableBuilder<
   /**
    * Build the final table. This should be called after all columns are added.
    */
-  build(): Table<TColumns, TRelations, TIndexes> {
+  build(): Table<TColumns, TIndexes> {
     let idCol: AnyColumn | undefined;
     let internalIdCol: AnyColumn | undefined;
     let versionCol: AnyColumn | undefined;
@@ -845,11 +869,12 @@ export class TableBuilder<
       (this.#columns as Record<string, AnyColumn>)["_version"] = col;
     }
 
-    const table = {
+    const table: Table<TColumns, TIndexes> = {
       name: this.#name,
       columns: this.#columns,
-      relations: this.#relations,
       indexes: this.#indexes,
+      foreignKeys: {},
+      relations: {},
       getColumnByName: (name) => {
         return Object.values(this.#columns).find((c) => c.name === name);
       },
@@ -862,7 +887,7 @@ export class TableBuilder<
       getVersionColumn: () => {
         return versionCol!;
       },
-    } as Table<TColumns, TRelations, TIndexes>;
+    } as Table<TColumns, TIndexes>;
 
     table["~standard"] = createTableStandardSchemaProps(table, validationClasses);
     table.validate = createTableValidator(table, validationClasses);
@@ -920,27 +945,6 @@ export interface Schema<TTables extends Record<string, AnyTable> = Record<string
 }
 
 /**
- * Utility type for updating a single table's relations in a schema.
- * Used to properly type the return value of addReference.
- */
-type UpdateTableRelations<
-  TTables extends Record<string, AnyTable>,
-  TTableName extends keyof TTables,
-  TReferenceName extends string,
-  TReferencedTableName extends keyof TTables,
-  TRelationType extends RelationType = RelationType,
-> = {
-  [K in keyof TTables]: K extends TTableName
-    ? Table<
-        TTables[TTableName]["columns"],
-        TTables[TTableName]["relations"] &
-          Record<TReferenceName, Relation<TRelationType, TTables[TReferencedTableName]>>,
-        TTables[TTableName]["indexes"]
-      >
-    : TTables[K];
-};
-
-/**
  * Utility type for updating a single table in a schema.
  * Used to properly type the return value of alterTable.
  */
@@ -948,12 +952,9 @@ type UpdateTable<
   TTables extends Record<string, AnyTable>,
   TTableName extends keyof TTables,
   TNewColumns extends Record<string, AnyColumn>,
-  TNewRelations extends Record<string, AnyRelation>,
   TNewIndexes extends Record<string, Index>,
 > = {
-  [K in keyof TTables]: K extends TTableName
-    ? Table<TNewColumns, TNewRelations, TNewIndexes>
-    : TTables[K];
+  [K in keyof TTables]: K extends TTableName ? Table<TNewColumns, TNewIndexes> : TTables[K];
 };
 
 /**
@@ -994,7 +995,6 @@ type NullableColumn<TColumn extends AnyColumn, TNullable extends boolean> =
 
 type ColumnAlterer<
   TColumns extends Record<string, AnyColumn>,
-  TRelations extends Record<string, AnyRelation>,
   TIndexes extends Record<string, Index>,
   TColumnName extends keyof TColumns,
 > = {
@@ -1002,7 +1002,6 @@ type ColumnAlterer<
     nullable?: TNullable,
   ): TableBuilder<
     UpdateColumn<TColumns, TColumnName, NullableColumn<TColumns[TColumnName], TNullable>>,
-    TRelations,
     TIndexes
   >;
 };
@@ -1049,29 +1048,10 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
     this.#indexNames.add(name);
   }
 
-  #rebindRelations(tableName: string, newTable: AnyTable): void {
-    for (const table of Object.values(this.#tables)) {
-      for (const relation of Object.values(table.relations)) {
-        if (relation.table.name === tableName) {
-          relation.table = newTable;
-        }
-        if (relation.referencer.name === tableName) {
-          relation.referencer = newTable;
-        }
-      }
-    }
-  }
-
-  #isJoinColumnIndexed(table: AnyTable, columnName: string): boolean {
-    const idColumnName = table.getIdColumn().name;
-    const internalIdColumnName = table.getInternalIdColumn().name;
-    if (columnName === idColumnName || columnName === internalIdColumnName) {
-      return true;
-    }
-
-    return Object.values(table.indexes).some((index) =>
-      index.columnNames.some((name) => name === columnName),
-    );
+  noOp(reason?: string): this {
+    this.#version++;
+    this.#operations.push({ type: "no-op", reason });
+    return this;
   }
 
   /**
@@ -1124,23 +1104,20 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
   addTable<
     TTableName extends string,
     TColumns extends Record<string, AnyColumn>,
-    TRelations extends Record<string, AnyRelation>,
     TIndexes extends Record<string, Index> = Record<string, Index>,
   >(
     name: TTableName,
     callback: (
-      builder: TableBuilder<{}, Record<string, AnyRelation>, Record<string, Index>>,
-    ) => TableBuilder<TColumns, TRelations, TIndexes>,
-  ): SchemaBuilder<TTables & Record<TTableName, Table<TColumns, TRelations, TIndexes>>> {
+      builder: TableBuilder<{}, Record<string, Index>>,
+    ) => TableBuilder<TColumns, TIndexes>,
+  ): SchemaBuilder<TTables & Record<TTableName, Table<TColumns, TIndexes>>> {
     this.#version++;
 
     if (this.#tableNames.has(name)) {
       throw new Error(`Duplicate table name "${name}" in schema "${this.#name}".`);
     }
 
-    const tableBuilder = new TableBuilder<{}, Record<string, AnyRelation>, Record<string, Index>>(
-      name,
-    );
+    const tableBuilder = new TableBuilder<{}, Record<string, Index>>(name);
     const result = callback(tableBuilder);
     const builtTable = result.build();
     const indexNames = result.getIndexes().map((idx) => idx.name);
@@ -1165,6 +1142,9 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
         columnName: colName,
         column: cloneColumn(col),
       });
+      if (isReferenceColumn(col)) {
+        subOperations.push(createForeignKeySubOperation(name, colName, col));
+      }
     }
 
     // Add system columns (_internalId and _version) that were auto-added
@@ -1201,185 +1181,17 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
     });
 
     // Update tables map
-    this.#tables = { ...this.#tables, [name]: builtTable } as TTables &
-      Record<TTableName, Table<TColumns, TRelations, TIndexes>>;
+    this.#tables = {
+      ...this.#tables,
+      [name]: builtTable,
+    } as TTables & Record<TTableName, Table<TColumns, TIndexes>>;
     this.#tableNames.add(name);
     for (const indexName of indexNames) {
       this.#indexNames.add(indexName);
     }
 
     return this as unknown as SchemaBuilder<
-      TTables & Record<TTableName, Table<TColumns, TRelations, TIndexes>>
-    >;
-  }
-
-  /**
-   * Add a relation between two tables.
-   *
-   * @param referenceName - A name for this relation (e.g., "author", "posts")
-   * @param config - Configuration specifying the relation type and foreign key mapping
-   *
-   * @example
-   * ```ts
-   * // One-to-one or many-to-one: post -> user
-   * schema("blog", s => s
-   *   .addTable("users", t => t.addColumn("id", idColumn()))
-   *   .addTable("posts", t => t
-   *     .addColumn("id", idColumn())
-   *     .addColumn("userId", referenceColumn()))
-   *   .addReference("author", {
-   *     type: "one",
-   *     from: { table: "posts", column: "userId" },
-   *     to: { table: "users", column: "id" },
-   *   })
-   * )
-   *
-   * // One-to-many (inverse relation): user -> posts
-   * .addReference("posts", {
-   *   type: "many",
-   *   from: { table: "users", column: "id" },
-   *   to: { table: "posts", column: "userId" },
-   * })
-   *
-   * // Self-referencing foreign key
-   * .addReference("inviter", {
-   *   type: "one",
-   *   from: { table: "users", column: "invitedBy" },
-   *   to: { table: "users", column: "id" },
-   * })
-   *
-   * // Join-only relation (no foreign key)
-   * .addReference("invitedUser", {
-   *   type: "one",
-   *   from: { table: "invitations", column: "email" },
-   *   to: { table: "users", column: "email" },
-   *   foreignKey: false,
-   * })
-   * ```
-   */
-  addReference<
-    TFromTableName extends string & keyof TTables,
-    TToTableName extends string & keyof TTables,
-    TReferenceName extends string,
-    TRelationType extends RelationType,
-  >(
-    referenceName: TReferenceName,
-    config: {
-      type: TRelationType;
-      from: {
-        table: TFromTableName;
-        column: keyof TTables[TFromTableName]["columns"];
-      };
-      to: {
-        table: TToTableName;
-        column: keyof TTables[TToTableName]["columns"];
-      };
-      /**
-       * When false, defines a join-only relation without foreign key migrations.
-       * References to external-id columns still coerce to `_internalId`
-       * (including left-side external IDs for join-only).
-       */
-      foreignKey?: boolean;
-    },
-  ): SchemaBuilder<
-    UpdateTableRelations<TTables, TFromTableName, TReferenceName, TToTableName, TRelationType>
-  > {
-    this.#version++;
-
-    const table = this.#tables[config.from.table];
-    const referencedTable = this.#tables[config.to.table];
-
-    if (!referenceName || referenceName.trim().length === 0) {
-      throw new Error(`referenceName is required for addReference on ${config.from.table}`);
-    }
-
-    if (!table) {
-      throw new Error(`Table ${config.from.table} not found in schema`);
-    }
-    if (!referencedTable) {
-      throw new Error(`Referenced table ${config.to.table} not found in schema`);
-    }
-
-    const columnName = config.from.column as string;
-    const targetColumnName = config.to.column as string;
-    const foreignKey = config.foreignKey !== false;
-
-    const column = table.columns[columnName];
-    const targetColumn = referencedTable.columns[targetColumnName];
-
-    if (!column) {
-      throw new Error(`Column ${columnName} not found in table ${config.from.table}`);
-    }
-    if (!targetColumn) {
-      throw new Error(`Column ${targetColumnName} not found in table ${config.to.table}`);
-    }
-
-    // External-id columns always target the internal ID column.
-    const actualTargetColumnName =
-      targetColumn.role === "external-id"
-        ? referencedTable.getInternalIdColumn().name
-        : targetColumnName;
-
-    const referencedColumn = referencedTable.columns[actualTargetColumnName];
-    if (!referencedColumn) {
-      throw new Error(`Column ${actualTargetColumnName} not found in table ${config.to.table}`);
-    }
-
-    if (table.relations[referenceName]) {
-      throw new Error(`Reference ${referenceName} already exists on table ${config.from.table}`);
-    }
-
-    // Verify that reference columns are bigint (matching internal ID type)
-    if (column.role === "reference" && column.type !== "bigint") {
-      throw new Error(
-        `Reference column ${columnName} must be of type bigint to match internal ID type`,
-      );
-    }
-
-    if (!foreignKey) {
-      const missingIndexes: string[] = [];
-      if (!this.#isJoinColumnIndexed(table, columnName)) {
-        missingIndexes.push(`${table.name}.${columnName}`);
-      }
-      if (!this.#isJoinColumnIndexed(referencedTable, actualTargetColumnName)) {
-        missingIndexes.push(`${referencedTable.name}.${actualTargetColumnName}`);
-      }
-      if (missingIndexes.length > 0) {
-        throw new Error(
-          `Join-only relation "${referenceName}" requires indexed join columns: ${missingIndexes.join(", ")}.`,
-        );
-      }
-    }
-
-    // Join-only relations treat external IDs as internal IDs on the left side.
-    const actualFromColumnName =
-      !foreignKey && column.role === "external-id" ? table.getInternalIdColumn().name : columnName;
-
-    // Create the relation (use user-facing right-side column name)
-    const init = new ExplicitRelationInit(config.type, referencedTable, table, { foreignKey });
-    init.on.push([actualFromColumnName, targetColumnName]);
-    const relation = init.init(referenceName);
-
-    // Add relation to the table
-    table.relations[referenceName] = relation;
-
-    // Record the operation
-    this.#operations.push({
-      type: "add-reference",
-      tableName: config.from.table,
-      referenceName,
-      config: {
-        type: config.type,
-        from: { table: config.from.table, column: actualFromColumnName },
-        to: { table: config.to.table, column: actualTargetColumnName },
-        foreignKey,
-      },
-    });
-
-    // Return this with updated type
-    // Safe: The relation was added to the table in place and now has the updated relations
-    return this as unknown as SchemaBuilder<
-      UpdateTableRelations<TTables, TFromTableName, TReferenceName, TToTableName, TRelationType>
+      TTables & Record<TTableName, Table<TColumns, TIndexes>>
     >;
   }
 
@@ -1408,18 +1220,13 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
   alterTable<
     TTableName extends string & keyof TTables,
     TNewColumns extends Record<string, AnyColumn>,
-    TNewRelations extends Record<string, AnyRelation>,
     TNewIndexes extends Record<string, Index> = Record<string, Index>,
   >(
     tableName: TTableName,
     callback: (
-      builder: TableBuilder<
-        TTables[TTableName]["columns"],
-        TTables[TTableName]["relations"],
-        Record<string, Index>
-      >,
-    ) => TableBuilder<TNewColumns, TNewRelations, TNewIndexes>,
-  ): SchemaBuilder<UpdateTable<TTables, TTableName, TNewColumns, TNewRelations, TNewIndexes>> {
+      builder: TableBuilder<TTables[TTableName]["columns"], Record<string, Index>>,
+    ) => TableBuilder<TNewColumns, TNewIndexes>,
+  ): SchemaBuilder<UpdateTable<TTables, TTableName, TNewColumns, TNewIndexes>> {
     const table = this.#tables[tableName];
 
     if (!table) {
@@ -1429,7 +1236,6 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
     // Create builder with existing table state
     const tableBuilder = new TableBuilder(tableName);
     tableBuilder.setColumns(table.columns);
-    tableBuilder.setRelations(table.relations);
     tableBuilder.setIndexes(table.indexes);
 
     // Track existing columns and indexes
@@ -1442,11 +1248,7 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
 
     // Apply modifications
     const resultBuilder = callback(
-      tableBuilder as TableBuilder<
-        TTables[TTableName]["columns"],
-        TTables[TTableName]["relations"],
-        Record<string, Index>
-      >,
+      tableBuilder as TableBuilder<TTables[TTableName]["columns"], Record<string, Index>>,
     );
     const newTable = resultBuilder.build();
 
@@ -1457,11 +1259,15 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
     const columnOrder = resultBuilder.getColumnOrder();
     for (const colName of columnOrder) {
       if (!existingColumns.has(colName)) {
+        const newColumn = newTable.columns[colName];
         subOperations.push({
           type: "add-column",
           columnName: colName,
-          column: cloneColumn(newTable.columns[colName]),
+          column: cloneColumn(newColumn),
         });
+        if (isReferenceColumn(newColumn)) {
+          subOperations.push(createForeignKeySubOperation(tableName, colName, newColumn));
+        }
       }
     }
 
@@ -1511,7 +1317,6 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
 
     // Update table reference in schema
     this.#tables[tableName] = newTable as unknown as TTables[TTableName];
-    this.#rebindRelations(tableName, newTable as unknown as AnyTable);
     for (const idx of resultBuilder.getIndexes()) {
       if (!existingIndexes.has(idx.name)) {
         this.#indexNames.add(idx.name);
@@ -1524,8 +1329,71 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
     }
 
     return this as unknown as SchemaBuilder<
-      UpdateTable<TTables, TTableName, TNewColumns, TNewRelations, TNewIndexes>
+      UpdateTable<TTables, TTableName, TNewColumns, TNewIndexes>
     >;
+  }
+
+  #resolveTableForeignKeys(tables: Record<string, AnyTable>): void {
+    for (const table of Object.values(tables)) {
+      const foreignKeys: Record<string, TableForeignKey> = {};
+      const relations: Record<string, AnyRelation> = {};
+      const usedRelationNames = new Set<string>();
+
+      for (const [columnName, column] of Object.entries(table.columns)) {
+        if (column.role !== "reference") {
+          continue;
+        }
+
+        if (!column.referenceTableName) {
+          throw new Error(
+            `Reference column ${table.name}.${columnName} must declare a target table via referenceColumn({ table }).`,
+          );
+        }
+
+        if (column.default) {
+          throw new Error(`referenceColumn({ table }) does not support defaults.`);
+        }
+
+        const referencedTable = tables[column.referenceTableName];
+        if (!referencedTable) {
+          throw new Error(
+            `Reference column ${table.name}.${columnName} targets unknown table "${column.referenceTableName}".`,
+          );
+        }
+
+        const referencedIdColumn = referencedTable.getIdColumn();
+        const referencedInternalIdColumn = referencedTable.getInternalIdColumn();
+        if (referencedIdColumn.role !== "external-id") {
+          throw new Error(
+            `Referenced table ${referencedTable.name} must define a standard idColumn() to be targeted by ${table.name}.${columnName}.`,
+          );
+        }
+
+        foreignKeys[columnName] = {
+          name: getForeignKeyOperationName(table.name, columnName),
+          columnName,
+          referencedTable,
+          referencedColumnName: referencedInternalIdColumn.name,
+        };
+
+        const relationName = ensureUniqueRelationName(
+          deriveForwardRelationBaseName(columnName),
+          usedRelationNames,
+        );
+        relations[relationName] = {
+          id: `${table.name}_${columnName}`,
+          name: relationName,
+          type: "one",
+          foreignKey: true,
+          table: referencedTable,
+          referencer: table,
+          on: [[columnName, referencedIdColumn.name]],
+        };
+      }
+
+      setTableForeignKeys(table, foreignKeys);
+      setTableRelations(table, relations);
+    }
   }
 
   /**
@@ -1535,6 +1403,8 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
     const operations = this.#operations;
     const version = this.#version;
     const tables = this.#tables;
+
+    this.#resolveTableForeignKeys(tables as Record<string, AnyTable>);
 
     const schema: Schema<TTables> = {
       name: this.#name,
@@ -1566,6 +1436,7 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
             clonedCol.isHidden = col.isHidden;
             clonedCol.default = col.default;
             clonedCol.tableName = col.tableName;
+            clonedCol.referenceTableName = col.referenceTableName;
             clonedColumns[colName] = clonedCol;
           }
 
@@ -1573,6 +1444,9 @@ export class SchemaBuilder<TTables extends Record<string, AnyTable> = {}> {
             ...v,
             columns: clonedColumns,
           } as AnyTable;
+
+          setTableForeignKeys(clonedTable, { ...getTableForeignKeys(v) });
+          setTableRelations(clonedTable, { ...getTableRelations(v) });
 
           clonedTable["~standard"] = createTableStandardSchemaProps(clonedTable, validationClasses);
           clonedTable.validate = createTableValidator(clonedTable, validationClasses);

--- a/packages/fragno-db/src/schema/serialize.test.ts
+++ b/packages/fragno-db/src/schema/serialize.test.ts
@@ -499,7 +499,7 @@ describe("serialize", () => {
 
       it("should skip reference column bigint to Number conversion for SQLite when enabled", () => {
         const bigintValue = 123456789n;
-        const refCol = referenceColumn();
+        const refCol = referenceColumn({ table: "users" });
 
         // Default behavior: converts to Number for reference columns
         const withConversion = serialize(bigintValue, refCol, "sqlite", false);

--- a/packages/fragno-db/src/schema/type-conversion/type-mapping.test.ts
+++ b/packages/fragno-db/src/schema/type-conversion/type-mapping.test.ts
@@ -99,7 +99,7 @@ describe("SQLTypeMapper", () => {
     });
 
     it("should keep reference bigint as integer", () => {
-      const userReferenceColumn = referenceColumn();
+      const userReferenceColumn = referenceColumn({ table: "users" });
       userReferenceColumn.name = "userId";
 
       expect(mapper.getDatabaseType(userReferenceColumn)).toBe("integer");

--- a/packages/fragno-db/src/schema/validator.test.ts
+++ b/packages/fragno-db/src/schema/validator.test.ts
@@ -24,7 +24,7 @@ const testSchema = schema("validation", (s) => {
     .addTable("posts", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("userId", referenceColumn())
+        .addColumn("userId", referenceColumn({ table: "users" }))
         .addColumn("title", column("varchar(10)"));
     })
     .addTable("all_types", (t) => {
@@ -40,7 +40,7 @@ const testSchema = schema("validation", (s) => {
         .addColumn("birthday", column("date"))
         .addColumn("data", column("json"))
         .addColumn("bigValue", column("bigint"))
-        .addColumn("ref", referenceColumn())
+        .addColumn("ref", referenceColumn({ table: "users" }))
         .addColumn("optionalWithDefault", column("string").defaultTo("x"))
         .addColumn("optionalNullable", column("string").nullable());
     });

--- a/packages/fragno-db/src/sync/conflict-checker.test.ts
+++ b/packages/fragno-db/src/sync/conflict-checker.test.ts
@@ -5,7 +5,7 @@ import { SqliteDialect } from "kysely";
 
 import { BetterSQLite3DriverConfig } from "../adapters/generic-sql/driver-config";
 import { buildFindOptions } from "../query/find-options";
-import { schema, column, idColumn, referenceColumn } from "../schema/create";
+import { getTableRelations, schema, column, idColumn, referenceColumn } from "../schema/create";
 import { sql } from "../sql-driver/sql";
 import { SqlDriverAdapter } from "../sql-driver/sql-driver-adapter";
 import { checkConflicts } from "./conflict-checker";
@@ -19,12 +19,7 @@ const testSchema = schema("test", (s) => {
       return t
         .addColumn("id", idColumn())
         .addColumn("title", column("string"))
-        .addColumn("userId", referenceColumn());
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "userId" },
-      to: { table: "users", column: "id" },
+        .addColumn("userId", referenceColumn({ table: "users" }));
     });
 });
 
@@ -158,12 +153,10 @@ describe("checkConflicts", () => {
 
     const options = buildFindOptions(testSchema.tables.posts, {
       where: (eb) => eb("title", "=", "Hello"),
-      join: (jb) => {
-        jb["author"]();
-      },
     });
 
-    if (!options) {
+    const userRelation = getTableRelations(testSchema.tables.posts)["user"];
+    if (!options || !userRelation) {
       throw new Error("Expected join options to compile.");
     }
 
@@ -178,7 +171,7 @@ describe("checkConflicts", () => {
             table: testSchema.tables.posts,
             indexName: "primary",
             condition: options.where,
-            joins: options.join,
+            joins: [{ relation: userRelation, options: buildFindOptions(userRelation.table, {})! }],
           },
         ],
       },

--- a/packages/fragno-db/src/sync/read-tracking.test.ts
+++ b/packages/fragno-db/src/sync/read-tracking.test.ts
@@ -34,34 +34,19 @@ const testSchema = schema("test", (s) =>
     .addTable("posts", (t) =>
       t
         .addColumn("id", idColumn())
-        .addColumn("author_id", referenceColumn())
+        .addColumn("author_id", referenceColumn({ table: "users" }))
         .addColumn("title", column("string"))
         .createIndex("posts_author_idx", ["author_id"]),
     )
     .addTable("comments", (t) =>
       t
         .addColumn("id", idColumn())
-        .addColumn("post_id", referenceColumn())
-        .addColumn("commenter_id", referenceColumn())
+        .addColumn("post_id", referenceColumn({ table: "posts" }))
+        .addColumn("commenter_id", referenceColumn({ table: "users" }))
         .addColumn("text", column("string"))
         .createIndex("comments_post_idx", ["post_id"])
         .createIndex("comments_commenter_idx", ["commenter_id"]),
-    )
-    .addReference("post", {
-      type: "one",
-      from: { table: "comments", column: "post_id" },
-      to: { table: "posts", column: "id" },
-    })
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "author_id" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("commenter", {
-      type: "one",
-      from: { table: "comments", column: "commenter_id" },
-      to: { table: "users", column: "id" },
-    }),
+    ),
 );
 
 const createMockCompiler = (): UOWCompiler<unknown> => ({

--- a/packages/fragno-db/src/sync/read-tracking.test.ts
+++ b/packages/fragno-db/src/sync/read-tracking.test.ts
@@ -91,7 +91,7 @@ describe("read tracking", () => {
     const baseUow = createUnitOfWork(compiler, executor, decoder, schemaNamespaceMap);
     baseUow.enableReadTracking();
 
-    baseUow.forSchema(testSchema).findNew("comments", (b) =>
+    baseUow.forSchema(testSchema).find("comments", (b) =>
       b
         .whereIndex("primary")
         .select(["text"])
@@ -174,7 +174,7 @@ describe("read tracking", () => {
     const baseUow = createUnitOfWork(compiler, executor, decoder, schemaNamespaceMap);
     baseUow.enableReadTracking();
 
-    baseUow.forSchema(testSchema).findNew("comments", (q) =>
+    baseUow.forSchema(testSchema).find("comments", (q) =>
       q
         .whereIndex("primary")
         .select(["text"])

--- a/packages/fragno-db/src/sync/read-tracking.test.ts
+++ b/packages/fragno-db/src/sync/read-tracking.test.ts
@@ -35,14 +35,17 @@ const testSchema = schema("test", (s) =>
       t
         .addColumn("id", idColumn())
         .addColumn("author_id", referenceColumn())
-        .addColumn("title", column("string")),
+        .addColumn("title", column("string"))
+        .createIndex("posts_author_idx", ["author_id"]),
     )
     .addTable("comments", (t) =>
       t
         .addColumn("id", idColumn())
         .addColumn("post_id", referenceColumn())
         .addColumn("commenter_id", referenceColumn())
-        .addColumn("text", column("string")),
+        .addColumn("text", column("string"))
+        .createIndex("comments_post_idx", ["post_id"])
+        .createIndex("comments_commenter_idx", ["commenter_id"]),
     )
     .addReference("post", {
       type: "one",
@@ -88,14 +91,107 @@ describe("read tracking", () => {
     const baseUow = createUnitOfWork(compiler, executor, decoder, schemaNamespaceMap);
     baseUow.enableReadTracking();
 
-    baseUow.forSchema(testSchema).find("comments", (b) =>
+    baseUow.forSchema(testSchema).findNew("comments", (b) =>
       b
         .whereIndex("primary")
         .select(["text"])
-        .join((jb) =>
-          jb["post"]((pb) =>
-            pb.select(["title"]).join((jb2) => jb2["author"]((ab) => ab.select(["name"]))),
-          )["commenter"]((cb) => cb.select(["name"])),
+        .joinOne("post", "posts", (pb) =>
+          pb
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+            .select(["title"])
+            .joinOne("author", "users", (ab) =>
+              ab.onIndex("primary", (eb) => eb("id", "=", eb.parent("author_id"))).select(["name"]),
+            ),
+        )
+        .joinOne("commenter", "users", (cb) =>
+          cb.onIndex("primary", (eb) => eb("id", "=", eb.parent("commenter_id"))).select(["name"]),
+        ),
+    );
+
+    const operations = baseUow.getRetrievalOperations();
+    const commentId = FragnoId.fromExternal("c1", 1);
+    const postId = FragnoId.fromExternal("p1", 1);
+    const authorId = FragnoId.fromExternal("a1", 1);
+    const commenterId = FragnoId.fromExternal("u2", 1);
+
+    const results = [
+      [
+        {
+          id: commentId,
+          text: "hello",
+          post: {
+            id: postId,
+            title: "post",
+            author: {
+              id: authorId,
+              name: "author",
+            },
+          },
+          commenter: {
+            id: commenterId,
+            name: "commenter",
+          },
+        },
+      ],
+    ];
+
+    const scopes = collectReadScopes(operations);
+    expect(scopes).toHaveLength(1);
+    expect(scopes[0]).toMatchObject({
+      schema: "tenant",
+      table: testSchema.tables.comments,
+      indexName: "_primary",
+    });
+
+    const keys = collectReadKeys(operations, results);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        { schema: "tenant", table: "comments", externalId: "c1" },
+        { schema: "tenant", table: "posts", externalId: "p1" },
+        { schema: "tenant", table: "users", externalId: "a1" },
+        { schema: "tenant", table: "users", externalId: "u2" },
+      ]),
+    );
+
+    stripReadTrackingResults(operations, results);
+
+    const [comment] = results[0] as Array<Record<string, unknown>>;
+    expect(comment["id"]).toBeUndefined();
+    expect((comment["post"] as Record<string, unknown>)["id"]).toBeUndefined();
+    expect((comment["commenter"] as Record<string, unknown>)["id"]).toBeUndefined();
+    expect(
+      ((comment["post"] as Record<string, unknown>)["author"] as Record<string, unknown>)["id"],
+    ).toBeUndefined();
+  });
+
+  it("collects query-tree read keys and strips injected ids", () => {
+    const compiler = createMockCompiler();
+    const executor = createMockExecutor();
+    const decoder = createMockDecoder();
+    const schemaNamespaceMap: WeakMap<AnySchema, string | null> = new WeakMap();
+    schemaNamespaceMap.set(testSchema, "tenant");
+
+    const baseUow = createUnitOfWork(compiler, executor, decoder, schemaNamespaceMap);
+    baseUow.enableReadTracking();
+
+    baseUow.forSchema(testSchema).findNew("comments", (q) =>
+      q
+        .whereIndex("primary")
+        .select(["text"])
+        .joinOne("post", "posts", (post) =>
+          post
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+            .select(["title"])
+            .joinOne("author", "users", (author) =>
+              author
+                .onIndex("primary", (eb) => eb("id", "=", eb.parent("author_id")))
+                .select(["name"]),
+            ),
+        )
+        .joinOne("commenter", "users", (commenter) =>
+          commenter
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("commenter_id")))
+            .select(["name"]),
         ),
     );
 

--- a/packages/fragno-db/src/sync/read-tracking.ts
+++ b/packages/fragno-db/src/sync/read-tracking.ts
@@ -3,6 +3,10 @@ import { buildCondition } from "../query/condition-builder";
 import type { CursorResult } from "../query/cursor";
 import type { CompiledJoin } from "../query/find-options";
 import type { AnySelectClause } from "../query/mod";
+import type {
+  CompiledQueryTreeChildNode,
+  CompiledQueryTreeRootNode,
+} from "../query/unit-of-work/query-tree";
 import type { MutationOperation, RetrievalOperation } from "../query/unit-of-work/unit-of-work";
 import type { AnySchema, AnyTable } from "../schema/create";
 import { FragnoId } from "../schema/create";
@@ -91,6 +95,39 @@ const collectKeysFromRecord = (
   }
 };
 
+const collectKeysFromQueryTreeRecord = (
+  record: unknown,
+  node: CompiledQueryTreeRootNode | CompiledQueryTreeChildNode,
+  schemaName: string,
+  output: ReadKey[],
+): void => {
+  if (!record || typeof record !== "object") {
+    return;
+  }
+
+  const idKey = node.table.getIdColumn().name;
+  const externalId = getExternalId((record as Record<string, unknown>)[idKey]);
+  if (externalId !== undefined) {
+    output.push({ schema: schemaName, table: node.table.name, externalId });
+  }
+
+  for (const child of node.children) {
+    const childValue = (record as Record<string, unknown>)[child.alias];
+    if (childValue === null || childValue === undefined) {
+      continue;
+    }
+
+    if (Array.isArray(childValue)) {
+      for (const item of childValue) {
+        collectKeysFromQueryTreeRecord(item, child, schemaName, output);
+      }
+      continue;
+    }
+
+    collectKeysFromQueryTreeRecord(childValue, child, schemaName, output);
+  }
+};
+
 const shouldStripId = (select: AnySelectClause | undefined, table: AnyTable): boolean => {
   if (!select || select === true) {
     return false;
@@ -98,6 +135,39 @@ const shouldStripId = (select: AnySelectClause | undefined, table: AnyTable): bo
 
   const idKey = table.getIdColumn().name;
   return !select.includes(idKey);
+};
+
+const stripKeysFromQueryTreeRecord = (
+  record: unknown,
+  node: CompiledQueryTreeRootNode | CompiledQueryTreeChildNode,
+  stripId: boolean,
+): void => {
+  if (!record || typeof record !== "object") {
+    return;
+  }
+
+  if (stripId) {
+    const idKey = node.table.getIdColumn().name;
+    delete (record as Record<string, unknown>)[idKey];
+  }
+
+  for (const child of node.children) {
+    const childValue = (record as Record<string, unknown>)[child.alias];
+    if (childValue === null || childValue === undefined) {
+      continue;
+    }
+
+    const stripChildId = shouldStripId(child.select, child.table);
+
+    if (Array.isArray(childValue)) {
+      for (const item of childValue) {
+        stripKeysFromQueryTreeRecord(item, child, stripChildId);
+      }
+      continue;
+    }
+
+    stripKeysFromQueryTreeRecord(childValue, child, stripChildId);
+  }
 };
 
 const stripKeysFromRecord = (
@@ -170,9 +240,11 @@ export const collectReadScopes = (
     }
 
     if (op.type === "find") {
-      const condition = op.options.where
-        ? buildCondition(op.table.columns, op.options.where)
-        : undefined;
+      const condition = op.options.queryTree
+        ? op.options.queryTree.where
+        : op.options.where
+          ? buildCondition(op.table.columns, op.options.where)
+          : undefined;
 
       if (condition === false) {
         continue;
@@ -215,7 +287,11 @@ export const collectReadKeys = (
     }
 
     for (const record of records) {
-      collectKeysFromRecord(record, op.table, op.options.joins, schemaName, keys);
+      if (op.options.queryTree) {
+        collectKeysFromQueryTreeRecord(record, op.options.queryTree, schemaName, keys);
+      } else {
+        collectKeysFromRecord(record, op.table, op.options.joins, schemaName, keys);
+      }
     }
   }
 
@@ -270,18 +346,30 @@ export const stripReadTrackingResults = (
 
     if (op.withCursor && isCursorResult(result)) {
       for (const record of result.items) {
-        stripKeysFromRecord(record, op.table, op.options.joins, stripId);
+        if (op.options.queryTree) {
+          stripKeysFromQueryTreeRecord(record, op.options.queryTree, stripId);
+        } else {
+          stripKeysFromRecord(record, op.table, op.options.joins, stripId);
+        }
       }
       continue;
     }
 
     if (Array.isArray(result)) {
       for (const record of result) {
-        stripKeysFromRecord(record, op.table, op.options.joins, stripId);
+        if (op.options.queryTree) {
+          stripKeysFromQueryTreeRecord(record, op.options.queryTree, stripId);
+        } else {
+          stripKeysFromRecord(record, op.table, op.options.joins, stripId);
+        }
       }
       continue;
     }
 
-    stripKeysFromRecord(result, op.table, op.options.joins, stripId);
+    if (op.options.queryTree) {
+      stripKeysFromQueryTreeRecord(result, op.options.queryTree, stripId);
+    } else {
+      stripKeysFromRecord(result, op.table, op.options.joins, stripId);
+    }
   }
 };

--- a/packages/fragno-db/turbo.json
+++ b/packages/fragno-db/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/fragno-node/turbo.json
+++ b/packages/fragno-node/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/fragno-test/src/adapter-conformance.test.ts
+++ b/packages/fragno-test/src/adapter-conformance.test.ts
@@ -25,32 +25,17 @@ const conformanceSchema = schema("conformance", (s) =>
       t
         .addColumn("id", idColumn())
         .addColumn("title", column("string"))
-        .addColumn("authorId", referenceColumn())
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .createIndex("posts_by_author", ["authorId"]),
     )
     .addTable("comments", (t) =>
       t
         .addColumn("id", idColumn())
-        .addColumn("postId", referenceColumn())
-        .addColumn("authorId", referenceColumn())
+        .addColumn("postId", referenceColumn({ table: "posts" }))
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .addColumn("body", column("string"))
         .createIndex("comments_by_post", ["postId"]),
-    )
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
-    })
-    .addReference("post", {
-      type: "one",
-      from: { table: "comments", column: "postId" },
-      to: { table: "posts", column: "id" },
-    })
-    .addReference("commenter", {
-      type: "one",
-      from: { table: "comments", column: "authorId" },
-      to: { table: "users", column: "id" },
-    }),
+    ),
 );
 
 const namespace = "conformance";

--- a/packages/fragno-test/src/adapter-conformance.test.ts
+++ b/packages/fragno-test/src/adapter-conformance.test.ts
@@ -247,12 +247,20 @@ for (const adapterCase of adapterCases) {
             .find("comments", (b) =>
               b
                 .whereIndex("primary")
-                .join((jb) =>
-                  jb
-                    .post((pb) =>
-                      pb.select(["title"]).join((jb2) => jb2.author((ab) => ab.select(["name"]))),
-                    )
-                    .commenter((cb) => cb.select(["name"])),
+                .joinOne("post", "posts", (pb) =>
+                  pb
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("postId")))
+                    .select(["title"])
+                    .joinOne("author", "users", (ab) =>
+                      ab
+                        .onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId")))
+                        .select(["name"]),
+                    ),
+                )
+                .joinOne("commenter", "users", (cb) =>
+                  cb
+                    .onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId")))
+                    .select(["name"]),
                 ),
             );
           await uow.executeRetrieve();

--- a/packages/fragno-test/src/db-roundtrip-guard.test.ts
+++ b/packages/fragno-test/src/db-roundtrip-guard.test.ts
@@ -78,7 +78,7 @@ describe("dbRoundtripGuard", () => {
         defineService({
           listUsers: function () {
             return this.serviceTx(userSchema)
-              .retrieve((uow) => uow.find("users"))
+              .retrieve((uow) => uow.find("users", (b) => b.whereIndex("primary")))
               .build();
           },
         }),
@@ -138,7 +138,9 @@ describe("dbRoundtripGuard", () => {
       outputSchema: z.object({ count: z.number() }),
       handler: async function (this: DatabaseRequestContext, _input, { json }) {
         const existing = await this.handlerTx()
-          .retrieve(({ forSchema }) => forSchema(userSchema).find("users"))
+          .retrieve(({ forSchema }) =>
+            forSchema(userSchema).find("users", (b) => b.whereIndex("primary")),
+          )
           .transformRetrieve(([users]) => users)
           .execute();
 
@@ -188,11 +190,15 @@ describe("dbRoundtripGuard", () => {
     const result = await fragments.user.fragment.inContext(
       async function (this: DatabaseRequestContext) {
         await this.handlerTx()
-          .retrieve(({ forSchema }) => forSchema(userSchema).find("users"))
+          .retrieve(({ forSchema }) =>
+            forSchema(userSchema).find("users", (b) => b.whereIndex("primary")),
+          )
           .execute();
 
         await this.handlerTx()
-          .retrieve(({ forSchema }) => forSchema(userSchema).find("users"))
+          .retrieve(({ forSchema }) =>
+            forSchema(userSchema).find("users", (b) => b.whereIndex("primary")),
+          )
           .execute();
 
         return "ok";

--- a/packages/fragno-test/turbo.json
+++ b/packages/fragno-test/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/fragno/turbo.json
+++ b/packages/fragno/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/github-app-fragment/src/github/routes.installations.test.ts
+++ b/packages/github-app-fragment/src/github/routes.installations.test.ts
@@ -206,7 +206,7 @@ describe("github-app installation sync", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation_repo")
+          .find("installation_repo", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
 
@@ -232,7 +232,7 @@ describe("github-app installation sync", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("repo_link")
+          .find("repo_link", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(repoLinks).toHaveLength(0);
@@ -287,7 +287,7 @@ describe("github-app installation sync", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation")
+          .find("installation", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(installations).toHaveLength(1);

--- a/packages/github-app-fragment/src/github/routes.repos.test.ts
+++ b/packages/github-app-fragment/src/github/routes.repos.test.ts
@@ -824,7 +824,11 @@ describe("github-app repo linking routes", () => {
               .whereIndex("idx_installation_repo_installation", (eb) =>
                 eb("installationId", "=", "11"),
               )
-              .join((jb) => jb.links()),
+              .joinMany("links", "repo_link", (link) =>
+                link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                  eb("repoId", "=", eb.parent("id")),
+                ),
+              ),
           )
           .executeRetrieve()
       )[0];
@@ -867,7 +871,9 @@ describe("github-app repo linking routes", () => {
               .whereIndex("idx_installation_repo_installation", (eb) =>
                 eb("installationId", "=", 999n),
               )
-              .join((jb) => jb.installation()),
+              .joinOne("installation", "installation", (installation) =>
+                installation.onIndex("primary", (eb) => eb("id", "=", eb.parent("installationId"))),
+              ),
           )
           .executeRetrieve()
       )[0];

--- a/packages/github-app-fragment/src/github/routes.webhooks.test.ts
+++ b/packages/github-app-fragment/src/github/routes.webhooks.test.ts
@@ -358,7 +358,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation")
+          .find("installation", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(installations).toHaveLength(1);
@@ -371,7 +371,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation_repo")
+          .find("installation_repo", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(repos).toHaveLength(1);
@@ -393,7 +393,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation_repo")
+          .find("installation_repo", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(reposAfter).toHaveLength(1);
@@ -441,7 +441,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation")
+          .find("installation", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(installations).toHaveLength(1);
@@ -452,7 +452,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation_repo")
+          .find("installation_repo", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(repos).toHaveLength(0);
@@ -526,7 +526,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation_repo")
+          .find("installation_repo", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(repos).toHaveLength(1);
@@ -614,7 +614,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation_repo")
+          .find("installation_repo", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(repos).toHaveLength(1);
@@ -713,7 +713,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("installation_repo")
+          .find("installation_repo", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       const byId = new Map(repos.map((repo) => [toExternalId(repo.id), repo]));
@@ -726,7 +726,7 @@ describe("github-app webhooks", () => {
         await fragments.githubApp.db
           .createUnitOfWork("read")
           .forSchema(githubAppSchema)
-          .find("repo_link")
+          .find("repo_link", (b) => b.whereIndex("primary"))
           .executeRetrieve()
       )[0];
       expect(links).toHaveLength(0);

--- a/packages/github-app-fragment/src/github/webhook-processing.ts
+++ b/packages/github-app-fragment/src/github/webhook-processing.ts
@@ -261,7 +261,11 @@ export const createWebhookProcessor = (config: Pick<GitHubAppFragmentConfig, "we
                 .whereIndex("idx_installation_repo_installation", (eb) =>
                   eb("installationId", "=", installationId),
                 )
-                .join((jb) => jb.links()),
+                .joinMany("links", "repo_link", (link) =>
+                  link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                    eb("repoId", "=", eb.parent("id")),
+                  ),
+                ),
             );
         })
         .execute();

--- a/packages/github-app-fragment/src/routes.ts
+++ b/packages/github-app-fragment/src/routes.ts
@@ -296,7 +296,11 @@ export const githubAppRoutesFactory = defineRoutes(githubAppFragmentDefinition).
                     .whereIndex("idx_installation_repo_installation", (eb) =>
                       eb("installationId", "=", installationId),
                     )
-                    .join((jb) => jb.links()),
+                    .joinMany("links", "repo_link", (link) =>
+                      link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                        eb("repoId", "=", eb.parent("id")),
+                      ),
+                    ),
                 );
             })
             .execute();
@@ -356,7 +360,16 @@ export const githubAppRoutesFactory = defineRoutes(githubAppFragmentDefinition).
               return uow.find("installation_repo", (b) =>
                 b
                   .whereIndex("idx_installation_repo_full_name", (eb) => eb("fullName", "!=", ""))
-                  .join((jb) => jb.installation().links()),
+                  .joinOne("installation", "installation", (installation) =>
+                    installation.onIndex("primary", (eb) =>
+                      eb("id", "=", eb.parent("installationId")),
+                    ),
+                  )
+                  .joinMany("links", "repo_link", (link) =>
+                    link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                      eb("repoId", "=", eb.parent("id")),
+                    ),
+                  ),
               );
             })
             .execute();
@@ -435,7 +448,11 @@ export const githubAppRoutesFactory = defineRoutes(githubAppFragmentDefinition).
                     .whereIndex("idx_installation_repo_installation", (eb) =>
                       eb("installationId", "=", values.installationId),
                     )
-                    .join((jb) => jb.links()),
+                    .joinMany("links", "repo_link", (link) =>
+                      link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                        eb("repoId", "=", eb.parent("id")),
+                      ),
+                    ),
                 );
             })
             .execute();
@@ -553,7 +570,16 @@ export const githubAppRoutesFactory = defineRoutes(githubAppFragmentDefinition).
               return uow.find("installation_repo", (b) =>
                 b
                   .whereIndex("idx_installation_repo_full_name", (eb) => eb("fullName", "!=", ""))
-                  .join((jb) => jb.installation().links()),
+                  .joinOne("installation", "installation", (installation) =>
+                    installation.onIndex("primary", (eb) =>
+                      eb("id", "=", eb.parent("installationId")),
+                    ),
+                  )
+                  .joinMany("links", "repo_link", (link) =>
+                    link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                      eb("repoId", "=", eb.parent("id")),
+                    ),
+                  ),
               );
             })
             .execute();
@@ -658,7 +684,16 @@ export const githubAppRoutesFactory = defineRoutes(githubAppFragmentDefinition).
                   .whereIndex("idx_installation_repo_full_name", (eb) =>
                     eb("fullName", "=", fullName),
                   )
-                  .join((jb) => jb.installation().links()),
+                  .joinOne("installation", "installation", (installation) =>
+                    installation.onIndex("primary", (eb) =>
+                      eb("id", "=", eb.parent("installationId")),
+                    ),
+                  )
+                  .joinMany("links", "repo_link", (link) =>
+                    link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                      eb("repoId", "=", eb.parent("id")),
+                    ),
+                  ),
               );
             })
             .execute();
@@ -765,7 +800,16 @@ export const githubAppRoutesFactory = defineRoutes(githubAppFragmentDefinition).
                   .whereIndex("idx_installation_repo_full_name", (eb) =>
                     eb("fullName", "=", fullName),
                   )
-                  .join((jb) => jb.installation().links()),
+                  .joinOne("installation", "installation", (installation) =>
+                    installation.onIndex("primary", (eb) =>
+                      eb("id", "=", eb.parent("installationId")),
+                    ),
+                  )
+                  .joinMany("links", "repo_link", (link) =>
+                    link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                      eb("repoId", "=", eb.parent("id")),
+                    ),
+                  ),
               );
             })
             .execute();
@@ -864,7 +908,11 @@ export const githubAppRoutesFactory = defineRoutes(githubAppFragmentDefinition).
                     .whereIndex("idx_installation_repo_installation", (eb) =>
                       eb("installationId", "=", installationId),
                     )
-                    .join((jb) => jb.links()),
+                    .joinMany("links", "repo_link", (link) =>
+                      link.onIndex("uniq_repo_link_repo_id_link_key", (eb) =>
+                        eb("repoId", "=", eb.parent("id")),
+                      ),
+                    ),
                 );
             })
             .execute();

--- a/packages/github-app-fragment/src/schema.ts
+++ b/packages/github-app-fragment/src/schema.ts
@@ -27,7 +27,7 @@ export const githubAppSchema = schema("github-app-fragment", (s) => {
     .addTable("installation_repo", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("installationId", referenceColumn())
+        .addColumn("installationId", referenceColumn({ table: "installation" }))
         .addColumn("ownerLogin", column("string"))
         .addColumn("name", column("string"))
         .addColumn("fullName", column("string"))
@@ -46,7 +46,7 @@ export const githubAppSchema = schema("github-app-fragment", (s) => {
       return (
         t
           .addColumn("id", idColumn())
-          .addColumn("repoId", referenceColumn())
+          .addColumn("repoId", referenceColumn({ table: "installation_repo" }))
           // Namespaces a repo link so the same repository can be linked for multiple contexts.
           .addColumn("linkKey", column("string"))
           .addColumn(
@@ -58,21 +58,7 @@ export const githubAppSchema = schema("github-app-fragment", (s) => {
           })
       );
     })
-    .addReference("installation", {
-      type: "one",
-      from: { table: "installation_repo", column: "installationId" },
-      to: { table: "installation", column: "id" },
-    })
-    .addReference("links", {
-      // A repo is considered authorized for PR routes when at least one link exists.
-      type: "many",
-      from: { table: "installation_repo", column: "id" },
-      to: { table: "repo_link", column: "repoId" },
-      foreignKey: false,
-    })
-    .addReference("repo", {
-      type: "one",
-      from: { table: "repo_link", column: "repoId" },
-      to: { table: "installation_repo", column: "id" },
-    });
+    .noOp("removed obsolete installation_repo -> installation addReference history")
+    .noOp("removed obsolete installation_repo -> repo_link join-only relation history")
+    .noOp("removed obsolete repo_link -> installation_repo addReference history");
 });

--- a/packages/github-app-fragment/turbo.json
+++ b/packages/github-app-fragment/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/lofi/src/adapters/in-memory/adapter.test.ts
+++ b/packages/lofi/src/adapters/in-memory/adapter.test.ts
@@ -31,7 +31,7 @@ describe("InMemoryLofiAdapter", () => {
     expect(first.applied).toBe(true);
 
     const query = adapter.createQueryEngine(appSchema);
-    const users = await query.find("users");
+    const users = await query.find("users", (b) => b.whereIndex("primary"));
     expect(users).toHaveLength(1);
     expect(users[0].name).toBe("Ada");
 

--- a/packages/lofi/src/adapters/in-memory/query.test.ts
+++ b/packages/lofi/src/adapters/in-memory/query.test.ts
@@ -127,7 +127,11 @@ describe("in-memory query engine", () => {
     const query = createInMemoryQueryEngine({ schema: appSchema, store });
 
     const joined = await query.find("posts", (b) =>
-      b.whereIndex("idx_author", (eb) => eb("authorId", "=", "user-2")).join((j) => j.author()),
+      b
+        .whereIndex("idx_author", (eb) => eb("authorId", "=", "user-2"))
+        .joinOne("author", "users", (author) =>
+          author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+        ),
     );
 
     expect(joined).toHaveLength(1);

--- a/packages/lofi/src/adapters/in-memory/query.test.ts
+++ b/packages/lofi/src/adapters/in-memory/query.test.ts
@@ -76,15 +76,10 @@ describe("in-memory query engine", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const store = createStore(appSchema);

--- a/packages/lofi/src/adapters/in-memory/query.ts
+++ b/packages/lofi/src/adapters/in-memory/query.ts
@@ -2,11 +2,22 @@ import type { CursorResult } from "@fragno-dev/db/cursor";
 import { Cursor, createCursorFromRecord, decodeCursor } from "@fragno-dev/db/cursor";
 import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
 import { Column, FragnoId, FragnoReference } from "@fragno-dev/db/schema";
-import { FindBuilder } from "@fragno-dev/db/unit-of-work";
+import {
+  getQueryTreeSelectedColumnNames,
+  isParentColumnRef,
+  type CompiledQueryTreeChildNode,
+  type CompiledQueryTreeRootNode,
+} from "@fragno-dev/db/unit-of-work";
 
 import type { ReferenceTarget } from "../../indexeddb/types";
 import { buildCondition, type Condition, type ConditionBuilder } from "../../query/conditions";
 import { normalizeValue } from "../../query/normalize";
+import {
+  buildReadPlan,
+  lofiExecuteReadPlan,
+  type LofiExecutableQueryInterface,
+  type LofiReadPlan,
+} from "../../query/read-plan";
 import type { LofiQueryInterface } from "../../types";
 import type { InMemoryLofiRow } from "./store";
 import { InMemoryLofiStore } from "./store";
@@ -832,9 +843,6 @@ const applyJoins = async (options: {
   return outputs;
 };
 
-const buildFindBuilder = <TTable extends AnyTable>(tableName: string, table: TTable) =>
-  new FindBuilder<TTable>(tableName, table);
-
 type OverlayFindOptions<TTable extends AnyTable = AnyTable> = {
   useIndex: string;
   select?: unknown;
@@ -847,6 +855,7 @@ type OverlayFindOptions<TTable extends AnyTable = AnyTable> = {
   before?: Cursor | string;
   pageSize?: number;
   joins?: CompiledJoin[];
+  queryTree?: CompiledQueryTreeRootNode<TTable>;
 };
 
 type OverlayRetrievalOperation =
@@ -912,11 +921,503 @@ const applyCursorFilters = (options: {
   });
 };
 
+const resolveComparableColumn = (column: AnyColumn, table: AnyTable): AnyColumn =>
+  column.role === "external-id" ? table.getInternalIdColumn() : column;
+
+const getNormalizedRowValue = (
+  row: InMemoryLofiRow,
+  _table: AnyTable,
+  column: AnyColumn,
+): unknown => {
+  if (column.role === "external-id") {
+    return row.id;
+  }
+  if (column.role === "internal-id") {
+    return row._lofi.internalId;
+  }
+  if (column.role === "version") {
+    return row._lofi.version;
+  }
+  return row._lofi.norm[column.name];
+};
+
+const resolveQueryTreeComparisonValue = (options: {
+  value: unknown;
+  column: AnyColumn;
+  currentTable: AnyTable;
+  currentRow: InMemoryLofiRow;
+  context: QueryContext;
+  parentTable?: AnyTable;
+  parentRow?: InMemoryLofiRow;
+}): { value: unknown; column: AnyColumn } => {
+  const { value, column, currentTable, currentRow, context, parentTable, parentRow } = options;
+
+  if (isParentColumnRef(value)) {
+    if (!parentTable || !parentRow) {
+      throw new Error("Parent column references can only be evaluated for child query-tree nodes.");
+    }
+
+    let leftColumn = column;
+    let parentColumn = value.column;
+
+    if (leftColumn.role === "external-id" && parentColumn.role !== "external-id") {
+      leftColumn = resolveComparableColumn(leftColumn, currentTable);
+    }
+    if (parentColumn.role === "external-id" && leftColumn.role !== "external-id") {
+      parentColumn = resolveComparableColumn(parentColumn, parentTable);
+    }
+
+    return {
+      value: getNormalizedRowValue(parentRow, parentTable, parentColumn),
+      column: parentColumn,
+    };
+  }
+
+  if (value instanceof Column) {
+    return { value: currentRow._lofi.norm[value.name], column: value };
+  }
+
+  if (isDbNow(value)) {
+    return { value: new Date(), column };
+  }
+
+  if (column.role === "reference") {
+    return {
+      value: resolveReferenceValue({
+        value,
+        column,
+        table: currentTable,
+        schemaName: context.schemaName,
+        store: context.store,
+        referenceTargets: context.referenceTargets,
+      }),
+      column,
+    };
+  }
+
+  return { value: resolveFragnoIdValue(value, column), column };
+};
+
+const evaluateQueryTreeCondition = async (options: {
+  condition: Condition | undefined;
+  currentTable: AnyTable;
+  currentRow: InMemoryLofiRow;
+  context: QueryContext;
+  parentTable?: AnyTable;
+  parentRow?: InMemoryLofiRow;
+}): Promise<boolean> => {
+  const { condition, currentTable, currentRow, context, parentTable, parentRow } = options;
+  if (!condition) {
+    return true;
+  }
+
+  switch (condition.type) {
+    case "and": {
+      for (const item of condition.items) {
+        if (
+          !(await evaluateQueryTreeCondition({
+            condition: item,
+            currentTable,
+            currentRow,
+            context,
+            parentTable,
+            parentRow,
+          }))
+        ) {
+          return false;
+        }
+      }
+      return true;
+    }
+    case "or": {
+      for (const item of condition.items) {
+        if (
+          await evaluateQueryTreeCondition({
+            condition: item,
+            currentTable,
+            currentRow,
+            context,
+            parentTable,
+            parentRow,
+          })
+        ) {
+          return true;
+        }
+      }
+      return false;
+    }
+    case "not":
+      return !(await evaluateQueryTreeCondition({
+        condition: condition.item,
+        currentTable,
+        currentRow,
+        context,
+        parentTable,
+        parentRow,
+      }));
+    case "compare":
+      break;
+    default: {
+      const exhaustiveCheck: never = condition;
+      throw new Error(`Unsupported condition type: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+
+  let leftColumn = condition.a;
+  let rightColumn = condition.a;
+  const right = resolveQueryTreeComparisonValue({
+    value: condition.b,
+    column: leftColumn,
+    currentTable,
+    currentRow,
+    context,
+    parentTable,
+    parentRow,
+  });
+
+  if (isParentColumnRef(condition.b)) {
+    if (leftColumn.role === "external-id" && right.column.role !== "external-id") {
+      leftColumn = resolveComparableColumn(leftColumn, currentTable);
+    }
+    if (right.column.role === "external-id" && leftColumn.role !== "external-id" && parentTable) {
+      rightColumn = resolveComparableColumn(right.column, parentTable);
+    } else {
+      rightColumn = right.column;
+    }
+  }
+
+  const leftValue = getNormalizedRowValue(currentRow, currentTable, leftColumn);
+  const rightValue = right.value;
+  const op = condition.operator;
+
+  if (op === "is" || op === "is not") {
+    if (isNullish(rightValue)) {
+      const matches = isNullish(leftValue);
+      return op === "is" ? matches : !matches;
+    }
+
+    if (isNullish(leftValue)) {
+      return op === "is not";
+    }
+
+    const rightNormalized =
+      rightColumn.role === "reference" || rightColumn.role === "internal-id"
+        ? coerceLocalInternalId(rightValue)
+        : normalizeValue(rightValue, rightColumn);
+    const matches = compareNormalizedValues(leftValue, rightNormalized) === 0;
+    return op === "is" ? matches : !matches;
+  }
+
+  if (isNullish(leftValue) || isNullish(rightValue)) {
+    return false;
+  }
+
+  if (op === "in" || op === "not in") {
+    if (!Array.isArray(rightValue)) {
+      throw new Error(`Operator "${op}" expects an array value.`);
+    }
+
+    const leftNormalized = leftValue;
+    let hasNull = false;
+    let hasMatch = false;
+
+    for (const item of rightValue) {
+      const resolved = resolveQueryTreeComparisonValue({
+        value: item,
+        column: leftColumn,
+        currentTable,
+        currentRow,
+        context,
+        parentTable,
+        parentRow,
+      });
+      if (isNullish(resolved.value)) {
+        hasNull = true;
+        continue;
+      }
+
+      const normalized =
+        resolved.column.role === "reference" || resolved.column.role === "internal-id"
+          ? coerceLocalInternalId(resolved.value)
+          : normalizeValue(resolved.value, resolved.column);
+      if (compareNormalizedValues(leftNormalized, normalized) === 0) {
+        hasMatch = true;
+        break;
+      }
+    }
+
+    if (hasMatch) {
+      return op === "in";
+    }
+
+    if (hasNull) {
+      return false;
+    }
+
+    return op === "not in";
+  }
+
+  if (
+    op === "contains" ||
+    op === "starts with" ||
+    op === "ends with" ||
+    op === "not contains" ||
+    op === "not starts with" ||
+    op === "not ends with"
+  ) {
+    const leftLike = normalizeLikeValue(leftValue, leftColumn);
+    const rightLike = normalizeLikeValue(rightValue, right.column);
+
+    if (leftLike === null || rightLike === null) {
+      return false;
+    }
+
+    const leftText = leftLike.toLowerCase();
+    const rightText = rightLike.toLowerCase();
+    let matches = false;
+
+    if (op.includes("contains")) {
+      matches = leftText.includes(rightText);
+    } else if (op.includes("starts with")) {
+      matches = leftText.startsWith(rightText);
+    } else {
+      matches = leftText.endsWith(rightText);
+    }
+
+    return op.startsWith("not ") ? !matches : matches;
+  }
+
+  const rightNormalized =
+    rightColumn.role === "reference" || rightColumn.role === "internal-id"
+      ? coerceLocalInternalId(rightValue)
+      : normalizeValue(rightValue, rightColumn);
+  const comparison = compareNormalizedValues(leftValue, rightNormalized);
+
+  switch (op) {
+    case "=":
+      return comparison === 0;
+    case "!=":
+      return comparison !== 0;
+    case ">":
+      return comparison > 0;
+    case ">=":
+      return comparison >= 0;
+    case "<":
+      return comparison < 0;
+    case "<=":
+      return comparison <= 0;
+    default:
+      throw new Error(`Unsupported operator "${op}".`);
+  }
+};
+
+const buildQueryTreeOutput = async (options: {
+  node: CompiledQueryTreeRootNode | CompiledQueryTreeChildNode;
+  row: InMemoryLofiRow;
+  context: QueryContext;
+  rowsByTable: Map<string, InMemoryLofiRow[]>;
+}): Promise<Record<string, unknown>> => {
+  const { node, row, context, rowsByTable } = options;
+  const output: Record<string, unknown> = {};
+
+  for (const columnName of getQueryTreeSelectedColumnNames(node.table, node.select)) {
+    const column = node.table.columns[columnName];
+    if (!column || column.isHidden) {
+      continue;
+    }
+    output[columnName] = buildOutputValueForColumn(row, column);
+  }
+
+  for (const child of node.children) {
+    const cacheKey = `${context.schemaName}::${child.table.name}`;
+    let childRows = rowsByTable.get(cacheKey);
+    if (!childRows) {
+      childRows = collectRows({ context, tableName: child.table.name });
+      rowsByTable.set(cacheKey, childRows);
+    }
+
+    const matches: InMemoryLofiRow[] = [];
+    for (const childRow of childRows) {
+      if (
+        !(await evaluateQueryTreeCondition({
+          condition: child.onIndex,
+          currentTable: child.table,
+          currentRow: childRow,
+          context,
+          parentTable: node.table,
+          parentRow: row,
+        }))
+      ) {
+        continue;
+      }
+      if (
+        !(await evaluateQueryTreeCondition({
+          condition: child.where,
+          currentTable: child.table,
+          currentRow: childRow,
+          context,
+        }))
+      ) {
+        continue;
+      }
+      matches.push(childRow);
+    }
+
+    const ordered = child.orderByIndex
+      ? orderRows(
+          matches,
+          buildOrderColumns(child.table, child.orderByIndex.indexName).map(
+            (column) => [column, child.orderByIndex!.direction] as [AnyColumn, "asc" | "desc"],
+          ),
+        )
+      : matches;
+    const limited = child.pageSize !== undefined ? ordered.slice(0, child.pageSize) : ordered;
+    const items = await Promise.all(
+      limited.map((childRow) =>
+        buildQueryTreeOutput({
+          node: child,
+          row: childRow,
+          context,
+          rowsByTable,
+        }),
+      ),
+    );
+
+    output[child.alias] = child.cardinality === "one" ? (items[0] ?? null) : items;
+  }
+
+  return output;
+};
+
+const executeInMemoryReadPlan = async (options: {
+  plan: LofiReadPlan;
+  context: QueryContext;
+}): Promise<
+  | Record<string, unknown>
+  | Record<string, unknown>[]
+  | CursorResult<Record<string, unknown>>
+  | number
+  | null
+> => {
+  const { plan, context } = options;
+
+  const rootRows = collectRows({ context, tableName: plan.table.name });
+  const matchingRows: InMemoryLofiRow[] = [];
+  for (const row of rootRows) {
+    if (
+      !(await evaluateQueryTreeCondition({
+        condition: plan.queryTree.where,
+        currentTable: plan.table,
+        currentRow: row,
+        context,
+      }))
+    ) {
+      continue;
+    }
+    matchingRows.push(row);
+  }
+
+  if (plan.kind === "count") {
+    return matchingRows.length;
+  }
+
+  const effectiveOrderBy = plan.queryTree.orderByIndex ?? {
+    indexName: plan.queryTree.useIndex,
+    direction: "asc" as const,
+  };
+  const orderColumns = buildOrderColumns(plan.table, effectiveOrderBy.indexName);
+  const ordered = orderRows(
+    matchingRows,
+    orderColumns.map(
+      (column) => [column, effectiveOrderBy.direction] as [AnyColumn, "asc" | "desc"],
+    ),
+  );
+  const filtered = applyCursorFilters({
+    rows: ordered,
+    orderColumns,
+    direction: effectiveOrderBy.direction,
+    after: plan.queryTree.after,
+    before: plan.queryTree.before,
+  });
+
+  const pageSize = plan.queryTree.pageSize;
+  const windowed =
+    pageSize !== undefined && plan.resultMode === "findWithCursor"
+      ? filtered.slice(0, pageSize + 1)
+      : pageSize !== undefined
+        ? filtered.slice(0, pageSize)
+        : filtered;
+
+  const rowsByTable = new Map<string, InMemoryLofiRow[]>();
+  const decoded = await Promise.all(
+    windowed.map((row) =>
+      buildQueryTreeOutput({
+        node: plan.queryTree,
+        row,
+        context,
+        rowsByTable,
+      }),
+    ),
+  );
+
+  if (plan.resultMode === "find") {
+    return decoded;
+  }
+
+  if (plan.resultMode === "findFirst") {
+    return decoded[0] ?? null;
+  }
+
+  let items = decoded;
+  let sourceRows = windowed;
+  let hasNextPage = false;
+
+  if (pageSize !== undefined && decoded.length > pageSize) {
+    hasNextPage = true;
+    items = decoded.slice(0, pageSize);
+    sourceRows = windowed.slice(0, pageSize);
+  }
+
+  let cursor: Cursor | undefined;
+  const lastRow = items[items.length - 1];
+  if (lastRow && pageSize) {
+    const cursorRecord: Record<string, unknown> = { ...lastRow };
+    const sourceRow = sourceRows[sourceRows.length - 1];
+    if (sourceRow) {
+      for (const column of orderColumns) {
+        if (cursorRecord[column.name] === undefined) {
+          cursorRecord[column.name] = buildOutputValueForColumn(sourceRow, column);
+        }
+      }
+    }
+
+    cursor = createCursorFromRecord(cursorRecord, orderColumns, {
+      indexName: effectiveOrderBy.indexName,
+      orderDirection: effectiveOrderBy.direction,
+      pageSize,
+    });
+  }
+
+  return { items, cursor, hasNextPage };
+};
+
 export const executeInMemoryRetrievalOperation = async (options: {
   operation: OverlayRetrievalOperation;
   context: QueryContext;
 }): Promise<Record<string, unknown>[] | CursorResult<Record<string, unknown>> | number> => {
   const { operation, context } = options;
+
+  if (operation.type === "find" && operation.options.queryTree) {
+    return (await executeInMemoryReadPlan({
+      plan: {
+        kind: "find",
+        resultMode: operation.withCursor ? "findWithCursor" : "find",
+        table: operation.table,
+        queryTree: operation.options.queryTree,
+      },
+      context,
+    })) as Record<string, unknown>[] | CursorResult<Record<string, unknown>>;
+  }
 
   const rows = collectRows({
     context,
@@ -1063,88 +1564,46 @@ export const createInMemoryQueryEngine = <T extends AnySchema>(options: {
     referenceTargets: options.store.referenceTargets,
   };
 
-  const runFind = async (
-    tableName: string,
-    builderFn: ((builder: FindBuilder<AnyTable>) => unknown) | undefined,
-    withCursor: boolean,
-  ): Promise<Record<string, unknown>[] | CursorResult<Record<string, unknown>> | number> => {
-    const tableMap = options.schema.tables as Record<string, AnyTable>;
-    const table = tableMap[tableName];
-    if (!table) {
-      throw new Error(`Table ${tableName} not found in schema`);
-    }
-
-    const builder = buildFindBuilder(tableName, table);
-    if (builderFn) {
-      builderFn(builder);
-    } else {
-      builder.whereIndex("primary");
-    }
-
-    const built = builder.build();
-    if (built.type === "count") {
-      return executeInMemoryRetrievalOperation({
-        operation: {
-          type: "count",
-          table,
-          indexName: built.indexName,
-          options: { where: built.options.where },
-        },
-        context,
-      });
-    }
-
-    return executeInMemoryRetrievalOperation({
-      operation: {
-        type: "find",
-        table,
-        indexName: built.indexName,
-        options: built.options,
-        withCursor,
-      },
+  const executePlan = async (plan: LofiReadPlan): Promise<unknown> => {
+    return executeInMemoryReadPlan({
+      plan,
       context,
     });
   };
 
   const queryEngine = {
+    [lofiExecuteReadPlan]: executePlan,
+
     async find(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn as unknown as (builder: FindBuilder<AnyTable>) => unknown,
-        false,
-      );
-      return result as Record<string, unknown>[] | number;
+        builderFn,
+        resultMode: "find",
+      });
+      return (await executePlan(plan)) as Record<string, unknown>[] | number;
     },
 
     async findWithCursor(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn as unknown as (builder: FindBuilder<AnyTable>) => unknown,
-        true,
-      );
-      return result as CursorResult<Record<string, unknown>>;
+        builderFn,
+        resultMode: "findWithCursor",
+      });
+      return (await executePlan(plan)) as CursorResult<Record<string, unknown>>;
     },
 
     async findFirst(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn
-          ? (builder: FindBuilder<AnyTable>) => {
-              (builderFn as unknown as (b: FindBuilder<AnyTable>) => unknown)(builder);
-              builder.pageSize(1);
-              return builder;
-            }
-          : (builder: FindBuilder<AnyTable>) => builder.whereIndex("primary").pageSize(1),
-        false,
-      );
-
-      if (typeof result === "number") {
-        return null;
-      }
-
-      return (result as Record<string, unknown>[])[0] ?? null;
+        builderFn,
+        resultMode: "findFirst",
+      });
+      return (await executePlan(plan)) as Record<string, unknown> | number | null;
     },
-  } as LofiQueryInterface<T>;
+  } as LofiExecutableQueryInterface<T>;
 
   return queryEngine;
 };

--- a/packages/lofi/src/adapters/in-memory/query.ts
+++ b/packages/lofi/src/adapters/in-memory/query.ts
@@ -1,7 +1,7 @@
 import type { CursorResult } from "@fragno-dev/db/cursor";
 import { Cursor, createCursorFromRecord, decodeCursor } from "@fragno-dev/db/cursor";
 import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
-import { Column, FragnoId, FragnoReference } from "@fragno-dev/db/schema";
+import { Column, FragnoId, FragnoReference, getTableRelations } from "@fragno-dev/db/schema";
 import {
   getQueryTreeSelectedColumnNames,
   isParentColumnRef,
@@ -233,7 +233,7 @@ const decodeRow = (row: RowSelection, table: AnyTable): Record<string, unknown> 
 
     const relationName = key.slice(0, colonIndex);
     const remainder = key.slice(colonIndex + 1);
-    const relation = table.relations[relationName];
+    const relation = getTableRelations(table)[relationName];
     if (!relation) {
       continue;
     }
@@ -243,7 +243,7 @@ const decodeRow = (row: RowSelection, table: AnyTable): Record<string, unknown> 
   }
 
   for (const relationName in relationData) {
-    const relation = table.relations[relationName];
+    const relation = getTableRelations(table)[relationName];
     if (!relation) {
       continue;
     }
@@ -1064,7 +1064,6 @@ const evaluateQueryTreeCondition = async (options: {
   }
 
   let leftColumn = condition.a;
-  let rightColumn = condition.a;
   const right = resolveQueryTreeComparisonValue({
     value: condition.b,
     column: leftColumn,
@@ -1075,14 +1074,14 @@ const evaluateQueryTreeCondition = async (options: {
     parentRow,
   });
 
+  let rightColumn = right.column;
+
   if (isParentColumnRef(condition.b)) {
     if (leftColumn.role === "external-id" && right.column.role !== "external-id") {
       leftColumn = resolveComparableColumn(leftColumn, currentTable);
     }
     if (right.column.role === "external-id" && leftColumn.role !== "external-id" && parentTable) {
       rightColumn = resolveComparableColumn(right.column, parentTable);
-    } else {
-      rightColumn = right.column;
     }
   }
 

--- a/packages/lofi/src/adapters/in-memory/store.ts
+++ b/packages/lofi/src/adapters/in-memory/store.ts
@@ -1,5 +1,5 @@
 import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
-import { FragnoId, FragnoReference } from "@fragno-dev/db/schema";
+import { FragnoId, FragnoReference, getTableRelations } from "@fragno-dev/db/schema";
 
 import type { ReferenceTarget } from "../../indexeddb/types";
 import { normalizeValue } from "../../query/normalize";
@@ -54,7 +54,7 @@ const createReferenceTargets = (schemas: AnySchema[]): Map<string, ReferenceTarg
   const referenceTargets = new Map<string, ReferenceTarget>();
   for (const schema of schemas) {
     for (const table of Object.values(schema.tables)) {
-      for (const relation of Object.values(table.relations)) {
+      for (const relation of Object.values(getTableRelations(table))) {
         for (const [fromColumn] of relation.on) {
           referenceTargets.set(`${schema.name}::${table.name}::${fromColumn}`, {
             schema: schema.name,

--- a/packages/lofi/src/adapters/stacked/adapter.test.ts
+++ b/packages/lofi/src/adapters/stacked/adapter.test.ts
@@ -242,7 +242,11 @@ describe("StackedLofiAdapter", () => {
 
     const query = stacked.createQueryEngine(appSchema);
     const joined = await query.find("posts", (b) =>
-      b.whereIndex("idx_author").join((j) => j.author()),
+      b
+        .joinOne("author", "users", (author) =>
+          author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+        )
+        .whereIndex("idx_author"),
     );
 
     expect(joined).toHaveLength(1);

--- a/packages/lofi/src/adapters/stacked/adapter.test.ts
+++ b/packages/lofi/src/adapters/stacked/adapter.test.ts
@@ -192,15 +192,10 @@ describe("StackedLofiAdapter", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { stacked } = createStackedAdapters(appSchema);

--- a/packages/lofi/src/adapters/stacked/adapter.ts
+++ b/packages/lofi/src/adapters/stacked/adapter.ts
@@ -84,13 +84,10 @@ export class StackedLofiAdapter implements LofiAdapter, LofiQueryableAdapter {
 
       const baseQuery = this.base.createQueryEngine(schema);
       const baseRow = (await baseQuery.findFirst(mutation.table, (b) =>
-        b.whereIndex("primary", (eb) =>
-          (eb as unknown as (col: string, op: "=", value: string) => boolean)(
-            table.getIdColumn().name,
-            "=",
-            mutation.externalId,
-          ),
-        ),
+        b.whereIndex("primary", (eb) => {
+          const compare = eb as unknown as (col: string, op: "=", value: unknown) => boolean;
+          return compare(table.getIdColumn().name, "=", mutation.externalId);
+        }),
       )) as Record<string, unknown> | null;
 
       let values: Record<string, unknown> | null = null;

--- a/packages/lofi/src/adapters/stacked/merge.test.ts
+++ b/packages/lofi/src/adapters/stacked/merge.test.ts
@@ -161,15 +161,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -223,15 +218,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -284,15 +274,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("posts", {
-          type: "many",
-          from: { table: "users", column: "id" },
-          to: { table: "posts", column: "authorId" },
-        }),
+        ),
     );
 
     const base = createStubBaseAdapter({
@@ -337,16 +322,11 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"])
             .createIndex("idx_title", ["title"]),
-        )
-        .addReference("posts", {
-          type: "many",
-          from: { table: "users", column: "id" },
-          to: { table: "posts", column: "authorId" },
-        }),
+        ),
     );
 
     const base = createStubBaseAdapter({
@@ -389,15 +369,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("posts", {
-          type: "many",
-          from: { table: "users", column: "id" },
-          to: { table: "posts", column: "authorId" },
-        }),
+        ),
     );
 
     const base = createStubBaseAdapter({
@@ -440,27 +415,17 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
         )
         .addTable("comments", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("postId", referenceColumn())
+            .addColumn("postId", referenceColumn({ table: "posts" }))
             .addColumn("body", column("string"))
             .createIndex("idx_post", ["postId"]),
-        )
-        .addReference("posts", {
-          type: "many",
-          from: { table: "users", column: "id" },
-          to: { table: "posts", column: "authorId" },
-        })
-        .addReference("comments", {
-          type: "many",
-          from: { table: "posts", column: "id" },
-          to: { table: "comments", column: "postId" },
-        }),
+        ),
     );
 
     const base = createStubBaseAdapter({
@@ -516,15 +481,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -611,15 +571,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -678,15 +633,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -750,28 +700,18 @@ describe("stacked merge", () => {
         .addTable("users", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("orgId", referenceColumn())
+            .addColumn("orgId", column("string"))
             .addColumn("email", column("string"))
             .createIndex("idx_user_org_email", ["orgId", "email"]),
         )
         .addTable("memberships", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("orgId", referenceColumn())
+            .addColumn("orgId", column("string"))
             .addColumn("userEmail", column("string"))
             .createIndex("idx_membership_org_email", ["orgId", "userEmail"]),
-        )
-        .addReference("member", {
-          type: "one",
-          from: { table: "memberships", column: "orgId" },
-          to: { table: "users", column: "orgId" },
-        }),
+        ),
     );
-
-    const relation = appSchema.tables.memberships.relations.member as {
-      on: Array<[string, string]>;
-    };
-    relation.on.push(["userEmail", "email"]);
 
     const base = createStubBaseAdapter({
       users: [
@@ -809,15 +749,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay: _overlay, query } = createStackedQuery(appSchema);
@@ -874,15 +809,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay: _overlay, query } = createStackedQuery(appSchema);
@@ -970,15 +900,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { overlay, query } = createStackedQuery(appSchema);
@@ -1012,15 +937,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1077,15 +997,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1180,27 +1095,17 @@ describe("stacked merge", () => {
         .addTable("users", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("orgId", referenceColumn())
+            .addColumn("orgId", referenceColumn({ table: "orgs" }))
             .addColumn("name", column("string"))
             .createIndex("idx_org", ["orgId"]),
         )
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        })
-        .addReference("org", {
-          type: "one",
-          from: { table: "users", column: "orgId" },
-          to: { table: "orgs", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1323,15 +1228,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1429,15 +1329,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1537,15 +1432,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1641,15 +1531,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1748,15 +1633,10 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1808,27 +1688,17 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
         )
         .addTable("comments", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("postId", referenceColumn())
+            .addColumn("postId", referenceColumn({ table: "posts" }))
             .addColumn("body", column("string"))
             .createIndex("idx_post", ["postId"]),
-        )
-        .addReference("posts", {
-          type: "many",
-          from: { table: "users", column: "id" },
-          to: { table: "posts", column: "authorId" },
-        })
-        .addReference("comments", {
-          type: "many",
-          from: { table: "posts", column: "id" },
-          to: { table: "comments", column: "postId" },
-        }),
+        ),
     );
 
     const base = createStubBaseAdapter({
@@ -1876,16 +1746,11 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("sortKey", column("integer"))
             .addColumn("title", column("string"))
             .createIndex("idx_sort", ["sortKey"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const { base, overlay, query } = createStackedQuery(appSchema);
@@ -1964,28 +1829,18 @@ describe("stacked merge", () => {
         .addTable("users", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("orgId", referenceColumn())
+            .addColumn("orgId", column("string"))
             .addColumn("email", column("string"))
             .createIndex("idx_user_org_email", ["orgId", "email"]),
         )
         .addTable("memberships", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("orgId", referenceColumn())
+            .addColumn("orgId", column("string"))
             .addColumn("userEmail", column("string").nullable())
             .createIndex("idx_membership_org_email", ["orgId", "userEmail"]),
-        )
-        .addReference("member", {
-          type: "one",
-          from: { table: "memberships", column: "orgId" },
-          to: { table: "users", column: "orgId" },
-        }),
+        ),
     );
-
-    const relation = appSchema.tables.memberships.relations.member as {
-      on: Array<[string, string]>;
-    };
-    relation.on.push(["userEmail", "email"]);
 
     const { base, overlay, query } = createStackedQuery(appSchema);
 
@@ -2059,7 +1914,7 @@ describe("stacked merge", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"])
             .createIndex("idx_title", ["title"]),
@@ -2067,21 +1922,11 @@ describe("stacked merge", () => {
         .addTable("comments", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("postId", referenceColumn())
+            .addColumn("postId", referenceColumn({ table: "posts" }))
             .addColumn("body", column("string"))
             .createIndex("idx_post", ["postId"])
             .createIndex("idx_body", ["body"]),
-        )
-        .addReference("posts", {
-          type: "many",
-          from: { table: "users", column: "id" },
-          to: { table: "posts", column: "authorId" },
-        })
-        .addReference("comments", {
-          type: "many",
-          from: { table: "posts", column: "id" },
-          to: { table: "comments", column: "postId" },
-        }),
+        ),
     );
 
     const base = createStubBaseAdapter({

--- a/packages/lofi/src/adapters/stacked/merge.test.ts
+++ b/packages/lofi/src/adapters/stacked/merge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { column, FragnoId, idColumn, referenceColumn, schema } from "@fragno-dev/db/schema";
 
+import type { Condition } from "../../query/conditions";
 import type { LofiAdapter, LofiQueryableAdapter } from "../../types";
 import { InMemoryLofiAdapter } from "../in-memory/adapter";
 import { createStackedQueryEngine } from "./merge";
@@ -34,6 +35,123 @@ const createStubBaseAdapter = (
     createQueryEngine: () => query,
   } as LofiAdapter & LofiQueryableAdapter;
 };
+
+type ParentAwareConditionBuilder = {
+  (column: string, operator: string, value?: unknown): Condition | boolean;
+  and: (...conditions: (Condition | boolean)[]) => Condition | boolean;
+  parent: (name: string) => unknown;
+};
+
+type JoinOneHost = {
+  joinOne: (...args: never[]) => unknown;
+};
+
+type JoinManyHost = {
+  joinMany: (...args: never[]) => unknown;
+};
+
+type OnIndexCapable = {
+  onIndex(indexName: string, condition?: (eb: unknown) => unknown): unknown;
+};
+
+type InferJoinOneBuilder<THostBuilder> = THostBuilder extends {
+  joinOne(alias: string, table: string, builderFn: (builder: infer TBuilder) => unknown): unknown;
+}
+  ? TBuilder
+  : never;
+
+type InferJoinManyBuilder<THostBuilder> = THostBuilder extends {
+  joinMany(alias: string, table: string, builderFn: (builder: infer TBuilder) => unknown): unknown;
+}
+  ? TBuilder
+  : never;
+
+const joinAuthor = <THostBuilder extends JoinOneHost>(
+  builder: THostBuilder,
+  configure?: (author: InferJoinOneBuilder<THostBuilder>) => unknown,
+) =>
+  (
+    builder.joinOne as (
+      alias: string,
+      table: string,
+      builderFn: (builder: InferJoinOneBuilder<THostBuilder>) => unknown,
+    ) => unknown
+  )("author", "users", (author) => {
+    (author as InferJoinOneBuilder<THostBuilder> & OnIndexCapable).onIndex(
+      "primary",
+      (eb: unknown) => {
+        const conditionBuilder = eb as ParentAwareConditionBuilder;
+        return conditionBuilder("id", "=", conditionBuilder.parent("authorId"));
+      },
+    );
+    return configure ? configure(author) : author;
+  });
+
+const joinPosts = <THostBuilder extends JoinManyHost>(
+  builder: THostBuilder,
+  configure?: (posts: InferJoinManyBuilder<THostBuilder>) => unknown,
+) =>
+  (
+    builder.joinMany as (
+      alias: string,
+      table: string,
+      builderFn: (builder: InferJoinManyBuilder<THostBuilder>) => unknown,
+    ) => unknown
+  )("posts", "posts", (posts) => {
+    (posts as InferJoinManyBuilder<THostBuilder> & OnIndexCapable).onIndex(
+      "idx_author",
+      (eb: unknown) => {
+        const conditionBuilder = eb as ParentAwareConditionBuilder;
+        return conditionBuilder("authorId", "=", conditionBuilder.parent("id"));
+      },
+    );
+    return configure ? configure(posts) : posts;
+  });
+
+const joinComments = <THostBuilder extends JoinManyHost>(
+  builder: THostBuilder,
+  configure?: (comments: InferJoinManyBuilder<THostBuilder>) => unknown,
+) =>
+  (
+    builder.joinMany as (
+      alias: string,
+      table: string,
+      builderFn: (builder: InferJoinManyBuilder<THostBuilder>) => unknown,
+    ) => unknown
+  )("comments", "comments", (comments) => {
+    (comments as InferJoinManyBuilder<THostBuilder> & OnIndexCapable).onIndex(
+      "idx_post",
+      (eb: unknown) => {
+        const conditionBuilder = eb as ParentAwareConditionBuilder;
+        return conditionBuilder("postId", "=", conditionBuilder.parent("id"));
+      },
+    );
+    return configure ? configure(comments) : comments;
+  });
+
+const joinMember = <THostBuilder extends JoinOneHost>(
+  builder: THostBuilder,
+  configure?: (member: InferJoinOneBuilder<THostBuilder>) => unknown,
+) =>
+  (
+    builder.joinOne as (
+      alias: string,
+      table: string,
+      builderFn: (builder: InferJoinOneBuilder<THostBuilder>) => unknown,
+    ) => unknown
+  )("member", "users", (member) => {
+    (member as InferJoinOneBuilder<THostBuilder> & OnIndexCapable).onIndex(
+      "idx_user_org_email",
+      (eb: unknown) => {
+        const conditionBuilder = eb as ParentAwareConditionBuilder;
+        return conditionBuilder.and(
+          conditionBuilder("orgId", "=", conditionBuilder.parent("orgId")),
+          conditionBuilder("email", "=", conditionBuilder.parent("userEmail")),
+        );
+      },
+    );
+    return configure ? configure(member) : member;
+  });
 
 describe("stacked merge", () => {
   it("backfills base joins for overlay-only rows", async () => {
@@ -83,9 +201,7 @@ describe("stacked merge", () => {
       },
     ]);
 
-    const joined = await query.find("posts", (b) =>
-      b.whereIndex("idx_author").join((j) => j["author"]()),
-    );
+    const joined = await query.find("posts", (b) => joinAuthor(b.whereIndex("idx_author")));
 
     expect(joined).toHaveLength(1);
     const author = (joined[0] as Record<string, unknown>)["author"] as
@@ -148,7 +264,7 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b.whereIndex("idx_author").join((j) => j["author"]((jb) => jb.select(["name"]))),
+      joinAuthor(b.whereIndex("idx_author"), (author) => author.select(["name"])),
     );
 
     expect(posts).toHaveLength(1);
@@ -169,7 +285,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("posts", {
           type: "many",
@@ -204,9 +321,7 @@ describe("stacked merge", () => {
       },
     ]);
 
-    const users = await query.find("users", (b) =>
-      b.whereIndex("primary").join((j) => j["posts"]()),
-    );
+    const users = await query.find("users", (b) => joinPosts(b.whereIndex("primary")));
 
     expect(users).toHaveLength(1);
     const posts = (users[0] as Record<string, unknown>)["posts"] as Array<Record<string, unknown>>;
@@ -224,6 +339,7 @@ describe("stacked merge", () => {
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
             .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"])
             .createIndex("idx_title", ["title"]),
         )
         .addReference("posts", {
@@ -255,9 +371,9 @@ describe("stacked merge", () => {
     ]);
 
     const users = await query.find("users", (b) =>
-      b
-        .whereIndex("primary")
-        .join((j) => j["posts"]((jb) => jb.orderByIndex("idx_title", "desc").pageSize(2))),
+      joinPosts(b.whereIndex("primary"), (posts) =>
+        posts.orderByIndex("idx_title", "desc").pageSize(2),
+      ),
     );
 
     expect(users).toHaveLength(1);
@@ -274,7 +390,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("posts", {
           type: "many",
@@ -308,9 +425,7 @@ describe("stacked merge", () => {
       },
     ]);
 
-    const users = await query.find("users", (b) =>
-      b.whereIndex("primary").join((j) => j["posts"]()),
-    );
+    const users = await query.find("users", (b) => joinPosts(b.whereIndex("primary")));
 
     expect(users).toHaveLength(1);
     const posts = (users[0] as Record<string, unknown>)["posts"] as Array<Record<string, unknown>>;
@@ -326,13 +441,15 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addTable("comments", (t) =>
           t
             .addColumn("id", idColumn())
             .addColumn("postId", referenceColumn())
-            .addColumn("body", column("string")),
+            .addColumn("body", column("string"))
+            .createIndex("idx_post", ["postId"]),
         )
         .addReference("posts", {
           type: "many",
@@ -377,7 +494,7 @@ describe("stacked merge", () => {
     ]);
 
     const users = await query.find("users", (b) =>
-      b.whereIndex("primary").join((j) => j["posts"]((pb) => pb.join((pj) => pj["comments"]()))),
+      joinPosts(b.whereIndex("primary"), (posts) => joinComments(posts)),
     );
 
     expect(users).toHaveLength(1);
@@ -400,7 +517,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("author", {
           type: "one",
@@ -455,11 +573,9 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .join((j) =>
-          j["author"]((jb) => jb.whereIndex("idx_name", (eb) => eb("name", "=", "Ada"))),
-        ),
+      joinAuthor(b.whereIndex("primary"), (author) =>
+        author.whereIndex("idx_name", (eb) => eb("name", "=", "Ada")),
+      ),
     );
 
     const adaPost = posts.find((post) => {
@@ -544,7 +660,7 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b.whereIndex("idx_author").join((j) => j["author"]((jb) => jb.select(["name"]))),
+      joinAuthor(b.whereIndex("idx_author"), (author) => author.select(["name"])),
     );
 
     expect(posts).toHaveLength(1);
@@ -618,9 +734,7 @@ describe("stacked merge", () => {
       },
     ]);
 
-    const posts = await query.find("posts", (b) =>
-      b.whereIndex("idx_author").join((j) => j["author"]()),
-    );
+    const posts = await query.find("posts", (b) => joinAuthor(b.whereIndex("idx_author")));
 
     expect(posts).toHaveLength(1);
     const author = (posts[0] as Record<string, unknown>)["author"] as
@@ -679,9 +793,7 @@ describe("stacked merge", () => {
       },
     ]);
 
-    const memberships = await query.find("memberships", (b) =>
-      b.whereIndex("primary").join((j) => j["member"]()),
-    );
+    const memberships = await query.find("memberships", (b) => joinMember(b.whereIndex("primary")));
 
     const member = (memberships[0] as Record<string, unknown>)["member"] as
       | Record<string, unknown>
@@ -698,7 +810,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("author", {
           type: "one",
@@ -734,19 +847,12 @@ describe("stacked merge", () => {
     });
 
     const posts = await query.find("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .join((j) =>
-          j["author"]((jb) =>
-            jb.whereIndex("primary", (eb) =>
-              (eb as unknown as (col: string, op: "=", value: string) => boolean)(
-                "id",
-                "=",
-                "user-1",
-              ),
-            ),
-          ),
-        ),
+      joinAuthor(b.whereIndex("primary"), (author) =>
+        author.whereIndex("primary", (eb) => {
+          const compare = eb as unknown as (col: string, op: "=", value: unknown) => boolean;
+          return compare("id", "=", "user-1");
+        }),
+      ),
     );
 
     const author = (posts[0] as Record<string, unknown>)["author"] as
@@ -838,25 +944,19 @@ describe("stacked merge", () => {
     });
 
     const firstPage = await query.findWithCursor("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .orderByIndex("primary", "asc")
-        .pageSize(2)
-        .join((j) =>
-          j["author"]((jb) => jb.whereIndex("idx_name").orderByIndex("idx_name", "asc")),
-        ),
+      joinAuthor(b.whereIndex("primary").orderByIndex("primary", "asc").pageSize(2), (author) =>
+        author.whereIndex("idx_name").orderByIndex("idx_name", "asc"),
+      ),
     );
 
     expect(firstPage.items).toHaveLength(2);
     expect(firstPage.hasNextPage).toBe(true);
 
     const secondPage = await query.findWithCursor("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .orderByIndex("primary", "asc")
-        .pageSize(2)
-        .after(firstPage.cursor!)
-        .join((j) => j["author"]()),
+      joinAuthor(
+        b.whereIndex("primary").orderByIndex("primary", "asc").pageSize(2).after(firstPage.cursor!),
+        (author) => author.whereIndex("idx_name").orderByIndex("idx_name", "asc"),
+      ),
     );
 
     expect(secondPage.items).toHaveLength(1);
@@ -894,9 +994,7 @@ describe("stacked merge", () => {
       },
     ]);
 
-    const posts = await query.find("posts", (b) =>
-      b.whereIndex("idx_author").join((j) => j["author"]()),
-    );
+    const posts = await query.find("posts", (b) => joinAuthor(b.whereIndex("idx_author")));
 
     const author = (posts[0] as Record<string, unknown>)["author"] as unknown;
     expect(author ?? null).toBeNull();
@@ -955,11 +1053,9 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b
-        .whereIndex("idx_author")
-        .join((j) =>
-          j["author"]((jb) => jb.whereIndex("idx_name", (eb) => eb("name", "contains", "love"))),
-        ),
+      joinAuthor(b.whereIndex("idx_author"), (author) =>
+        author.whereIndex("idx_name", (eb) => eb("name", "contains", "love")),
+      ),
     );
 
     const author = (posts[0] as Record<string, unknown>)["author"] as
@@ -1038,11 +1134,9 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .join((j) =>
-          j["author"]((jb) => jb.whereIndex("idx_name", (eb) => eb("name", "not in", ["Grace"]))),
-        ),
+      joinAuthor(b.whereIndex("primary"), (author) =>
+        author.whereIndex("idx_name", (eb) => eb("name", "not in", ["Grace"])),
+      ),
     );
 
     const adaPost = posts.find((post) => {
@@ -1171,15 +1265,16 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .join((j) =>
-          j["author"]((jb) =>
-            jb.join((oj) =>
-              oj["org"]((ob) => ob.whereIndex("idx_name", (eb) => eb("name", "=", "Org A"))),
-            ),
-          ),
+      joinAuthor(b.whereIndex("primary"), (author) =>
+        author.joinOne("org", "orgs", (org) =>
+          org
+            .onIndex("primary", (eb) => {
+              const conditionBuilder = eb as ParentAwareConditionBuilder;
+              return conditionBuilder("id", "=", conditionBuilder.parent("orgId"));
+            })
+            .whereIndex("idx_name", (eb) => eb("name", "=", "Org A")),
         ),
+      ),
     );
 
     const post1 = posts.find((post) => {
@@ -1229,7 +1324,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("author", {
           type: "one",
@@ -1284,9 +1380,9 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .join((j) => j["author"]((jb) => jb.whereIndex("idx_age", (eb) => eb("age", ">", 25)))),
+      joinAuthor(b.whereIndex("primary"), (author) =>
+        author.whereIndex("idx_age", (eb) => eb("age", ">", 25)),
+      ),
     );
 
     const youngPost = posts.find((post) => {
@@ -1334,7 +1430,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("author", {
           type: "one",
@@ -1389,11 +1486,9 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .join((j) =>
-          j["author"]((jb) => jb.whereIndex("idx_name", (eb) => eb("name", "not contains", "Ada"))),
-        ),
+      joinAuthor(b.whereIndex("primary"), (author) =>
+        author.whereIndex("idx_name", (eb) => eb("name", "not contains", "Ada")),
+      ),
     );
 
     const adaPost = posts.find((post) => {
@@ -1443,7 +1538,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("author", {
           type: "one",
@@ -1498,13 +1594,11 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b.whereIndex("primary").join((j) =>
-        j["author"]((jb) =>
-          jb.whereIndex("idx_min", (eb) => {
-            const compare = eb as unknown as (col: string, op: "<=", value: unknown) => boolean;
-            return compare("minAge", "<=", appSchema.tables.users.columns.maxAge);
-          }),
-        ),
+      joinAuthor(b.whereIndex("primary"), (author) =>
+        author.whereIndex("idx_min", (eb) => {
+          const compare = eb as unknown as (col: string, op: "<=", value: unknown) => boolean;
+          return compare("minAge", "<=", appSchema.tables.users.columns.maxAge);
+        }),
       ),
     );
 
@@ -1548,7 +1642,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("author", {
           type: "one",
@@ -1603,19 +1698,15 @@ describe("stacked merge", () => {
     ]);
 
     const posts = await query.find("posts", (b) =>
-      b
-        .whereIndex("primary")
-        .join((j) =>
-          j["author"]((jb) =>
-            jb.whereIndex("primary", (eb) =>
-              (eb as unknown as (col: string, op: "=", value: unknown) => boolean)(
-                "id",
-                "=",
-                FragnoId.fromExternal("user-1", 1),
-              ),
-            ),
+      joinAuthor(b.whereIndex("primary"), (author) =>
+        author.whereIndex("primary", (eb) =>
+          (eb as unknown as (col: string, op: "=", value: unknown) => boolean)(
+            "id",
+            "=",
+            FragnoId.fromExternal("user-1", 1),
           ),
         ),
+      ),
     );
 
     const adaPost = posts.find((post) => {
@@ -1658,7 +1749,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addReference("author", {
           type: "one",
@@ -1703,9 +1795,7 @@ describe("stacked merge", () => {
       },
     ]);
 
-    const posts = await query.find("posts", (b) =>
-      b.whereIndex("primary").join((j) => j["author"]()),
-    );
+    const posts = await query.find("posts", (b) => joinAuthor(b.whereIndex("primary")));
 
     const author = (posts[0] as Record<string, unknown>)["author"] as unknown;
     expect(author ?? null).toBeNull();
@@ -1719,13 +1809,15 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
-            .addColumn("title", column("string")),
+            .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"]),
         )
         .addTable("comments", (t) =>
           t
             .addColumn("id", idColumn())
             .addColumn("postId", referenceColumn())
-            .addColumn("body", column("string")),
+            .addColumn("body", column("string"))
+            .createIndex("idx_post", ["postId"]),
         )
         .addReference("posts", {
           type: "many",
@@ -1769,7 +1861,7 @@ describe("stacked merge", () => {
     ]);
 
     const users = await query.find("users", (b) =>
-      b.whereIndex("primary").join((j) => j["posts"]((pb) => pb.join((pj) => pj["comments"]()))),
+      joinPosts(b.whereIndex("primary"), (posts) => joinComments(posts)),
     );
 
     const posts = (users[0] as Record<string, unknown>)["posts"] as Array<Record<string, unknown>>;
@@ -1842,23 +1934,20 @@ describe("stacked merge", () => {
     ]);
 
     const firstPage = await query.findWithCursor("posts", (b) =>
-      b
-        .whereIndex("idx_sort")
-        .orderByIndex("idx_sort", "asc")
-        .pageSize(2)
-        .join((j) => j["author"]()),
+      joinAuthor(b.whereIndex("idx_sort").orderByIndex("idx_sort", "asc").pageSize(2)),
     );
 
     expect(firstPage.items).toHaveLength(2);
     expect(firstPage.hasNextPage).toBe(true);
 
     const secondPage = await query.findWithCursor("posts", (b) =>
-      b
-        .whereIndex("idx_sort")
-        .orderByIndex("idx_sort", "asc")
-        .pageSize(2)
-        .after(firstPage.cursor!)
-        .join((j) => j["author"]()),
+      joinAuthor(
+        b
+          .whereIndex("idx_sort")
+          .orderByIndex("idx_sort", "asc")
+          .pageSize(2)
+          .after(firstPage.cursor!),
+      ),
     );
 
     expect(secondPage.items).toHaveLength(1);
@@ -1876,7 +1965,8 @@ describe("stacked merge", () => {
           t
             .addColumn("id", idColumn())
             .addColumn("orgId", referenceColumn())
-            .addColumn("email", column("string")),
+            .addColumn("email", column("string"))
+            .createIndex("idx_user_org_email", ["orgId", "email"]),
         )
         .addTable("memberships", (t) =>
           t
@@ -1934,9 +2024,7 @@ describe("stacked merge", () => {
       },
     ]);
 
-    const memberships = await query.find("memberships", (b) =>
-      b.whereIndex("primary").join((j) => j["member"]()),
-    );
+    const memberships = await query.find("memberships", (b) => joinMember(b.whereIndex("primary")));
 
     const first = memberships.find((row) => {
       const id = (row as Record<string, unknown>)["id"] as
@@ -1973,6 +2061,7 @@ describe("stacked merge", () => {
             .addColumn("id", idColumn())
             .addColumn("authorId", referenceColumn())
             .addColumn("title", column("string"))
+            .createIndex("idx_author", ["authorId"])
             .createIndex("idx_title", ["title"]),
         )
         .addTable("comments", (t) =>
@@ -1980,6 +2069,7 @@ describe("stacked merge", () => {
             .addColumn("id", idColumn())
             .addColumn("postId", referenceColumn())
             .addColumn("body", column("string"))
+            .createIndex("idx_post", ["postId"])
             .createIndex("idx_body", ["body"]),
         )
         .addReference("posts", {
@@ -2020,12 +2110,9 @@ describe("stacked merge", () => {
     ]);
 
     const users = await query.find("users", (b) =>
-      b.whereIndex("primary").join((j) =>
-        j["posts"]((pb) =>
-          pb
-            .orderByIndex("idx_title", "desc")
-            .pageSize(1)
-            .join((pj) => pj["comments"]((cb) => cb.orderByIndex("idx_body", "asc").pageSize(1))),
+      joinPosts(b.whereIndex("primary"), (posts) =>
+        joinComments(posts.orderByIndex("idx_title", "desc").pageSize(1), (comments) =>
+          comments.orderByIndex("idx_body", "asc").pageSize(1),
         ),
       ),
     );

--- a/packages/lofi/src/adapters/stacked/merge.ts
+++ b/packages/lofi/src/adapters/stacked/merge.ts
@@ -1,45 +1,36 @@
 import type { CursorResult } from "@fragno-dev/db/cursor";
 import { Cursor, createCursorFromRecord, decodeCursor } from "@fragno-dev/db/cursor";
-import type { AnyColumn, AnyRelation, AnySchema, AnyTable } from "@fragno-dev/db/schema";
+import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
 import { FragnoId, FragnoReference } from "@fragno-dev/db/schema";
-import { FindBuilder } from "@fragno-dev/db/unit-of-work";
+import { isParentColumnRef, type CompiledQueryTreeChildNode } from "@fragno-dev/db/unit-of-work";
 
 import type { Condition } from "../../query/conditions";
 import { normalizeValue } from "../../query/normalize";
+import {
+  buildReadPlan,
+  lofiExecuteReadPlan,
+  type LofiExecutableQueryInterface,
+  type LofiReadPlan,
+} from "../../query/read-plan";
 import type { LofiQueryInterface, LofiQueryableAdapter } from "../../types";
 import type { InMemoryLofiAdapter } from "../in-memory/adapter";
 import type { InMemoryLofiRow } from "../in-memory/store";
 import { compareNormalizedValues } from "../in-memory/value-comparison";
 
 type CompiledJoin = {
-  relation: AnyRelation;
-  options:
-    | {
-        select: unknown;
-        where?: unknown;
-        orderBy?: [AnyColumn, "asc" | "desc"][];
-        join?: CompiledJoin[];
-        limit?: number;
-      }
-    | false;
-};
-
-type BuiltFindOptions = {
-  useIndex: string;
-  select?: unknown;
-  where?: unknown;
-  orderByIndex?: {
-    indexName: string;
-    direction: "asc" | "desc";
+  alias: string;
+  table: AnyTable;
+  parentTable: AnyTable;
+  cardinality: "one" | "many";
+  on?: Condition;
+  options: {
+    select: unknown;
+    where?: Condition;
+    orderBy?: [AnyColumn, "asc" | "desc"][];
+    join?: CompiledJoin[];
+    limit?: number;
   };
-  after?: Cursor | string;
-  before?: Cursor | string;
-  pageSize?: number;
-  joins?: CompiledJoin[];
 };
-
-const buildFindBuilder = <TTable extends AnyTable>(tableName: string, table: TTable) =>
-  new FindBuilder<TTable>(tableName, table);
 
 const buildOrderColumns = (table: AnyTable, indexName: string): AnyColumn[] => {
   if (indexName === "_primary") {
@@ -89,6 +80,9 @@ const resolveOrderValue = (value: unknown, column: AnyColumn): unknown => {
     if (value instanceof FragnoId) {
       return coerceLocalInternalId(value.internalId);
     }
+    if (typeof value === "string") {
+      return value;
+    }
     return coerceLocalInternalId(value);
   }
 
@@ -134,104 +128,6 @@ const bytesToHex = (bytes: Uint8Array): string => {
     hex += byte.toString(16).padStart(2, "0");
   }
   return hex;
-};
-
-type JoinCandidates = {
-  internal: unknown[];
-  external: unknown[];
-  normalized: unknown[];
-};
-
-const collectJoinCandidates = (value: unknown, column: AnyColumn): JoinCandidates => {
-  const candidates: JoinCandidates = { internal: [], external: [], normalized: [] };
-  if (isNullish(value)) {
-    return candidates;
-  }
-
-  const pushInternal = (input: unknown) => {
-    const coerced = coerceLocalInternalId(input);
-    if (coerced !== null) {
-      candidates.internal.push(coerced);
-    }
-  };
-
-  const pushExternal = (input: unknown) => {
-    if (input !== undefined) {
-      candidates.external.push(input);
-    }
-  };
-
-  if (value instanceof FragnoId) {
-    pushInternal(value.internalId);
-    pushExternal(value.externalId);
-    return candidates;
-  }
-
-  if (value instanceof FragnoReference) {
-    pushInternal(value.internalId);
-    return candidates;
-  }
-
-  if (typeof value === "object") {
-    if ("internalId" in value) {
-      pushInternal((value as { internalId?: unknown }).internalId);
-    }
-    if (
-      "externalId" in value &&
-      typeof (value as { externalId?: unknown }).externalId === "string"
-    ) {
-      pushExternal((value as { externalId: string }).externalId);
-    }
-  }
-
-  if (column.role === "external-id") {
-    if (typeof value === "string") {
-      pushExternal(value);
-      return candidates;
-    }
-    if (typeof value === "number" || typeof value === "bigint") {
-      pushInternal(value);
-      return candidates;
-    }
-  }
-
-  if (column.role === "reference" || column.role === "internal-id") {
-    if (typeof value === "string") {
-      pushExternal(value);
-      return candidates;
-    }
-    if (typeof value === "number" || typeof value === "bigint") {
-      pushInternal(value);
-      return candidates;
-    }
-  }
-
-  candidates.normalized.push(normalizeValue(value, column));
-  return candidates;
-};
-
-const hasCandidateMatch = (left: unknown[], right: unknown[]): boolean => {
-  for (const leftValue of left) {
-    for (const rightValue of right) {
-      if (compareNormalizedValues(leftValue, rightValue) === 0) {
-        return true;
-      }
-    }
-  }
-  return false;
-};
-
-const matchesJoinCandidates = (left: JoinCandidates, right: JoinCandidates): boolean => {
-  if (left.internal.length > 0 && right.internal.length > 0) {
-    return hasCandidateMatch(left.internal, right.internal);
-  }
-  if (left.external.length > 0 && right.external.length > 0) {
-    return hasCandidateMatch(left.external, right.external);
-  }
-  if (left.normalized.length > 0 && right.normalized.length > 0) {
-    return hasCandidateMatch(left.normalized, right.normalized);
-  }
-  return false;
 };
 
 const getRowValueWithOverlay = (
@@ -280,6 +176,9 @@ const normalizeConditionValue = (value: unknown, column: AnyColumn): unknown => 
     }
     if (typeof value === "number" || typeof value === "bigint") {
       return coerceLocalInternalId(value);
+    }
+    if (typeof value === "string") {
+      return value;
     }
   }
 
@@ -462,6 +361,213 @@ const orderJoinRows = (
   });
 };
 
+const resolveComparableColumn = (column: AnyColumn, table: AnyTable): AnyColumn =>
+  column.role === "external-id" ? table.getInternalIdColumn() : column;
+
+const resolveCorrelatedConditionValue = (options: {
+  value: unknown;
+  column: AnyColumn;
+  row: Record<string, unknown>;
+  currentTable: AnyTable;
+  parentRow: Record<string, unknown>;
+  parentTable: AnyTable;
+  parentOverlayData?: Record<string, unknown>;
+}): { value: unknown; column: AnyColumn } => {
+  const { value, column, row, parentRow, parentOverlayData } = options;
+
+  if (isParentColumnRef(value)) {
+    return {
+      value: getRowValueWithOverlay(parentRow, value.column.name, parentOverlayData),
+      column: value.column,
+    };
+  }
+
+  if (isConditionColumn(value)) {
+    return { value: row[value.name], column: value };
+  }
+
+  return { value, column };
+};
+
+const evaluateCorrelatedCondition = (options: {
+  condition: Condition | undefined;
+  row: Record<string, unknown>;
+  currentTable: AnyTable;
+  parentRow: Record<string, unknown>;
+  parentTable: AnyTable;
+  parentOverlayData?: Record<string, unknown>;
+}): boolean => {
+  const { condition, row, currentTable, parentRow, parentTable, parentOverlayData } = options;
+  if (!condition) {
+    return true;
+  }
+
+  switch (condition.type) {
+    case "and":
+      return condition.items.every((item) =>
+        evaluateCorrelatedCondition({
+          condition: item,
+          row,
+          currentTable,
+          parentRow,
+          parentTable,
+          parentOverlayData,
+        }),
+      );
+    case "or":
+      return condition.items.some((item) =>
+        evaluateCorrelatedCondition({
+          condition: item,
+          row,
+          currentTable,
+          parentRow,
+          parentTable,
+          parentOverlayData,
+        }),
+      );
+    case "not":
+      return !evaluateCorrelatedCondition({
+        condition: condition.item,
+        row,
+        currentTable,
+        parentRow,
+        parentTable,
+        parentOverlayData,
+      });
+    case "compare":
+      break;
+    default: {
+      const exhaustiveCheck: never = condition;
+      throw new Error(`Unsupported condition type: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+
+  const leftSourceColumn = condition.a;
+  let leftColumn = leftSourceColumn;
+  let rightColumn = leftSourceColumn;
+  const right = resolveCorrelatedConditionValue({
+    value: condition.b,
+    column: leftColumn,
+    row,
+    currentTable,
+    parentRow,
+    parentTable,
+    parentOverlayData,
+  });
+  const rightValue = right.value;
+
+  if (isParentColumnRef(condition.b)) {
+    const rawLeftValue = row[leftSourceColumn.name];
+    if (
+      leftColumn.role === "external-id" &&
+      right.column.role !== "external-id" &&
+      typeof rightValue !== "string"
+    ) {
+      leftColumn = resolveComparableColumn(leftColumn, currentTable);
+    }
+    if (
+      right.column.role === "external-id" &&
+      leftColumn.role !== "external-id" &&
+      typeof rawLeftValue !== "string"
+    ) {
+      rightColumn = resolveComparableColumn(right.column, parentTable);
+    } else {
+      rightColumn = right.column;
+    }
+  }
+
+  const leftValue = normalizeConditionValue(row[leftSourceColumn.name], leftColumn);
+
+  if (condition.operator === "is" || condition.operator === "is not") {
+    if (isNullish(rightValue)) {
+      const matches = isNullish(leftValue);
+      return condition.operator === "is" ? matches : !matches;
+    }
+    if (isNullish(leftValue)) {
+      return condition.operator === "is not";
+    }
+    const rightNormalized = normalizeConditionValue(rightValue, rightColumn);
+    const matches = compareNormalizedValues(leftValue, rightNormalized) === 0;
+    return condition.operator === "is" ? matches : !matches;
+  }
+
+  if (condition.operator === "in" || condition.operator === "not in") {
+    const values = Array.isArray(rightValue) ? rightValue : [];
+    let hasNull = false;
+    let hasMatch = false;
+
+    for (const entry of values) {
+      if (isNullish(entry)) {
+        hasNull = true;
+        continue;
+      }
+      const normalized = normalizeConditionValue(entry, leftColumn);
+      if (compareNormalizedValues(leftValue, normalized) === 0) {
+        hasMatch = true;
+        break;
+      }
+    }
+
+    if (hasMatch) {
+      return condition.operator === "in";
+    }
+    if (hasNull) {
+      return false;
+    }
+    return condition.operator === "not in";
+  }
+
+  if (
+    condition.operator === "contains" ||
+    condition.operator === "starts with" ||
+    condition.operator === "ends with" ||
+    condition.operator === "not contains" ||
+    condition.operator === "not starts with" ||
+    condition.operator === "not ends with"
+  ) {
+    const leftLike = normalizeLikeValue(leftValue, leftColumn);
+    const rightLike = normalizeLikeValue(rightValue, rightColumn);
+
+    if (leftLike === null || rightLike === null) {
+      return false;
+    }
+
+    const leftText = leftLike.toLowerCase();
+    const rightText = rightLike.toLowerCase();
+    let matches = false;
+
+    if (condition.operator.includes("contains")) {
+      matches = leftText.includes(rightText);
+    } else if (condition.operator.includes("starts with")) {
+      matches = leftText.startsWith(rightText);
+    } else {
+      matches = leftText.endsWith(rightText);
+    }
+
+    return condition.operator.startsWith("not ") ? !matches : matches;
+  }
+
+  const rightNormalized = normalizeConditionValue(rightValue, rightColumn);
+  const comparison = compareNormalizedValues(leftValue, rightNormalized);
+
+  switch (condition.operator) {
+    case "=":
+      return comparison === 0;
+    case "!=":
+      return comparison !== 0;
+    case ">":
+      return comparison > 0;
+    case ">=":
+      return comparison >= 0;
+    case "<":
+      return comparison < 0;
+    case "<=":
+      return comparison <= 0;
+    default:
+      throw new Error(`Unsupported operator "${condition.operator}".`);
+  }
+};
+
 const matchesJoinOn = (options: {
   parentRow: Record<string, unknown>;
   targetRow: Record<string, unknown>;
@@ -470,37 +576,19 @@ const matchesJoinOn = (options: {
   schemaName: string;
 }): boolean => {
   const { parentRow, targetRow, join, overlay, schemaName } = options;
-  const parentTable = join.relation.referencer;
-  const targetTable = join.relation.table;
-  const parentExternalId = getExternalIdFromRow(parentRow, parentTable);
+  const parentExternalId = getExternalIdFromRow(parentRow, join.parentTable);
   const overlayParent = parentExternalId
-    ? overlay.store.getRow(schemaName, parentTable.name, parentExternalId)
+    ? overlay.store.getRow(schemaName, join.parentTable.name, parentExternalId)
     : undefined;
-  const overlayData = overlayParent?.data;
 
-  for (const [left, right] of join.relation.on) {
-    const leftColumn = parentTable.columns[left];
-    if (!leftColumn) {
-      throw new Error(`Column "${left}" not found on table "${parentTable.name}".`);
-    }
-
-    const rightColumn = targetTable.columns[right];
-    if (!rightColumn) {
-      throw new Error(`Column "${right}" not found on table "${targetTable.name}".`);
-    }
-
-    const leftValue = getRowValueWithOverlay(parentRow, left, overlayData);
-    const rightValue = targetRow[right];
-
-    const leftCandidates = collectJoinCandidates(leftValue, leftColumn);
-    const rightCandidates = collectJoinCandidates(rightValue, rightColumn);
-
-    if (!matchesJoinCandidates(leftCandidates, rightCandidates)) {
-      return false;
-    }
-  }
-
-  return true;
+  return evaluateCorrelatedCondition({
+    condition: join.on,
+    row: targetRow,
+    currentTable: join.table,
+    parentRow,
+    parentTable: join.parentTable,
+    parentOverlayData: overlayParent?.data,
+  });
 };
 
 const buildCursorValues = (
@@ -608,10 +696,12 @@ const buildOutputFromLofiRow = (
 
     if (column.role === "reference") {
       const value = row._lofi.norm[column.name];
-      output[column.name] =
-        value === null || value === undefined
-          ? null
-          : FragnoReference.fromInternal(BigInt(value as number));
+      if (value === null || value === undefined) {
+        const rawValue = row.data[column.name];
+        output[column.name] = rawValue ?? null;
+      } else {
+        output[column.name] = FragnoReference.fromInternal(BigInt(value as number));
+      }
       continue;
     }
 
@@ -666,17 +756,36 @@ const patchJoinRows = async <TSchema extends AnySchema>(options: {
   }
 
   for (const join of joins) {
-    if (join.options === false) {
-      continue;
-    }
-
     const joinOptions = join.options;
-    const relationName = join.relation.name;
+    const relationName = join.alias;
     let target = row[relationName];
 
     if (target !== undefined && target !== null) {
-      const canCheck = (targetRow: Record<string, unknown>) =>
-        join.relation.on.every(([, right]) => right in targetRow);
+      const canCheck = (targetRow: Record<string, unknown>) => {
+        if (!join.on) {
+          return true;
+        }
+
+        const stack: Condition[] = [join.on];
+        while (stack.length > 0) {
+          const next = stack.pop();
+          if (!next) {
+            continue;
+          }
+          if (next.type === "compare") {
+            if (!(next.a.name in targetRow)) {
+              return false;
+            }
+            continue;
+          }
+          if (next.type === "not") {
+            stack.push(next.item);
+            continue;
+          }
+          stack.push(...next.items);
+        }
+        return true;
+      };
 
       const needsRefresh = Array.isArray(target)
         ? target.some(
@@ -718,7 +827,7 @@ const patchJoinRows = async <TSchema extends AnySchema>(options: {
         baseRowsCache,
       });
       if (baseMatches.length > 0) {
-        target = join.relation.type === "many" ? baseMatches : baseMatches[0];
+        target = join.cardinality === "many" ? baseMatches : baseMatches[0];
         row[relationName] = target;
       }
     }
@@ -730,7 +839,7 @@ const patchJoinRows = async <TSchema extends AnySchema>(options: {
     const patchTarget = async (
       targetRow: Record<string, unknown>,
     ): Promise<Record<string, unknown> | null> => {
-      const targetTable = join.relation.table;
+      const targetTable = join.table;
       const externalId = getExternalIdFromRow(targetRow, targetTable);
       if (!externalId) {
         await patchJoinRows({
@@ -810,12 +919,9 @@ async function loadBaseJoinMatches<TSchema extends AnySchema>(options: {
   baseRowsCache: Map<string, Record<string, unknown>[]>;
 }): Promise<Record<string, unknown>[]> {
   const { parentRow, join, overlay, baseQuery, schemaName, baseRowsCache } = options;
-  if (join.options === false) {
-    return [];
-  }
 
   const joinOptions = join.options;
-  const targetTable = join.relation.table;
+  const targetTable = join.table;
   let baseRows = baseRowsCache.get(targetTable.name);
   if (!baseRows) {
     baseRows = (await baseQuery.find(targetTable.name, (b) => b.whereIndex("primary"))) as Record<
@@ -826,6 +932,19 @@ async function loadBaseJoinMatches<TSchema extends AnySchema>(options: {
   }
 
   const matches: Record<string, unknown>[] = [];
+  const matchedIds = new Set<string>();
+
+  const addMatch = (candidate: Record<string, unknown>) => {
+    const externalId = getExternalIdFromRow(candidate, targetTable);
+    if (externalId) {
+      if (matchedIds.has(externalId)) {
+        return;
+      }
+      matchedIds.add(externalId);
+    }
+    matches.push(candidate);
+  };
+
   for (const baseRow of baseRows) {
     if (!matchesJoinOn({ parentRow, targetRow: baseRow, join, overlay, schemaName })) {
       continue;
@@ -833,7 +952,22 @@ async function loadBaseJoinMatches<TSchema extends AnySchema>(options: {
     if (joinOptions.where && !evaluateCondition(joinOptions.where as Condition, baseRow)) {
       continue;
     }
-    matches.push({ ...baseRow });
+    addMatch({ ...baseRow });
+  }
+
+  for (const overlayRow of overlay.store.getTableRows(schemaName, targetTable.name)) {
+    if (overlay.store.hasTombstone(schemaName, targetTable.name, overlayRow.id)) {
+      continue;
+    }
+
+    const candidate = buildOutputFromLofiRow(overlayRow, targetTable, true);
+    if (!matchesJoinOn({ parentRow, targetRow: candidate, join, overlay, schemaName })) {
+      continue;
+    }
+    if (joinOptions.where && !evaluateCondition(joinOptions.where as Condition, candidate)) {
+      continue;
+    }
+    addMatch(candidate);
   }
 
   let ordered = orderJoinRows(matches, joinOptions.orderBy);
@@ -897,11 +1031,8 @@ const stripSelection = (options: {
 
   if (joins) {
     for (const join of joins) {
-      if (join.options === false) {
-        continue;
-      }
       const joinOptions = join.options;
-      const relationName = join.relation.name;
+      const relationName = join.alias;
       const child = stripped[relationName];
       if (!child) {
         continue;
@@ -910,7 +1041,7 @@ const stripSelection = (options: {
         stripped[relationName] = child.map((entry) =>
           stripSelection({
             row: entry as Record<string, unknown>,
-            table: join.relation.table,
+            table: join.table,
             select: joinOptions.select as undefined | true | readonly string[],
             joins: joinOptions.join,
           }),
@@ -918,7 +1049,7 @@ const stripSelection = (options: {
       } else if (typeof child === "object") {
         stripped[relationName] = stripSelection({
           row: child as Record<string, unknown>,
-          table: join.relation.table,
+          table: join.table,
           select: joinOptions.select as undefined | true | readonly string[],
           joins: joinOptions.join,
         });
@@ -948,6 +1079,32 @@ const augmentSelect = (options: {
   const result = Array.from(augmented);
   return result.length === select.length ? select : result;
 };
+
+const compileJoins = (
+  parentTable: AnyTable,
+  children: CompiledQueryTreeChildNode[],
+): CompiledJoin[] =>
+  children.map((child) => ({
+    alias: child.alias,
+    table: child.table,
+    parentTable,
+    cardinality: child.cardinality,
+    on: child.onIndex,
+    options: {
+      select: child.select,
+      where: child.where,
+      orderBy: child.orderByIndex
+        ? buildOrderColumns(child.table, child.orderByIndex.indexName).map(
+            (column) => [column, child.orderByIndex!.direction] as [AnyColumn, "asc" | "desc"],
+          )
+        : undefined,
+      join: compileJoins(child.table, child.children),
+      limit: child.pageSize,
+    },
+  }));
+
+const normalizeIndexName = (indexName: string): "primary" | string =>
+  indexName === "_primary" ? "primary" : indexName;
 
 const mergeRows = (options: {
   baseRows: Record<string, unknown>[];
@@ -1002,6 +1159,20 @@ const mergeRows = (options: {
   return merged;
 };
 
+type StackedFindBuilder = {
+  whereIndex(
+    indexName: string,
+    condition?: (builder: unknown) => Condition | boolean,
+  ): StackedFindBuilder;
+  select(columns: readonly string[]): StackedFindBuilder;
+  orderByIndex(indexName: string, direction: "asc" | "desc"): StackedFindBuilder;
+  after(cursor: Cursor | string): StackedFindBuilder;
+  before(cursor: Cursor | string): StackedFindBuilder;
+  pageSize(size: number): StackedFindBuilder;
+};
+
+type StackedFindBuilderFn = (builder: StackedFindBuilder) => unknown;
+
 export const createStackedQueryEngine = <T extends AnySchema>(options: {
   schema: T;
   base: LofiQueryableAdapter;
@@ -1013,55 +1184,80 @@ export const createStackedQueryEngine = <T extends AnySchema>(options: {
   const overlayQuery = options.overlay.createQueryEngine(options.schema, { schemaName });
 
   const runFind = async (
-    tableName: string,
-    builderFn: ((builder: FindBuilder<AnyTable>) => unknown) | undefined,
-    withCursor: boolean,
-  ): Promise<Record<string, unknown>[] | CursorResult<Record<string, unknown>> | number> => {
-    const tableMap = options.schema.tables as Record<string, AnyTable>;
-    const table = tableMap[tableName];
-    if (!table) {
-      throw new Error(`Table ${tableName} not found in schema`);
-    }
+    query: LofiQueryInterface<T>,
+    tableName: keyof T["tables"] & string,
+    builder: StackedFindBuilderFn,
+  ): Promise<Record<string, unknown>[] | number> =>
+    (await query.find(tableName, builder)) as Record<string, unknown>[] | number;
 
-    const baseFind = baseQuery.find as unknown as (
-      name: string,
-      builder: (builder: FindBuilder<AnyTable>) => unknown,
-    ) => Promise<Record<string, unknown>[] | number>;
-    const baseFindWithCursor = baseQuery.findWithCursor as unknown as (
-      name: string,
-      builder: (builder: FindBuilder<AnyTable>) => unknown,
-    ) => Promise<CursorResult<Record<string, unknown>>>;
-    const overlayFind = overlayQuery.find as unknown as (
-      name: string,
-      builder: (builder: FindBuilder<AnyTable>) => unknown,
-    ) => Promise<Record<string, unknown>[] | number>;
+  const runFindWithCursor = async (
+    query: LofiQueryInterface<T>,
+    tableName: keyof T["tables"] & string,
+    builder: StackedFindBuilderFn,
+  ): Promise<CursorResult<Record<string, unknown>>> =>
+    (await query.findWithCursor(tableName, builder)) as CursorResult<Record<string, unknown>>;
 
-    const builder = buildFindBuilder(tableName, table);
-    if (builderFn) {
-      builderFn(builder);
-    } else {
-      builder.whereIndex("primary");
-    }
+  const buildRootBuilder =
+    (
+      plan: LofiReadPlan,
+      selectOverride?: undefined | true | readonly string[],
+    ): StackedFindBuilderFn =>
+    (builder) => {
+      const useIndex = normalizeIndexName(plan.queryTree.useIndex);
+      if (plan.queryTree.where) {
+        builder.whereIndex(useIndex, () => plan.queryTree.where as Condition);
+      } else {
+        builder.whereIndex(useIndex);
+      }
 
-    const built = builder.build() as
-      | { type: "find"; indexName: string; options: BuiltFindOptions }
-      | { type: "count"; indexName: string; options: Pick<BuiltFindOptions, "where"> };
-
-    if (built.type === "count") {
-      const countBuilder = (b: FindBuilder<AnyTable>) => {
-        if (!built.options.where) {
-          b.whereIndex(built.indexName as "primary");
-          return;
+      if (plan.kind === "find") {
+        const select =
+          selectOverride ?? (plan.queryTree.select as undefined | true | readonly string[]);
+        if (select && select !== true) {
+          builder.select(select as readonly string[]);
         }
-        if (typeof built.options.where === "function") {
-          b.whereIndex(built.indexName as "primary", built.options.where as () => Condition);
-          return;
+        if (plan.queryTree.orderByIndex) {
+          builder.orderByIndex(
+            normalizeIndexName(plan.queryTree.orderByIndex.indexName),
+            plan.queryTree.orderByIndex.direction,
+          );
         }
-        b.whereIndex(built.indexName as "primary", () => built.options.where as Condition);
-      };
+        if (plan.queryTree.after) {
+          builder.after(plan.queryTree.after);
+        }
+        if (plan.queryTree.before) {
+          builder.before(plan.queryTree.before);
+        }
+        if (plan.queryTree.pageSize !== undefined) {
+          builder.pageSize(plan.queryTree.pageSize);
+        }
+      }
 
-      const baseRows = (await baseFind(tableName, countBuilder)) as Record<string, unknown>[];
-      const overlayRows = (await overlayFind(tableName, countBuilder)) as Record<string, unknown>[];
+      return builder;
+    };
+
+  const runPlan = async (
+    plan: LofiReadPlan,
+  ): Promise<
+    | Record<string, unknown>
+    | Record<string, unknown>[]
+    | CursorResult<Record<string, unknown>>
+    | number
+    | null
+  > => {
+    const table = plan.table;
+    const tableName = table.name as keyof T["tables"] & string;
+
+    if (plan.kind === "count") {
+      const rowBuilder = buildRootBuilder(plan);
+      const baseRows = (await runFind(baseQuery, tableName, rowBuilder)) as Record<
+        string,
+        unknown
+      >[];
+      const overlayRows = (await runFind(overlayQuery, tableName, rowBuilder)) as Record<
+        string,
+        unknown
+      >[];
 
       const merged = mergeRows({
         baseRows,
@@ -1075,85 +1271,55 @@ export const createStackedQueryEngine = <T extends AnySchema>(options: {
       return merged.length;
     }
 
-    const orderIndexName = built.options.orderByIndex?.indexName ?? built.indexName;
-    const direction = built.options.orderByIndex?.direction ?? "asc";
+    const joins = compileJoins(table, plan.queryTree.children);
+    const orderIndexName = plan.queryTree.orderByIndex?.indexName ?? plan.queryTree.useIndex;
+    const direction = plan.queryTree.orderByIndex?.direction ?? "asc";
     const orderColumns = buildOrderColumns(table, orderIndexName);
-    const originalSelect = built.options.select as undefined | true | readonly string[];
-    const select = augmentSelect({
-      table,
-      select: originalSelect,
-      orderColumns,
-    });
+    const originalSelect = plan.queryTree.select as undefined | true | readonly string[];
+    const select = augmentSelect({ table, select: originalSelect, orderColumns });
 
-    const overlayPageSize = built.options.pageSize;
-    const overlayBuilder = (b: FindBuilder<AnyTable>) => {
-      if (builderFn) {
-        builderFn(b);
-      } else {
-        b.whereIndex("primary");
-      }
-      if (select && select !== originalSelect) {
-        b.select(select as unknown as true | string[]);
-      }
-      if (overlayPageSize !== undefined) {
-        b.pageSize(overlayPageSize);
-      }
-    };
-
-    const overlayRows = (await overlayFind(tableName, overlayBuilder)) as Record<string, unknown>[];
+    const overlayRows = (await runFind(
+      overlayQuery,
+      tableName,
+      buildRootBuilder(plan, select),
+    )) as Record<string, unknown>[];
 
     const baseRows: Record<string, unknown>[] = [];
     let mergedRows: Record<string, unknown>[] = [];
     let hasNextBase = false;
     let cursor: Cursor | undefined;
 
-    const pageSize = built.options.pageSize;
+    const pageSize = plan.queryTree.pageSize;
     if (pageSize === undefined) {
-      const baseBuilder = (b: FindBuilder<AnyTable>) => {
-        if (builderFn) {
-          builderFn(b);
-        } else {
-          b.whereIndex("primary");
-        }
-        if (select && select !== originalSelect) {
-          b.select(select as unknown as true | string[]);
-        }
-      };
-
-      baseRows.push(...((await baseFind(tableName, baseBuilder)) as Record<string, unknown>[]));
+      baseRows.push(
+        ...((await runFind(baseQuery, tableName, buildRootBuilder(plan, select))) as Record<
+          string,
+          unknown
+        >[]),
+      );
     } else {
-      let nextAfter: Cursor | string | undefined = built.options.after;
-      let nextBefore: Cursor | string | undefined = built.options.before;
+      let nextAfter: Cursor | string | undefined = plan.queryTree.after;
+      let nextBefore: Cursor | string | undefined = plan.queryTree.before;
       let firstPage = true;
-      let keepFetching = true;
 
-      while (keepFetching) {
-        const baseBuilder = (b: FindBuilder<AnyTable>) => {
-          if (builderFn) {
-            builderFn(b);
-          } else {
-            b.whereIndex("primary");
-          }
-          if (select && select !== originalSelect) {
-            b.select(select as unknown as true | string[]);
-          }
-          b.pageSize(pageSize);
+      while (true) {
+        const pageBuilder: StackedFindBuilderFn = (builder) => {
+          buildRootBuilder(plan, select)(builder);
+          builder.pageSize(pageSize);
           if (firstPage) {
             if (nextAfter) {
-              b.after(nextAfter);
+              builder.after(nextAfter);
             }
             if (nextBefore) {
-              b.before(nextBefore);
+              builder.before(nextBefore);
             }
           } else if (cursor) {
-            b.after(cursor);
+            builder.after(cursor);
           }
+          return builder;
         };
 
-        const page = (await baseFindWithCursor(tableName, baseBuilder)) as CursorResult<
-          Record<string, unknown>
-        >;
-
+        const page = await runFindWithCursor(baseQuery, tableName, pageBuilder);
         baseRows.push(...page.items);
         hasNextBase = page.hasNextPage;
         cursor = page.cursor;
@@ -1177,8 +1343,8 @@ export const createStackedQueryEngine = <T extends AnySchema>(options: {
           rows: mergedRows,
           orderColumns,
           direction,
-          after: built.options.after,
-          before: built.options.before,
+          after: plan.queryTree.after,
+          before: plan.queryTree.before,
         });
 
         if (!pageSize || mergedRows.length > pageSize || !hasNextBase) {
@@ -1205,15 +1371,15 @@ export const createStackedQueryEngine = <T extends AnySchema>(options: {
       rows: mergedRows,
       orderColumns,
       direction,
-      after: built.options.after,
-      before: built.options.before,
+      after: plan.queryTree.after,
+      before: plan.queryTree.before,
     });
 
     const baseRowsCache = new Map<string, Record<string, unknown>[]>();
     for (const row of mergedRows) {
       await patchJoinRows({
         row,
-        joins: built.options.joins,
+        joins,
         overlay: options.overlay,
         baseQuery,
         schemaName,
@@ -1221,22 +1387,30 @@ export const createStackedQueryEngine = <T extends AnySchema>(options: {
       });
     }
 
-    if (!withCursor) {
-      const limited =
-        pageSize !== undefined ? mergedRows.slice(0, Math.max(0, pageSize)) : mergedRows;
-      return limited.map((row) =>
+    const strip = (rows: Record<string, unknown>[]) =>
+      rows.map((row) =>
         stripSelection({
           row,
           table,
           select: originalSelect,
-          joins: built.options.joins,
+          joins,
         }),
       );
+
+    if (plan.resultMode === "find") {
+      const limited =
+        pageSize !== undefined ? mergedRows.slice(0, Math.max(0, pageSize)) : mergedRows;
+      return strip(limited);
+    }
+
+    if (plan.resultMode === "findFirst") {
+      const limited =
+        pageSize !== undefined ? mergedRows.slice(0, Math.max(0, pageSize)) : mergedRows;
+      return strip(limited)[0] ?? null;
     }
 
     let hasNextPage = false;
     let items = mergedRows;
-
     if (pageSize && mergedRows.length > pageSize) {
       hasNextPage = true;
       items = mergedRows.slice(0, pageSize);
@@ -1253,56 +1427,45 @@ export const createStackedQueryEngine = <T extends AnySchema>(options: {
     }
 
     return {
-      items: items.map((row) =>
-        stripSelection({
-          row,
-          table,
-          select: originalSelect,
-          joins: built.options.joins,
-        }),
-      ),
+      items: strip(items),
       cursor: nextCursor,
       hasNextPage,
     };
   };
 
-  return {
+  const queryEngine = {
+    [lofiExecuteReadPlan]: runPlan,
+
     async find(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn as unknown as (builder: FindBuilder<AnyTable>) => unknown,
-        false,
-      );
-      return result as Record<string, unknown>[] | number;
+        builderFn,
+        resultMode: "find",
+      });
+      return (await runPlan(plan)) as Record<string, unknown>[] | number;
     },
 
     async findWithCursor(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn as unknown as (builder: FindBuilder<AnyTable>) => unknown,
-        true,
-      );
-      return result as CursorResult<Record<string, unknown>>;
+        builderFn,
+        resultMode: "findWithCursor",
+      });
+      return (await runPlan(plan)) as CursorResult<Record<string, unknown>>;
     },
 
     async findFirst(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn
-          ? (builder: FindBuilder<AnyTable>) => {
-              (builderFn as unknown as (b: FindBuilder<AnyTable>) => unknown)(builder);
-              builder.pageSize(1);
-              return builder;
-            }
-          : (builder: FindBuilder<AnyTable>) => builder.whereIndex("primary").pageSize(1),
-        false,
-      );
-
-      if (typeof result === "number") {
-        return null;
-      }
-
-      return (result as Record<string, unknown>[])[0] ?? null;
+        builderFn,
+        resultMode: "findFirst",
+      });
+      return (await runPlan(plan)) as Record<string, unknown> | number | null;
     },
-  } as LofiQueryInterface<T>;
+  } as LofiExecutableQueryInterface<T>;
+
+  return queryEngine;
 };

--- a/packages/lofi/src/cli/client.ts
+++ b/packages/lofi/src/cli/client.ts
@@ -7,7 +7,14 @@ import { openDB, type IDBPDatabase } from "idb";
 
 import { IndexedDbAdapter, LofiClient, LofiSubmitClient } from "../mod.js";
 import type { LofiSchemaRegistration, LofiSubmitCommandDefinition } from "../types.js";
-import { buildOutboxUrl, coerceNumber, deriveEndpointName, formatError, sleep } from "./utils.js";
+import {
+  buildOutboxUrl,
+  coerceNumber,
+  deriveEndpointName,
+  deriveInternalUrls,
+  formatError,
+  sleep,
+} from "./utils.js";
 import { installIndexedDbGlobals } from "./utils.js";
 
 type ClientModule = {
@@ -186,10 +193,11 @@ export const clientCommand = define({
     let submitClient: LofiSubmitClient<unknown> | undefined;
     const commands = moduleConfig?.commands ?? [];
     if (commands.length > 0) {
+      const { submitUrl, internalUrl } = deriveInternalUrls(outboxUrl);
       submitClient = new LofiSubmitClient({
         endpointName,
-        submitUrl: outboxUrl.replace(/\/_internal\/outbox$/, "/_internal/sync"),
-        internalUrl: outboxUrl.replace(/\/_internal\/outbox$/, "/_internal"),
+        submitUrl,
+        internalUrl,
         adapter,
         schemas: schemas.map((entry) => entry.schema) as AnySchema[],
         commands,

--- a/packages/lofi/src/cli/utils.test.ts
+++ b/packages/lofi/src/cli/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveInternalUrls } from "./utils";
+
+describe("deriveInternalUrls", () => {
+  it("preserves query parameters when deriving submit and internal URLs", () => {
+    expect(
+      deriveInternalUrls("https://example.com/app/_internal/outbox?token=abc&mode=cli"),
+    ).toEqual({
+      submitUrl: "https://example.com/app/_internal/sync?token=abc&mode=cli",
+      internalUrl: "https://example.com/app/_internal?token=abc&mode=cli",
+    });
+  });
+});

--- a/packages/lofi/src/cli/utils.ts
+++ b/packages/lofi/src/cli/utils.ts
@@ -33,6 +33,26 @@ export function buildOutboxUrl(endpoint: string): string {
   return url.toString();
 }
 
+export function deriveInternalUrls(outboxUrl: string): {
+  submitUrl: string;
+  internalUrl: string;
+} {
+  const submitUrl = new URL(outboxUrl);
+  const internalUrl = new URL(outboxUrl);
+
+  if (!submitUrl.pathname.endsWith("/_internal/outbox")) {
+    throw new Error(`Invalid outbox URL: ${outboxUrl}`);
+  }
+
+  internalUrl.pathname = submitUrl.pathname.slice(0, -"/outbox".length);
+  submitUrl.pathname = `${internalUrl.pathname}/sync`;
+
+  return {
+    submitUrl: submitUrl.toString(),
+    internalUrl: internalUrl.toString(),
+  };
+}
+
 export function deriveEndpointName(outboxUrl: string): string {
   const url = new URL(outboxUrl);
   const raw = `${url.host}${url.pathname.replace(/\/_internal\/outbox$/, "")}`;

--- a/packages/lofi/src/indexeddb/adapter.test.ts
+++ b/packages/lofi/src/indexeddb/adapter.test.ts
@@ -207,14 +207,9 @@ describe("IndexedDbAdapter", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string")),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const dbName = createDbName();
@@ -351,14 +346,9 @@ describe("IndexedDbAdapter", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string")),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const dbName = createDbName();

--- a/packages/lofi/src/indexeddb/adapter.test.ts
+++ b/packages/lofi/src/indexeddb/adapter.test.ts
@@ -407,6 +407,113 @@ describe("IndexedDbAdapter", () => {
     db.close();
   });
 
+  it("recreates managed indexes when an existing index definition changes", async () => {
+    const schemaV1 = schema("app", (s) =>
+      s.addTable("users", (t) =>
+        t
+          .addColumn("id", idColumn())
+          .addColumn("name", column("string"))
+          .addColumn("email", column("string"))
+          .createIndex("idx_lookup", ["name"]),
+      ),
+    );
+
+    const dbName = createDbName();
+    const adapterV1 = new IndexedDbAdapter({
+      dbName,
+      endpointName: "app",
+      schemas: [{ schema: schemaV1 }],
+    });
+
+    await adapterV1.getMeta("app::schema_fingerprint");
+
+    const dbBefore = await openDb(dbName);
+    const rowsStoreBefore = dbBefore.transaction("lofi_rows", "readonly").objectStore("lofi_rows");
+    const indexBefore = rowsStoreBefore.index("idx__app__users__idx_lookup");
+    expect(indexBefore.keyPath).toEqual(["endpoint", "schema", "table", "_lofi.norm.name", "id"]);
+    expect(indexBefore.unique).toBe(false);
+    dbBefore.close();
+
+    const schemaV2 = schema("app", (s) =>
+      s.addTable("users", (t) =>
+        t
+          .addColumn("id", idColumn())
+          .addColumn("name", column("string"))
+          .addColumn("email", column("string"))
+          .createIndex("idx_lookup", ["email"], { unique: true }),
+      ),
+    );
+
+    const adapterV2 = new IndexedDbAdapter({
+      dbName,
+      endpointName: "app",
+      schemas: [{ schema: schemaV2 }],
+    });
+
+    await adapterV2.getMeta("app::schema_fingerprint");
+
+    const dbAfter = await openDb(dbName);
+    const rowsStoreAfter = dbAfter.transaction("lofi_rows", "readonly").objectStore("lofi_rows");
+    const indexAfter = rowsStoreAfter.index("idx__app__users__idx_lookup");
+    expect(indexAfter.keyPath).toEqual(["endpoint", "schema", "table", "_lofi.norm.email", "id"]);
+    expect(indexAfter.unique).toBe(true);
+    dbAfter.close();
+  });
+
+  it("clears registered custom cursor state on schema fingerprint changes", async () => {
+    const schemaV1 = schema("app", (s) =>
+      s.addTable("users", (t) => t.addColumn("id", idColumn()).addColumn("name", column("string"))),
+    );
+
+    const dbName = createDbName();
+    const adapterV1 = new IndexedDbAdapter({
+      dbName,
+      endpointName: "app",
+      schemas: [{ schema: schemaV1 }],
+    });
+
+    const customCursorKey = "custom-client::cursor";
+    await adapterV1.applyOutboxEntry({
+      sourceKey: customCursorKey,
+      versionstamp: "vs1",
+      uowId: "uow-vs1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app",
+          table: "users",
+          externalId: "user-1",
+          versionstamp: "vs1",
+          values: { name: "Ada" },
+        },
+      ],
+    });
+    await adapterV1.setMeta(customCursorKey, "vs1");
+
+    const schemaV2 = schema("app", (s) =>
+      s.addTable("users", (t) =>
+        t
+          .addColumn("id", idColumn())
+          .addColumn("name", column("string"))
+          .addColumn("email", column("string"))
+          .createIndex("idx_email", ["email"]),
+      ),
+    );
+
+    const adapterV2 = new IndexedDbAdapter({
+      dbName,
+      endpointName: "app",
+      schemas: [{ schema: schemaV2 }],
+    });
+
+    await adapterV2.getMeta("app::schema_fingerprint");
+
+    const dbAfter = await openDb(dbName);
+    expect(await getInboxRow(dbAfter, [customCursorKey, "uow-vs1", "vs1"])).toBeUndefined();
+    expect(await adapterV2.getMeta(customCursorKey)).toBeUndefined();
+    dbAfter.close();
+  });
+
   it("creates indexes and clears rows on schema fingerprint changes", async () => {
     const schemaV1 = schema("app", (s) =>
       s.addTable("users", (t) =>

--- a/packages/lofi/src/indexeddb/adapter.ts
+++ b/packages/lofi/src/indexeddb/adapter.ts
@@ -197,6 +197,7 @@ export class IndexedDbAdapter implements LofiAdapter, LofiQueryableAdapter {
         receivedAt: Date.now(),
       };
       await inboxStore.put(inboxRow);
+      await registerCursorKey(metaStore, this.endpointName, options.sourceKey);
 
       await tx.done;
       return { applied: true };
@@ -364,6 +365,7 @@ export class IndexedDbAdapter implements LofiAdapter, LofiQueryableAdapter {
 }
 const schemaFingerprintKey = (endpointName: string) => `${endpointName}::schema_fingerprint`;
 const cursorKeyDefault = (endpointName: string) => `${endpointName}::outbox`;
+const cursorKeysRegistryKey = (endpointName: string) => `${endpointName}::cursor_keys`;
 const seqKey = (endpointName: string, schema: string, table: string) =>
   `${endpointName}::seq::${schema}::${table}`;
 
@@ -460,10 +462,6 @@ const ensureIndexes = <TxStores extends ArrayLike<string>>(
 
   for (const index of indexes) {
     const name = `idx__${index.schema}__${index.table}__${index.name}`;
-    if (store.indexNames.contains(name)) {
-      continue;
-    }
-
     const keyPath = [
       "endpoint",
       "schema",
@@ -471,6 +469,14 @@ const ensureIndexes = <TxStores extends ArrayLike<string>>(
       ...index.columns.map((column) => `_lofi.norm.${column}`),
       "id",
     ];
+
+    if (store.indexNames.contains(name)) {
+      const existing = store.index(name);
+      if (isSameIndexDefinition(existing.keyPath, keyPath) && existing.unique === index.unique) {
+        continue;
+      }
+      store.deleteIndex(name);
+    }
 
     store.createIndex(name, keyPath, { unique: index.unique });
   }
@@ -483,16 +489,78 @@ const clearEndpointData = async <TxStores extends ArrayLike<string>>(
   const rowsStore = tx.objectStore(ROWS_STORE);
   const inboxStore = tx.objectStore(INBOX_STORE);
   const metaStore = tx.objectStore(META_STORE);
+  const registeredCursorKeys = await readRegisteredCursorKeys(metaStore, endpointName);
+  const cursorKeys = new Set([cursorKeyDefault(endpointName), ...registeredCursorKeys]);
 
   await deleteRowsForEndpoint(rowsStore, endpointName);
   await deleteWhere(
     inboxStore,
-    (row) => isInboxRow(row) && row.sourceKey.startsWith(`${endpointName}::`),
+    (row) =>
+      isInboxRow(row) &&
+      (row.sourceKey.startsWith(`${endpointName}::`) || cursorKeys.has(row.sourceKey)),
   );
   await deleteWhere(
     metaStore,
-    (row) => isMetaRow(row) && row.key === cursorKeyDefault(endpointName),
+    (row) =>
+      isMetaRow(row) &&
+      (row.key === cursorKeysRegistryKey(endpointName) || cursorKeys.has(row.key)),
   );
+};
+
+const isSameIndexDefinition = (current: string | string[] | null, expected: string[]): boolean => {
+  if (!Array.isArray(current)) {
+    return false;
+  }
+  if (current.length !== expected.length) {
+    return false;
+  }
+  return current.every((value, index) => value === expected[index]);
+};
+
+const readRegisteredCursorKeys = async <TxStores extends ArrayLike<string>>(
+  metaStore: UpgradeStore<TxStores, typeof META_STORE>,
+  endpointName: string,
+): Promise<string[]> => {
+  const row = (await metaStore.get(cursorKeysRegistryKey(endpointName))) as MetaRow | undefined;
+  if (!row?.value) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.value);
+  } catch (error) {
+    throw new Error(`Failed to parse registered cursor keys for endpoint ${endpointName}`, {
+      cause: error,
+    });
+  }
+
+  if (!Array.isArray(parsed) || !parsed.every((value) => typeof value === "string")) {
+    throw new Error(`Registered cursor keys for endpoint ${endpointName} must be a string array`);
+  }
+
+  return parsed;
+};
+
+const registerCursorKey = async <TxStores extends ArrayLike<string>>(
+  metaStore: WriteStore<TxStores, typeof META_STORE>,
+  endpointName: string,
+  cursorKey: string,
+): Promise<void> => {
+  const existing = await metaStore.get(cursorKeysRegistryKey(endpointName));
+  const keys = existing && isMetaRow(existing) ? JSON.parse(existing.value) : [];
+
+  if (!Array.isArray(keys) || !keys.every((value) => typeof value === "string")) {
+    throw new Error(`Registered cursor keys for endpoint ${endpointName} must be a string array`);
+  }
+  if (keys.includes(cursorKey)) {
+    return;
+  }
+
+  await metaStore.put({
+    key: cursorKeysRegistryKey(endpointName),
+    value: JSON.stringify([...keys, cursorKey].sort()),
+  });
 };
 
 const deleteRowsForEndpoint = async <TxStores extends ArrayLike<string>, StoreName extends string>(

--- a/packages/lofi/src/indexeddb/adapter.ts
+++ b/packages/lofi/src/indexeddb/adapter.ts
@@ -1,6 +1,6 @@
 import { generateMigrationFromSchema } from "@fragno-dev/db/client";
 import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
-import { FragnoId, FragnoReference } from "@fragno-dev/db/schema";
+import { FragnoId, FragnoReference, getTableRelations } from "@fragno-dev/db/schema";
 import { openDB, type IDBPDatabase, type IDBPObjectStore, type IDBPTransaction } from "idb";
 
 import { createIndexedDbQueryEngine, type IndexedDbQueryContext } from "../query/engine";
@@ -110,7 +110,7 @@ export class IndexedDbAdapter implements LofiAdapter, LofiQueryableAdapter {
       const tables = new Map<string, AnyTable>();
       for (const [tableName, table] of Object.entries(schema.tables)) {
         tables.set(tableName, table);
-        for (const relation of Object.values(table.relations)) {
+        for (const relation of Object.values(getTableRelations(table))) {
           for (const [fromColumn] of relation.on) {
             referenceTargets.set(`${schema.name}::${table.name}::${fromColumn}`, {
               schema: schema.name,

--- a/packages/lofi/src/optimistic/overlay-manager.test.ts
+++ b/packages/lofi/src/optimistic/overlay-manager.test.ts
@@ -76,7 +76,7 @@ describe("optimistic overlay manager", () => {
     await manager.rebuild();
 
     const query = manager.createQueryEngine(appSchema);
-    const users = await query.find("users");
+    const users = await query.find("users", (b) => b.whereIndex("primary"));
     expect(users).toHaveLength(1);
     expect(users[0].name).toBe("Ada Lovelace");
     const userId = users[0].id as FragnoId;

--- a/packages/lofi/src/query-types.test.ts
+++ b/packages/lofi/src/query-types.test.ts
@@ -37,10 +37,13 @@ describe("AsyncQueryFindFamily", () => {
   type TestSchema = typeof testSchema;
   type Query = AsyncQueryFindFamily<TestSchema>;
 
+  const findUsers = (query: Query) => query.find("users", (b) => b.whereIndex("primary"));
+  const findPostsFirst = (query: Query) => query.findFirst("posts", (b) => b.whereIndex("primary"));
+  const findUsersFirst = (query: Query) => query.findFirst("users", (b) => b.whereIndex("primary"));
+
   describe("findFirst", () => {
     it("returns all columns when select is omitted", () => {
-      const query = {} as Query;
-      type Result = Awaited<ReturnType<typeof query.findFirst<"users">>>;
+      type Result = Awaited<ReturnType<typeof findUsersFirst>>;
 
       expectTypeOf<Result>().toExtend<{
         _id: FragnoId;
@@ -52,9 +55,8 @@ describe("AsyncQueryFindFamily", () => {
     });
 
     it("returns selected columns only", () => {
-      function selectNameAndEmailFirst(query: Query) {
-        return query.findFirst("users", (b) => b.select(["name", "email"]));
-      }
+      const selectNameAndEmailFirst = (query: Query) =>
+        query.findFirst("users", (b) => b.whereIndex("primary").select(["name", "email"]));
 
       type Result = Awaited<ReturnType<typeof selectNameAndEmailFirst>>;
       expectTypeOf<Result>().toExtend<{
@@ -64,9 +66,8 @@ describe("AsyncQueryFindFamily", () => {
     });
 
     it("preserves nullable column types", () => {
-      function selectAge(query: Query) {
-        return query.findFirst("users", (b) => b.select(["age"]));
-      }
+      const selectAge = (query: Query) =>
+        query.findFirst("users", (b) => b.whereIndex("primary").select(["age"]));
 
       type Result = Awaited<ReturnType<typeof selectAge>>;
       type NonNullResult = Exclude<Result, null>;
@@ -76,8 +77,7 @@ describe("AsyncQueryFindFamily", () => {
 
   describe("find", () => {
     it("returns arrays of full rows when select is omitted", () => {
-      const query = {} as Query;
-      type Result = Awaited<ReturnType<typeof query.find<"users">>>;
+      type Result = Awaited<ReturnType<typeof findUsers>>;
 
       expectTypeOf<Result>().toExtend<
         {
@@ -91,9 +91,8 @@ describe("AsyncQueryFindFamily", () => {
     });
 
     it("returns arrays of selected columns only", () => {
-      function selectNameAndEmail(query: Query) {
-        return query.find("users", (b) => b.select(["name", "email"]));
-      }
+      const selectNameAndEmail = (query: Query) =>
+        query.find("users", (b) => b.whereIndex("primary").select(["name", "email"]));
 
       type Result = Awaited<ReturnType<typeof selectNameAndEmail>>;
       type ResultElement = Result[number];
@@ -108,23 +107,29 @@ describe("AsyncQueryFindFamily", () => {
       // @ts-expect-error isActive should not exist on the selected result
       type _IsActiveType = ResultElement["isActive"];
     });
+
+    it("returns number for selectCount", () => {
+      const countUsers = (query: Query) =>
+        query.find("users", (b) => b.whereIndex("primary").selectCount());
+
+      type Result = Awaited<ReturnType<typeof countUsers>>;
+      expectTypeOf<Result>().toEqualTypeOf<number>();
+    });
   });
 
   it("only allows valid table names", () => {
-    const query = {} as Query;
+    const validUsersFind = (query: Query) => query.find("users", (b) => b.whereIndex("primary"));
+    const validPostsFind = (query: Query) => query.find("posts", (b) => b.whereIndex("primary"));
+    const validCommentsFind = (query: Query) =>
+      query.find("comments", (b) => b.whereIndex("primary"));
 
-    type UsersParam = Parameters<typeof query.find<"users">>;
-    type PostsParam = Parameters<typeof query.find<"posts">>;
-    type CommentsParam = Parameters<typeof query.find<"comments">>;
-
-    expectTypeOf<UsersParam>().not.toEqualTypeOf<never>();
-    expectTypeOf<PostsParam>().not.toEqualTypeOf<never>();
-    expectTypeOf<CommentsParam>().not.toEqualTypeOf<never>();
+    expectTypeOf(validUsersFind).not.toEqualTypeOf<never>();
+    expectTypeOf(validPostsFind).not.toEqualTypeOf<never>();
+    expectTypeOf(validCommentsFind).not.toEqualTypeOf<never>();
   });
 
   it("infers column types correctly", () => {
-    const query = {} as Query;
-    type Result = Awaited<ReturnType<typeof query.findFirst<"posts">>>;
+    type Result = Awaited<ReturnType<typeof findPostsFirst>>;
     type Post = Exclude<Result, null>;
 
     expectTypeOf<Post["_id"]>().toEqualTypeOf<FragnoId>();

--- a/packages/lofi/src/query-types.ts
+++ b/packages/lofi/src/query-types.ts
@@ -1,6 +1,12 @@
 import type { CursorResult } from "@fragno-dev/db/cursor";
 import type { AnySchema, AnyTable } from "@fragno-dev/db/schema";
-import type { FindBuilder } from "@fragno-dev/db/unit-of-work";
+import type {
+  ExtractQueryTreeBuilderCount,
+  ExtractQueryTreeBuilderOut,
+  ExtractQueryTreeBuilderSelect,
+} from "@fragno-dev/db/unit-of-work";
+
+import type { LofiFindBuilder } from "./query/read-plan";
 
 type Prettify<T> = {
   [K in keyof T]: T[K];
@@ -28,75 +34,50 @@ type SelectResult<T extends AnyTable, JoinOut, Select extends SelectClause<T>> =
   MainSelectResult<Select, T> & JoinOut
 >;
 
-type ExtractSelect<T> =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends FindBuilder<any, infer TSelect, any>
-    ? TSelect
-    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      T extends Omit<FindBuilder<any, infer TSelect, any>, any>
-      ? TSelect
-      : true;
+type QueryRow<TTable extends AnyTable, TBuilderResult> = SelectResult<
+  TTable,
+  ExtractQueryTreeBuilderOut<TBuilderResult>,
+  Extract<ExtractQueryTreeBuilderSelect<TBuilderResult>, SelectClause<TTable>>
+>;
 
-type ExtractJoinOut<T> =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends FindBuilder<any, any, infer TJoinOut>
-    ? TJoinOut
-    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      T extends Omit<FindBuilder<any, any, infer TJoinOut>, any>
-      ? TJoinOut
-      : {};
+type QueryFindResult<TTable extends AnyTable, TBuilderResult> =
+  ExtractQueryTreeBuilderCount<TBuilderResult> extends true
+    ? number
+    : QueryRow<TTable, TBuilderResult>[];
+
+type QueryFindFirstResult<TTable extends AnyTable, TBuilderResult> =
+  ExtractQueryTreeBuilderCount<TBuilderResult> extends true
+    ? number
+    : QueryRow<TTable, TBuilderResult> | null;
 
 /**
  * Async read helpers used by Lofi query engines.
  * Database-backed Fragno query engines should use createUnitOfWork(...) + uow.find(...).
  */
 export interface AsyncQueryFindFamily<TSchema extends AnySchema> {
-  find: {
-    <TableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
-      table: TableName,
-      builderFn: (
-        builder: Omit<FindBuilder<TSchema["tables"][TableName]>, "build">,
-      ) => TBuilderResult,
-    ): Promise<
-      SelectResult<
-        TSchema["tables"][TableName],
-        ExtractJoinOut<TBuilderResult>,
-        Extract<ExtractSelect<TBuilderResult>, SelectClause<TSchema["tables"][TableName]>>
-      >[]
-    >;
-    <TableName extends keyof TSchema["tables"] & string>(
-      table: TableName,
-    ): Promise<SelectResult<TSchema["tables"][TableName], {}, true>[]>;
-  };
+  find: <TableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    table: TableName,
+    builderFn: (builder: LofiFindBuilder<TSchema, TableName>) => TBuilderResult,
+  ) => Promise<QueryFindResult<TSchema["tables"][TableName], TBuilderResult>>;
 
   findWithCursor: <TableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
     table: TableName,
-    builderFn: (
-      builder: Omit<FindBuilder<TSchema["tables"][TableName]>, "build">,
-    ) => TBuilderResult,
+    builderFn: (builder: LofiFindBuilder<TSchema, TableName>) => TBuilderResult,
   ) => Promise<
     CursorResult<
       SelectResult<
         TSchema["tables"][TableName],
-        ExtractJoinOut<TBuilderResult>,
-        Extract<ExtractSelect<TBuilderResult>, SelectClause<TSchema["tables"][TableName]>>
+        ExtractQueryTreeBuilderOut<TBuilderResult>,
+        Extract<
+          ExtractQueryTreeBuilderSelect<TBuilderResult>,
+          SelectClause<TSchema["tables"][TableName]>
+        >
       >
     >
   >;
 
-  findFirst: {
-    <TableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
-      table: TableName,
-      builderFn: (
-        builder: Omit<FindBuilder<TSchema["tables"][TableName]>, "build">,
-      ) => TBuilderResult,
-    ): Promise<SelectResult<
-      TSchema["tables"][TableName],
-      ExtractJoinOut<TBuilderResult>,
-      Extract<ExtractSelect<TBuilderResult>, SelectClause<TSchema["tables"][TableName]>>
-    > | null>;
-    <TableName extends keyof TSchema["tables"] & string>(
-      table: TableName,
-    ): Promise<SelectResult<TSchema["tables"][TableName], {}, true> | null>;
-  };
+  findFirst: <TableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    table: TableName,
+    builderFn: (builder: LofiFindBuilder<TSchema, TableName>) => TBuilderResult,
+  ) => Promise<QueryFindFirstResult<TSchema["tables"][TableName], TBuilderResult>>;
 }

--- a/packages/lofi/src/query/engine.ts
+++ b/packages/lofi/src/query/engine.ts
@@ -1,7 +1,7 @@
 import type { CursorResult } from "@fragno-dev/db/cursor";
 import { Cursor, createCursorFromRecord, decodeCursor } from "@fragno-dev/db/cursor";
 import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
-import { Column, FragnoId, FragnoReference } from "@fragno-dev/db/schema";
+import { Column, FragnoId, FragnoReference, getTableRelations } from "@fragno-dev/db/schema";
 import {
   getQueryTreeSelectedColumnNames,
   isParentColumnRef,
@@ -320,7 +320,7 @@ const decodeRow = (row: RowSelection, table: AnyTable): Record<string, unknown> 
 
     const relationName = key.slice(0, colonIndex);
     const remainder = key.slice(colonIndex + 1);
-    const relation = table.relations[relationName];
+    const relation = getTableRelations(table)[relationName];
     if (!relation) {
       continue;
     }
@@ -330,7 +330,7 @@ const decodeRow = (row: RowSelection, table: AnyTable): Record<string, unknown> 
   }
 
   for (const relationName in relationData) {
-    const relation = table.relations[relationName];
+    const relation = getTableRelations(table)[relationName];
     if (!relation) {
       continue;
     }

--- a/packages/lofi/src/query/engine.ts
+++ b/packages/lofi/src/query/engine.ts
@@ -2,13 +2,24 @@ import type { CursorResult } from "@fragno-dev/db/cursor";
 import { Cursor, createCursorFromRecord, decodeCursor } from "@fragno-dev/db/cursor";
 import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
 import { Column, FragnoId, FragnoReference } from "@fragno-dev/db/schema";
-import { FindBuilder } from "@fragno-dev/db/unit-of-work";
+import {
+  getQueryTreeSelectedColumnNames,
+  isParentColumnRef,
+  type CompiledQueryTreeChildNode,
+  type CompiledQueryTreeRootNode,
+} from "@fragno-dev/db/unit-of-work";
 import type { IDBPDatabase, IDBPIndex, IDBPObjectStore } from "idb";
 
 import type { ReferenceTarget } from "../indexeddb/types";
 import type { LofiQueryInterface } from "../types";
 import { buildCondition, type Condition, type ConditionBuilder } from "./conditions";
 import { normalizeValue } from "./normalize";
+import {
+  buildReadPlan,
+  lofiExecuteReadPlan,
+  type LofiExecutableQueryInterface,
+  type LofiReadPlan,
+} from "./read-plan";
 
 const ROWS_STORE = "lofi_rows";
 const INDEX_SCHEMA_TABLE = "idx_schema_table";
@@ -1002,9 +1013,6 @@ const applyJoins = async <TxStores extends ArrayLike<string>, StoreName extends 
   return outputs;
 };
 
-const buildFindBuilder = <TTable extends AnyTable>(tableName: string, table: TTable) =>
-  new FindBuilder<TTable>(tableName, table);
-
 type IndexedDbFindOptions<TTable extends AnyTable = AnyTable> = {
   useIndex: string;
   select?: unknown;
@@ -1017,6 +1025,7 @@ type IndexedDbFindOptions<TTable extends AnyTable = AnyTable> = {
   before?: Cursor | string;
   pageSize?: number;
   joins?: CompiledJoin[];
+  queryTree?: CompiledQueryTreeRootNode<TTable>;
 };
 
 type IndexedDbRetrievalOperation =
@@ -1059,6 +1068,21 @@ export const executeIndexedDbRetrievalOperation = async (options: {
   const db = await context.getDb();
   const tx = db.transaction(ROWS_STORE, "readonly");
   const rowsStore = tx.objectStore(ROWS_STORE);
+
+  if (operation.type === "find" && operation.options.queryTree) {
+    const result = await executeIndexedDbReadPlan({
+      plan: {
+        kind: "find",
+        resultMode: operation.withCursor ? "findWithCursor" : "find",
+        table: operation.table,
+        queryTree: operation.options.queryTree,
+      },
+      context,
+      rowsStore,
+    });
+    await tx.done;
+    return result as Record<string, unknown>[] | CursorResult<Record<string, unknown>>;
+  }
 
   const rows = await collectRows({
     rowsStore,
@@ -1237,6 +1261,524 @@ const applyCursorFilters = (options: {
   });
 };
 
+const resolveComparableColumn = (column: AnyColumn, table: AnyTable): AnyColumn =>
+  column.role === "external-id" ? table.getInternalIdColumn() : column;
+
+const getNormalizedRowValue = (row: LofiRow, _table: AnyTable, column: AnyColumn): unknown => {
+  if (column.role === "external-id") {
+    return row.id;
+  }
+  if (column.role === "internal-id") {
+    return row._lofi.internalId;
+  }
+  if (column.role === "version") {
+    return row._lofi.version;
+  }
+  return row._lofi.norm[column.name];
+};
+
+const resolveQueryTreeComparisonValue = async <
+  TxStores extends ArrayLike<string>,
+  StoreName extends string,
+>(options: {
+  value: unknown;
+  column: AnyColumn;
+  currentTable: AnyTable;
+  currentRow: LofiRow;
+  context: QueryContext;
+  rowsStore: ReadStore<TxStores, StoreName>;
+  parentTable?: AnyTable;
+  parentRow?: LofiRow;
+}): Promise<{ value: unknown; column: AnyColumn }> => {
+  const { value, column, currentTable, currentRow, context, rowsStore, parentTable, parentRow } =
+    options;
+
+  if (isParentColumnRef(value)) {
+    if (!parentTable || !parentRow) {
+      throw new Error("Parent column references can only be evaluated for child query-tree nodes.");
+    }
+
+    let leftColumn = column;
+    let parentColumn = value.column;
+
+    if (leftColumn.role === "external-id" && parentColumn.role !== "external-id") {
+      leftColumn = resolveComparableColumn(leftColumn, currentTable);
+    }
+    if (parentColumn.role === "external-id" && leftColumn.role !== "external-id") {
+      parentColumn = resolveComparableColumn(parentColumn, parentTable);
+    }
+
+    return {
+      value: getNormalizedRowValue(parentRow, parentTable, parentColumn),
+      column: parentColumn,
+    };
+  }
+
+  if (value instanceof Column) {
+    return { value: currentRow._lofi.norm[value.name], column: value };
+  }
+
+  if (isDbNow(value)) {
+    return { value: new Date(), column };
+  }
+
+  if (column.role === "reference") {
+    return {
+      value: await resolveReferenceValue({
+        value,
+        column,
+        table: currentTable,
+        schemaName: context.schemaName,
+        endpointName: context.endpointName,
+        rowsStore,
+        referenceTargets: context.referenceTargets,
+      }),
+      column,
+    };
+  }
+
+  return { value: resolveFragnoIdValue(value, column), column };
+};
+
+const evaluateQueryTreeCondition = async <
+  TxStores extends ArrayLike<string>,
+  StoreName extends string,
+>(options: {
+  condition: Condition | undefined;
+  currentTable: AnyTable;
+  currentRow: LofiRow;
+  context: QueryContext;
+  rowsStore: ReadStore<TxStores, StoreName>;
+  parentTable?: AnyTable;
+  parentRow?: LofiRow;
+}): Promise<boolean> => {
+  const { condition, currentTable, currentRow, context, rowsStore, parentTable, parentRow } =
+    options;
+  if (!condition) {
+    return true;
+  }
+
+  switch (condition.type) {
+    case "and": {
+      for (const item of condition.items) {
+        if (
+          !(await evaluateQueryTreeCondition({
+            condition: item,
+            currentTable,
+            currentRow,
+            context,
+            rowsStore,
+            parentTable,
+            parentRow,
+          }))
+        ) {
+          return false;
+        }
+      }
+      return true;
+    }
+    case "or": {
+      for (const item of condition.items) {
+        if (
+          await evaluateQueryTreeCondition({
+            condition: item,
+            currentTable,
+            currentRow,
+            context,
+            rowsStore,
+            parentTable,
+            parentRow,
+          })
+        ) {
+          return true;
+        }
+      }
+      return false;
+    }
+    case "not":
+      return !(await evaluateQueryTreeCondition({
+        condition: condition.item,
+        currentTable,
+        currentRow,
+        context,
+        rowsStore,
+        parentTable,
+        parentRow,
+      }));
+    case "compare":
+      break;
+    default: {
+      const exhaustiveCheck: never = condition;
+      throw new Error(`Unsupported condition type: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+
+  let leftColumn = condition.a;
+  let rightColumn = condition.a;
+  const right = await resolveQueryTreeComparisonValue({
+    value: condition.b,
+    column: leftColumn,
+    currentTable,
+    currentRow,
+    context,
+    rowsStore,
+    parentTable,
+    parentRow,
+  });
+
+  if (isParentColumnRef(condition.b)) {
+    if (leftColumn.role === "external-id" && right.column.role !== "external-id") {
+      leftColumn = resolveComparableColumn(leftColumn, currentTable);
+    }
+    if (right.column.role === "external-id" && leftColumn.role !== "external-id" && parentTable) {
+      rightColumn = resolveComparableColumn(right.column, parentTable);
+    } else {
+      rightColumn = right.column;
+    }
+  }
+
+  const leftValue = getNormalizedRowValue(currentRow, currentTable, leftColumn);
+  const rightValue = right.value;
+  const op = condition.operator;
+
+  if (op === "is" || op === "is not") {
+    if (isNullish(rightValue)) {
+      const matches = isNullish(leftValue);
+      return op === "is" ? matches : !matches;
+    }
+
+    if (isNullish(leftValue)) {
+      return op === "is not";
+    }
+
+    const rightNormalized =
+      rightColumn.role === "reference" || rightColumn.role === "internal-id"
+        ? coerceLocalInternalId(rightValue)
+        : normalizeValue(rightValue, rightColumn);
+    const matches = compareNormalizedValues(leftValue, rightNormalized) === 0;
+    return op === "is" ? matches : !matches;
+  }
+
+  if (isNullish(leftValue) || isNullish(rightValue)) {
+    return false;
+  }
+
+  if (op === "in" || op === "not in") {
+    if (!Array.isArray(rightValue)) {
+      throw new Error(`Operator "${op}" expects an array value.`);
+    }
+
+    const leftNormalized = leftValue;
+    let hasNull = false;
+    let hasMatch = false;
+
+    for (const item of rightValue) {
+      const resolved = await resolveQueryTreeComparisonValue({
+        value: item,
+        column: leftColumn,
+        currentTable,
+        currentRow,
+        context,
+        rowsStore,
+        parentTable,
+        parentRow,
+      });
+      if (isNullish(resolved.value)) {
+        hasNull = true;
+        continue;
+      }
+
+      const normalized =
+        resolved.column.role === "reference" || resolved.column.role === "internal-id"
+          ? coerceLocalInternalId(resolved.value)
+          : normalizeValue(resolved.value, resolved.column);
+      if (compareNormalizedValues(leftNormalized, normalized) === 0) {
+        hasMatch = true;
+        break;
+      }
+    }
+
+    if (hasMatch) {
+      return op === "in";
+    }
+
+    if (hasNull) {
+      return false;
+    }
+
+    return op === "not in";
+  }
+
+  if (
+    op === "contains" ||
+    op === "starts with" ||
+    op === "ends with" ||
+    op === "not contains" ||
+    op === "not starts with" ||
+    op === "not ends with"
+  ) {
+    const leftLike = normalizeLikeValue(leftValue, leftColumn);
+    const rightLike = normalizeLikeValue(rightValue, right.column);
+
+    if (leftLike === null || rightLike === null) {
+      return false;
+    }
+
+    const leftText = leftLike.toLowerCase();
+    const rightText = rightLike.toLowerCase();
+    let matches = false;
+
+    if (op.includes("contains")) {
+      matches = leftText.includes(rightText);
+    } else if (op.includes("starts with")) {
+      matches = leftText.startsWith(rightText);
+    } else {
+      matches = leftText.endsWith(rightText);
+    }
+
+    return op.startsWith("not ") ? !matches : matches;
+  }
+
+  const rightNormalized =
+    rightColumn.role === "reference" || rightColumn.role === "internal-id"
+      ? coerceLocalInternalId(rightValue)
+      : normalizeValue(rightValue, rightColumn);
+  const comparison = compareNormalizedValues(leftValue, rightNormalized);
+
+  switch (op) {
+    case "=":
+      return comparison === 0;
+    case "!=":
+      return comparison !== 0;
+    case ">":
+      return comparison > 0;
+    case ">=":
+      return comparison >= 0;
+    case "<":
+      return comparison < 0;
+    case "<=":
+      return comparison <= 0;
+    default:
+      throw new Error(`Unsupported operator "${op}".`);
+  }
+};
+
+const buildQueryTreeOutput = async <
+  TxStores extends ArrayLike<string>,
+  StoreName extends string,
+>(options: {
+  node: CompiledQueryTreeRootNode | CompiledQueryTreeChildNode;
+  row: LofiRow;
+  context: QueryContext;
+  rowsStore: ReadStore<TxStores, StoreName>;
+  rowsByTable: Map<string, LofiRow[]>;
+}): Promise<Record<string, unknown>> => {
+  const { node, row, context, rowsStore, rowsByTable } = options;
+  const output: Record<string, unknown> = {};
+
+  for (const columnName of getQueryTreeSelectedColumnNames(node.table, node.select)) {
+    const column = node.table.columns[columnName];
+    if (!column || column.isHidden) {
+      continue;
+    }
+    output[columnName] = buildOutputValueForColumn(row, column);
+  }
+
+  for (const child of node.children) {
+    const cacheKey = `${context.schemaName}::${child.table.name}`;
+    let childRows = rowsByTable.get(cacheKey);
+    if (!childRows) {
+      childRows = await collectRows({
+        rowsStore,
+        endpointName: context.endpointName,
+        schemaName: context.schemaName,
+        tableName: child.table.name,
+        indexName: child.onIndexName,
+      });
+      rowsByTable.set(cacheKey, childRows);
+    }
+
+    const matches: LofiRow[] = [];
+    for (const childRow of childRows) {
+      if (
+        !(await evaluateQueryTreeCondition({
+          condition: child.onIndex,
+          currentTable: child.table,
+          currentRow: childRow,
+          context,
+          rowsStore,
+          parentTable: node.table,
+          parentRow: row,
+        }))
+      ) {
+        continue;
+      }
+      if (
+        !(await evaluateQueryTreeCondition({
+          condition: child.where,
+          currentTable: child.table,
+          currentRow: childRow,
+          context,
+          rowsStore,
+        }))
+      ) {
+        continue;
+      }
+      matches.push(childRow);
+    }
+
+    const ordered = child.orderByIndex
+      ? orderRows(
+          matches,
+          buildOrderColumns(child.table, child.orderByIndex.indexName).map(
+            (column) => [column, child.orderByIndex!.direction] as [AnyColumn, "asc" | "desc"],
+          ),
+        )
+      : matches;
+    const limited = child.pageSize !== undefined ? ordered.slice(0, child.pageSize) : ordered;
+    const items = await Promise.all(
+      limited.map((childRow) =>
+        buildQueryTreeOutput({
+          node: child,
+          row: childRow,
+          context,
+          rowsStore,
+          rowsByTable,
+        }),
+      ),
+    );
+
+    output[child.alias] = child.cardinality === "one" ? (items[0] ?? null) : items;
+  }
+
+  return output;
+};
+
+const executeIndexedDbReadPlan = async <
+  TxStores extends ArrayLike<string>,
+  StoreName extends string,
+>(options: {
+  plan: LofiReadPlan;
+  context: QueryContext;
+  rowsStore: ReadStore<TxStores, StoreName>;
+}): Promise<
+  | Record<string, unknown>
+  | Record<string, unknown>[]
+  | CursorResult<Record<string, unknown>>
+  | number
+  | null
+> => {
+  const { plan, context, rowsStore } = options;
+
+  const rootRows = await collectRows({
+    rowsStore,
+    endpointName: context.endpointName,
+    schemaName: context.schemaName,
+    tableName: plan.table.name,
+    indexName: plan.kind === "find" ? plan.queryTree.useIndex : plan.queryTree.useIndex,
+  });
+
+  const matchingRows: LofiRow[] = [];
+  for (const row of rootRows) {
+    if (
+      !(await evaluateQueryTreeCondition({
+        condition: plan.queryTree.where,
+        currentTable: plan.table,
+        currentRow: row,
+        context,
+        rowsStore,
+      }))
+    ) {
+      continue;
+    }
+    matchingRows.push(row);
+  }
+
+  if (plan.kind === "count") {
+    return matchingRows.length;
+  }
+
+  const effectiveOrderBy = plan.queryTree.orderByIndex ?? {
+    indexName: plan.queryTree.useIndex,
+    direction: "asc" as const,
+  };
+  const orderColumns = buildOrderColumns(plan.table, effectiveOrderBy.indexName);
+  const ordered = orderRows(
+    matchingRows,
+    orderColumns.map(
+      (column) => [column, effectiveOrderBy.direction] as [AnyColumn, "asc" | "desc"],
+    ),
+  );
+  const filtered = applyCursorFilters({
+    rows: ordered,
+    orderColumns,
+    direction: effectiveOrderBy.direction,
+    after: plan.queryTree.after,
+    before: plan.queryTree.before,
+  });
+
+  const pageSize = plan.queryTree.pageSize;
+  const windowed =
+    pageSize !== undefined && plan.resultMode === "findWithCursor"
+      ? filtered.slice(0, pageSize + 1)
+      : pageSize !== undefined
+        ? filtered.slice(0, pageSize)
+        : filtered;
+
+  const rowsByTable = new Map<string, LofiRow[]>();
+  const decoded = await Promise.all(
+    windowed.map((row) =>
+      buildQueryTreeOutput({
+        node: plan.queryTree,
+        row,
+        context,
+        rowsStore,
+        rowsByTable,
+      }),
+    ),
+  );
+
+  if (plan.resultMode === "find") {
+    return decoded;
+  }
+
+  if (plan.resultMode === "findFirst") {
+    return decoded[0] ?? null;
+  }
+
+  let items = decoded;
+  let sourceRows = windowed;
+  let hasNextPage = false;
+
+  if (pageSize !== undefined && decoded.length > pageSize) {
+    hasNextPage = true;
+    items = decoded.slice(0, pageSize);
+    sourceRows = windowed.slice(0, pageSize);
+  }
+
+  let cursor: Cursor | undefined;
+  const lastRow = items[items.length - 1];
+  if (lastRow && pageSize) {
+    const cursorRecord: Record<string, unknown> = { ...lastRow };
+    const sourceRow = sourceRows[sourceRows.length - 1];
+    if (sourceRow) {
+      for (const column of orderColumns) {
+        if (cursorRecord[column.name] === undefined) {
+          cursorRecord[column.name] = buildOutputValueForColumn(sourceRow, column);
+        }
+      }
+    }
+
+    cursor = createCursorFromRecord(cursorRecord, orderColumns, {
+      indexName: effectiveOrderBy.indexName,
+      orderDirection: effectiveOrderBy.direction,
+      pageSize,
+    });
+  }
+
+  return { items, cursor, hasNextPage };
+};
+
 export const createIndexedDbQueryEngine = <T extends AnySchema>(options: {
   schema: T;
   endpointName: string;
@@ -1252,88 +1794,62 @@ export const createIndexedDbQueryEngine = <T extends AnySchema>(options: {
     referenceTargets: options.referenceTargets,
   };
 
-  const runFind = async (
-    tableName: string,
-    builderFn: ((builder: FindBuilder<AnyTable>) => unknown) | undefined,
-    withCursor: boolean,
-  ): Promise<Record<string, unknown>[] | CursorResult<Record<string, unknown>> | number> => {
-    const tableMap = options.schema.tables as Record<string, AnyTable>;
-    const table = tableMap[tableName];
-    if (!table) {
-      throw new Error(`Table ${tableName} not found in schema`);
-    }
+  const executePlan = async (plan: LofiReadPlan): Promise<unknown> => {
+    const db = await context.getDb();
+    const tx = db.transaction(ROWS_STORE, "readonly");
+    const rowsStore = tx.objectStore(ROWS_STORE);
 
-    const builder = buildFindBuilder(tableName, table);
-    if (builderFn) {
-      builderFn(builder);
-    } else {
-      builder.whereIndex("primary");
-    }
-
-    const built = builder.build();
-    if (built.type === "count") {
-      return executeIndexedDbRetrievalOperation({
-        operation: {
-          type: "count",
-          table,
-          indexName: built.indexName,
-          options: { where: built.options.where },
-        },
+    try {
+      const result = await executeIndexedDbReadPlan({
+        plan,
         context,
+        rowsStore,
       });
+      await tx.done;
+      return result;
+    } catch (error) {
+      try {
+        await tx.done;
+      } catch {
+        // Ignore transaction completion errors; return the original failure.
+      }
+      throw error;
     }
-
-    return executeIndexedDbRetrievalOperation({
-      operation: {
-        type: "find",
-        table,
-        indexName: built.indexName,
-        options: built.options,
-        withCursor,
-      },
-      context,
-    });
   };
 
   const queryEngine = {
+    [lofiExecuteReadPlan]: executePlan,
+
     async find(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn as unknown as (builder: FindBuilder<AnyTable>) => unknown,
-        false,
-      );
-      return result as Record<string, unknown>[] | number;
+        builderFn,
+        resultMode: "find",
+      });
+      return (await executePlan(plan)) as Record<string, unknown>[] | number;
     },
 
     async findWithCursor(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn as unknown as (builder: FindBuilder<AnyTable>) => unknown,
-        true,
-      );
-      return result as CursorResult<Record<string, unknown>>;
+        builderFn,
+        resultMode: "findWithCursor",
+      });
+      return (await executePlan(plan)) as CursorResult<Record<string, unknown>>;
     },
 
     async findFirst(tableName, builderFn) {
-      const result = await runFind(
+      const plan = buildReadPlan({
+        schema: options.schema,
         tableName,
-        builderFn
-          ? (builder: FindBuilder<AnyTable>) => {
-              (builderFn as unknown as (b: FindBuilder<AnyTable>) => unknown)(builder);
-              builder.pageSize(1);
-              return builder;
-            }
-          : (builder: FindBuilder<AnyTable>) => builder.whereIndex("primary").pageSize(1),
-        false,
-      );
-
-      if (typeof result === "number") {
-        return null;
-      }
-
-      return (result as Record<string, unknown>[])[0] ?? null;
+        builderFn,
+        resultMode: "findFirst",
+      });
+      return (await executePlan(plan)) as Record<string, unknown> | number | null;
     },
-  } as LofiQueryInterface<T>;
+  } as LofiExecutableQueryInterface<T>;
 
   return queryEngine;
 };

--- a/packages/lofi/src/query/query.test.ts
+++ b/packages/lofi/src/query/query.test.ts
@@ -174,7 +174,11 @@ describe("IndexedDbAdapter query engine", () => {
     const query = adapter.createQueryEngine(appSchema);
 
     const joined = await query.find("posts", (b) =>
-      b.whereIndex("idx_author", (eb) => eb("authorId", "=", "user-2")).join((j) => j.author()),
+      b
+        .whereIndex("idx_author", (eb) => eb("authorId", "=", "user-2"))
+        .joinOne("author", "users", (author) =>
+          author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+        ),
     );
 
     expect(joined).toHaveLength(1);

--- a/packages/lofi/src/query/query.test.ts
+++ b/packages/lofi/src/query/query.test.ts
@@ -106,15 +106,10 @@ describe("IndexedDbAdapter query engine", () => {
         .addTable("posts", (t) =>
           t
             .addColumn("id", idColumn())
-            .addColumn("authorId", referenceColumn())
+            .addColumn("authorId", referenceColumn({ table: "users" }))
             .addColumn("title", column("string"))
             .createIndex("idx_author", ["authorId"]),
-        )
-        .addReference("author", {
-          type: "one",
-          from: { table: "posts", column: "authorId" },
-          to: { table: "users", column: "id" },
-        }),
+        ),
     );
 
     const adapter = new IndexedDbAdapter({

--- a/packages/lofi/src/query/read-plan.ts
+++ b/packages/lofi/src/query/read-plan.ts
@@ -1,0 +1,84 @@
+import type { AnySchema, AnyTable } from "@fragno-dev/db/schema";
+import {
+  QueryTreeFindBuilder,
+  type CompiledQueryTreeCountNode,
+  type CompiledQueryTreeRootNode,
+} from "@fragno-dev/db/unit-of-work";
+
+import type { LofiQueryInterface } from "../types";
+
+export type LofiFindBuilder<
+  TSchema extends AnySchema,
+  TTableName extends keyof TSchema["tables"] & string,
+> = Omit<QueryTreeFindBuilder<TSchema, TSchema["tables"][TTableName]>, "build">;
+
+export type LofiReadPlan<TTable extends AnyTable = AnyTable> =
+  | {
+      kind: "count";
+      resultMode: "find" | "findFirst";
+      table: TTable;
+      queryTree: CompiledQueryTreeCountNode<TTable>;
+    }
+  | {
+      kind: "find";
+      resultMode: "find" | "findFirst" | "findWithCursor";
+      table: TTable;
+      queryTree: CompiledQueryTreeRootNode<TTable>;
+    };
+
+export const lofiExecuteReadPlan = Symbol("lofi.executeReadPlan");
+
+export type LofiExecutableQueryInterface<TSchema extends AnySchema> =
+  LofiQueryInterface<TSchema> & {
+    [lofiExecuteReadPlan]: (plan: LofiReadPlan) => Promise<unknown>;
+  };
+
+export const buildReadPlan = <
+  TSchema extends AnySchema,
+  TTableName extends keyof TSchema["tables"] & string,
+>(options: {
+  schema: TSchema;
+  tableName: TTableName;
+  builderFn: (builder: LofiFindBuilder<TSchema, TTableName>) => unknown;
+  resultMode: LofiReadPlan["resultMode"];
+}): LofiReadPlan<TSchema["tables"][TTableName]> => {
+  const { schema, tableName, builderFn, resultMode } = options;
+  const table = schema.tables[tableName];
+  if (!table) {
+    throw new Error(`Table ${tableName} not found in schema`);
+  }
+
+  const builder = new QueryTreeFindBuilder(
+    schema,
+    tableName,
+    table as TSchema["tables"][TTableName],
+  );
+  builderFn(builder as LofiFindBuilder<TSchema, TTableName>);
+  if (resultMode === "findFirst") {
+    builder.pageSize(1);
+  }
+
+  const queryTree = builder.build();
+  if (queryTree.kind === "count") {
+    if (resultMode === "findWithCursor") {
+      throw new Error(
+        `findWithCursor() does not support selectCount() on table "${tableName}". ` +
+          `Use find() or findFirst() instead.`,
+      );
+    }
+
+    return {
+      kind: "count",
+      resultMode,
+      table: table as TSchema["tables"][TTableName],
+      queryTree,
+    };
+  }
+
+  return {
+    kind: "find",
+    resultMode,
+    table: table as TSchema["tables"][TTableName],
+    queryTree,
+  };
+};

--- a/packages/lofi/src/submit/client.test.ts
+++ b/packages/lofi/src/submit/client.test.ts
@@ -101,6 +101,76 @@ describe("LofiSubmitClient", () => {
     expect(commandId).toBeTruthy();
   });
 
+  it("does not re-submit confirmed commands after local rebase failures", async () => {
+    const adapter = new IndexedDbAdapter({
+      dbName: createDbName(),
+      endpointName: "app",
+      schemas: [{ schema: appSchema }],
+    });
+
+    const commandDef: LofiSubmitCommandDefinition = {
+      name: "noop",
+      target: { fragment: "app", schema: "app" },
+      handler: async () => undefined,
+    };
+
+    const overlay = {
+      applyCommand: vi.fn(async () => undefined),
+      rebuild: vi.fn(async () => undefined),
+    };
+    overlay.rebuild.mockRejectedValueOnce(new Error("overlay rebuild failed"));
+
+    const submitBodies: Array<{ requestId: string; commands: Array<{ id: string }> }> = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "https://example.com/_internal") {
+        return new Response(JSON.stringify({ adapterIdentity: "adapter-123" }), { status: 200 });
+      }
+
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      submitBodies.push(body);
+      return new Response(
+        JSON.stringify({
+          status: "applied",
+          requestId: body?.requestId ?? "req",
+          confirmedCommandIds: [body?.commands?.[0]?.id],
+          entries: [],
+        }),
+        { status: 200 },
+      );
+    });
+
+    const client = new LofiSubmitClient({
+      endpointName: "app",
+      submitUrl: "https://example.com/_internal/sync",
+      internalUrl: "https://example.com/_internal",
+      adapter,
+      schemas: [appSchema],
+      commands: [commandDef],
+      overlay,
+      fetch: fetcher as typeof fetch,
+    });
+
+    await client.queueCommand({
+      name: "noop",
+      target: { fragment: "app", schema: "app" },
+      input: {},
+      optimistic: false,
+    });
+
+    await expect(client.submitOnce()).rejects.toThrow("overlay rebuild failed");
+    expect(submitBodies).toHaveLength(1);
+
+    const retried = await client.submitOnce();
+    expect(retried.status).toBe("applied");
+    expect(submitBodies).toHaveLength(1);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    const stored = await adapter.getMeta("app::submit-queue");
+    const deserialized = stored ? superjson.deserialize(JSON.parse(stored)) : null;
+    expect(deserialized).toEqual([]);
+  });
+
   it("routes optimistic commands through the overlay store", async () => {
     const adapter = new IndexedDbAdapter({
       dbName: createDbName(),
@@ -146,11 +216,11 @@ describe("LofiSubmitClient", () => {
     });
 
     const baseQuery = adapter.createQueryEngine(appSchema);
-    const baseUsers = await baseQuery.find("users");
+    const baseUsers = await baseQuery.find("users", (b) => b.whereIndex("primary"));
     expect(baseUsers).toHaveLength(0);
 
     const overlayQuery = overlay.createQueryEngine(appSchema);
-    const overlayUsers = await overlayQuery.find("users");
+    const overlayUsers = await overlayQuery.find("users", (b) => b.whereIndex("primary"));
     expect(overlayUsers).toHaveLength(1);
     expect(overlayUsers[0].email).toBe("ada@example.com");
   });

--- a/packages/lofi/src/submit/client.ts
+++ b/packages/lofi/src/submit/client.ts
@@ -9,7 +9,15 @@ import type {
   LofiQueryableAdapter,
 } from "../types";
 import { createLocalHandlerTx } from "./local-handler-tx";
-import { buildCommandKey, defaultQueueKey, loadSubmitQueue, storeSubmitQueue } from "./queue";
+import {
+  buildCommandKey,
+  defaultQueueKey,
+  loadPendingSubmit,
+  loadSubmitQueue,
+  pendingSubmitKey,
+  storePendingSubmit,
+  storeSubmitQueue,
+} from "./queue";
 import { rebaseSubmitQueue } from "./rebase";
 
 type InternalDescribeResponse = {
@@ -44,6 +52,7 @@ export class LofiSubmitClient<TContext = unknown> {
   private readonly fetcher: typeof fetch;
   private readonly cursorKey: string;
   private readonly queueKey: string;
+  private readonly pendingKey: string;
   private readonly conflictResolutionStrategy: "server" | "disabled";
   private readonly commands: Map<string, LofiSubmitCommandDefinition<unknown, TContext>>;
   private readonly createCommandContext?: SubmitClientOptions<TContext>["createCommandContext"];
@@ -61,6 +70,7 @@ export class LofiSubmitClient<TContext = unknown> {
     this.fetcher = options.fetch ?? defaultFetch;
     this.cursorKey = options.cursorKey ?? `${options.endpointName}::outbox`;
     this.queueKey = options.queueKey ?? defaultQueueKey(options.endpointName);
+    this.pendingKey = pendingSubmitKey(options.endpointName);
     this.conflictResolutionStrategy = options.conflictResolutionStrategy ?? "server";
     this.createCommandContext = options.createCommandContext;
     this.commands = new Map(options.commands.map((command) => [buildCommandKey(command), command]));
@@ -116,34 +126,47 @@ export class LofiSubmitClient<TContext = unknown> {
     });
 
     try {
-      const queue = await loadSubmitQueue(this.adapter, this.queueKey);
-      const adapterIdentity = await this.getAdapterIdentity(options?.signal);
-      const baseVersionstamp = await this.adapter.getMeta(this.cursorKey);
+      let pending = await loadPendingSubmit(this.adapter, this.pendingKey);
 
-      const requestId = crypto.randomUUID();
-      const request: LofiSubmitRequest = {
-        baseVersionstamp: baseVersionstamp ?? undefined,
-        requestId,
-        conflictResolutionStrategy: this.conflictResolutionStrategy,
-        adapterIdentity,
-        commands: queue,
-      };
+      if (!pending) {
+        const queue = await loadSubmitQueue(this.adapter, this.queueKey);
+        const adapterIdentity = await this.getAdapterIdentity(options?.signal);
+        const baseVersionstamp = await this.adapter.getMeta(this.cursorKey);
 
-      const response = await this.fetcher(this.submitUrl, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(request),
-        signal: options?.signal,
-      });
+        const requestId = crypto.randomUUID();
+        const request: LofiSubmitRequest = {
+          baseVersionstamp: baseVersionstamp ?? undefined,
+          requestId,
+          conflictResolutionStrategy: this.conflictResolutionStrategy,
+          adapterIdentity,
+          commands: queue,
+        };
 
-      if (!response.ok) {
-        throw new Error(`Submit request failed: ${response.status} ${response.statusText}`);
+        pending = { request };
+        await storePendingSubmit(this.adapter, this.pendingKey, pending);
       }
 
-      const payload = (await response.json()) as LofiSubmitResponse;
+      let payload = pending.response;
+      if (!payload) {
+        const response = await this.fetcher(this.submitUrl, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(pending.request),
+          signal: options?.signal,
+        });
 
+        if (!response.ok) {
+          throw new Error(`Submit request failed: ${response.status} ${response.statusText}`);
+        }
+
+        payload = (await response.json()) as LofiSubmitResponse;
+        pending = { ...pending, response: payload };
+        await storePendingSubmit(this.adapter, this.pendingKey, pending);
+      }
+
+      const queue = await loadSubmitQueue(this.adapter, this.queueKey);
       const rebased = await rebaseSubmitQueue({
         adapter: this.adapter,
         entries: payload.entries,
@@ -154,6 +177,7 @@ export class LofiSubmitClient<TContext = unknown> {
       });
 
       await storeSubmitQueue(this.adapter, this.queueKey, rebased.queue);
+      await storePendingSubmit(this.adapter, this.pendingKey, undefined);
       return payload;
     } finally {
       resolveSubmitting();

--- a/packages/lofi/src/submit/local-handler-tx.test.ts
+++ b/packages/lofi/src/submit/local-handler-tx.test.ts
@@ -29,15 +29,10 @@ const appSchema = schema("app", (s) => {
     .addTable("posts", (t) =>
       t
         .addColumn("id", idColumn())
-        .addColumn("authorId", referenceColumn())
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .addColumn("title", column("string"))
         .createIndex("idx_author", ["authorId"]),
-    )
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
-    });
+    );
 });
 
 const createDbName = () => `lofi-local-${Math.random().toString(16).slice(2)}`;

--- a/packages/lofi/src/submit/local-handler-tx.test.ts
+++ b/packages/lofi/src/submit/local-handler-tx.test.ts
@@ -79,7 +79,11 @@ describe("local handler tx", () => {
 
     const query = adapter.createQueryEngine(appSchema);
     const posts = await query.find("posts", (b) =>
-      b.whereIndex("idx_author").join((j) => j.author()),
+      b
+        .whereIndex("idx_author")
+        .joinOne("author", "users", (author) =>
+          author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+        ),
     );
 
     expect(posts).toHaveLength(1);

--- a/packages/lofi/src/submit/local-handler-tx.ts
+++ b/packages/lofi/src/submit/local-handler-tx.ts
@@ -3,9 +3,7 @@ import { FragnoId } from "@fragno-dev/db/schema";
 import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
 import type {
   CompiledMutation,
-  FindBuilder,
-  IndexedJoinBuilder,
-  JoinFindBuilder,
+  CompiledQueryTreeRootNode,
   MutationOperation,
   RetrievalOperation,
   UOWCompiler,
@@ -15,9 +13,10 @@ import type {
 
 import { createHandlerTxBuilder, UnitOfWork, type HandlerTxBuilder } from "@fragno-dev/db";
 
-import type { Condition, ConditionBuilder } from "../query/conditions";
+import { buildCondition, type Condition, type ConditionBuilder } from "../query/conditions";
 import type { IndexedDbQueryContext } from "../query/engine";
 import { executeIndexedDbRetrievalOperation } from "../query/engine";
+import { lofiExecuteReadPlan, type LofiExecutableQueryInterface } from "../query/read-plan";
 import type { LofiMutation, LofiQueryInterface, LofiQueryableAdapter } from "../types";
 
 type HandlerTxOptions = Parameters<typeof createHandlerTxBuilder>[0];
@@ -55,7 +54,7 @@ type LocalRetrievalOperation =
         after?: Cursor | string;
         before?: Cursor | string;
         pageSize?: number;
-        joins?: CompiledJoin[];
+        queryTree?: CompiledQueryTreeRootNode;
       };
       withCursor: boolean;
     }
@@ -69,19 +68,6 @@ type LocalRetrievalOperation =
           | Condition;
       };
     };
-
-type CompiledJoin = {
-  relation: { name: string; table: AnyTable; on: [string, string][] };
-  options:
-    | {
-        select: unknown;
-        where?: Condition;
-        orderBy?: [AnyColumn, "asc" | "desc"][];
-        join?: CompiledJoin[];
-        limit?: number;
-      }
-    | false;
-};
 
 export type LocalHandlerQueryExecutor<TContext> = {
   createQueryContext: (schemaName: string) => TContext;
@@ -170,164 +156,87 @@ const resolveQueryContext = <TContext>(
   schema: AnySchema,
 ): TContext => executor.createQueryContext(schema.name);
 
-const normalizeIndexName = (indexName: string): string =>
-  indexName === "_primary" ? "primary" : indexName;
-
-const resolveIndexNameFromOrderBy = (
-  table: AnyTable,
-  orderBy: [AnyColumn, "asc" | "desc"][],
-): string | null => {
-  if (orderBy.length === 0) {
-    return null;
-  }
-
-  const direction = orderBy[0]?.[1];
-  if (!direction || orderBy.some(([, dir]) => dir !== direction)) {
-    return null;
-  }
-
-  const orderColumns = orderBy.map(([column]) => column.name);
-  const idColumn = table.getIdColumn();
-  if (orderColumns.length === 1 && orderColumns[0] === idColumn.name) {
-    return "primary";
-  }
-
-  for (const [indexName, index] of Object.entries(table.indexes)) {
-    const indexColumns = index.columns.map((column) => column.name);
-    if (
-      indexColumns.length === orderColumns.length &&
-      indexColumns.every((name, idx) => name === orderColumns[idx])
-    ) {
-      return indexName;
-    }
-  }
-
-  return null;
-};
-
-const applyCompiledJoins = (
-  builder: IndexedJoinBuilder<AnyTable, {}>,
-  joins: CompiledJoin[] | undefined,
-): IndexedJoinBuilder<AnyTable, {}> => {
-  if (!joins || joins.length === 0) {
-    return builder;
-  }
-
-  let current: Record<string, unknown> = builder as Record<string, unknown>;
-
-  for (const join of joins) {
-    if (join.options === false) {
-      continue;
-    }
-    const joinOptions = join.options;
-
-    const relationName = join.relation.name;
-    const relationBuilder = current[relationName];
-    if (typeof relationBuilder !== "function") {
-      continue;
-    }
-
-    current = relationBuilder((joinBuilder: JoinFindBuilder<AnyTable>) => {
-      if (joinOptions.select && joinOptions.select !== true) {
-        joinBuilder.select(joinOptions.select as unknown as true | string[]);
-      }
-
-      if (joinOptions.where) {
-        joinBuilder.whereIndex("primary", () => joinOptions.where as Condition);
-      }
-
-      if (joinOptions.orderBy && joinOptions.orderBy.length > 0) {
-        const indexName = resolveIndexNameFromOrderBy(join.relation.table, joinOptions.orderBy);
-        const direction = joinOptions.orderBy[0][1];
-        if (indexName) {
-          joinBuilder.orderByIndex(indexName as "primary" | string, direction);
-        }
-      }
-
-      if (joinOptions.limit !== undefined) {
-        joinBuilder.pageSize(joinOptions.limit);
-      }
-
-      if (joinOptions.join && joinOptions.join.length > 0) {
-        joinBuilder.join((nestedBuilder) => applyCompiledJoins(nestedBuilder, joinOptions.join));
-      }
-
-      return joinBuilder;
-    }) as Record<string, unknown>;
-  }
-
-  return current as IndexedJoinBuilder<AnyTable, {}>;
-};
-
-const applyFindOptionsToBuilder = (
-  builder: Omit<FindBuilder<AnyTable>, "build">,
-  operation: LocalRetrievalOperation,
-): void => {
-  const useIndex = normalizeIndexName(
-    operation.type === "count" ? operation.indexName : operation.options.useIndex,
-  ) as "primary" | string;
-  if (operation.options.where) {
-    if (typeof operation.options.where === "function") {
-      builder.whereIndex(useIndex, operation.options.where as () => Condition);
-    } else {
-      builder.whereIndex(useIndex, () => operation.options.where as Condition);
-    }
-  } else {
-    builder.whereIndex(useIndex);
-  }
-
-  if (operation.type === "count") {
-    builder.selectCount();
-    return;
-  }
-
-  if (operation.options.select && operation.options.select !== true) {
-    builder.select(operation.options.select as unknown as true | string[]);
-  }
-
-  if (operation.options.orderByIndex) {
-    builder.orderByIndex(
-      normalizeIndexName(operation.options.orderByIndex.indexName) as "primary" | string,
-      operation.options.orderByIndex.direction,
-    );
-  }
-
-  if (operation.options.after) {
-    builder.after(operation.options.after);
-  }
-
-  if (operation.options.before) {
-    builder.before(operation.options.before);
-  }
-
-  if (operation.options.pageSize !== undefined) {
-    builder.pageSize(operation.options.pageSize);
-  }
-
-  if (operation.options.joins && operation.options.joins.length > 0) {
-    builder.join((joinBuilder) => applyCompiledJoins(joinBuilder, operation.options.joins));
-  }
-};
-
 const executeQueryEngineRetrievalOperation = async (
   operation: LocalRetrievalOperation,
   query: LofiQueryInterface<AnySchema>,
 ): Promise<unknown> => {
-  const tableName = operation.table.name;
-  const builderFn = (builder: Omit<FindBuilder<AnyTable>, "build">) => {
-    applyFindOptionsToBuilder(builder, operation);
-    return builder;
+  const executable = query as LofiExecutableQueryInterface<AnySchema>;
+  const executeReadPlan = executable[lofiExecuteReadPlan];
+  if (!executeReadPlan) {
+    throw new Error(
+      "Local handler tx requires a Lofi query engine that supports canonical read plans.",
+    );
+  }
+
+  const buildWhere = (
+    where:
+      | ((builder: ConditionBuilder<Record<string, AnyColumn>>) => Condition | boolean)
+      | Condition
+      | undefined,
+  ): Condition | undefined | false => {
+    if (!where) {
+      return undefined;
+    }
+    if (typeof where === "function") {
+      const built = buildCondition(operation.table.columns as Record<string, AnyColumn>, where);
+      if (built === true) {
+        return undefined;
+      }
+      return built;
+    }
+    return where;
   };
 
   if (operation.type === "count") {
-    return (query.find as unknown as typeof query.find)(tableName, builderFn);
+    const where = buildWhere(operation.options.where);
+    if (where === false) {
+      return 0;
+    }
+    return executeReadPlan({
+      kind: "count",
+      resultMode: "find",
+      table: operation.table,
+      queryTree: {
+        kind: "count",
+        table: operation.table,
+        useIndex: operation.indexName,
+        where,
+      },
+    });
   }
 
-  if (operation.withCursor) {
-    return (query.findWithCursor as unknown as typeof query.findWithCursor)(tableName, builderFn);
+  const queryTree = operation.options.queryTree;
+  if (queryTree) {
+    return executeReadPlan({
+      kind: "find",
+      resultMode: operation.withCursor ? "findWithCursor" : "find",
+      table: operation.table,
+      queryTree,
+    });
   }
 
-  return (query.find as unknown as typeof query.find)(tableName, builderFn);
+  const where = buildWhere(operation.options.where);
+  if (where === false) {
+    return operation.withCursor ? { items: [], hasNextPage: false } : [];
+  }
+
+  return executeReadPlan({
+    kind: "find",
+    resultMode: operation.withCursor ? "findWithCursor" : "find",
+    table: operation.table,
+    queryTree: {
+      kind: "root",
+      table: operation.table,
+      useIndex: operation.options.useIndex,
+      where,
+      select: (operation.options.select ?? true) as true | readonly string[],
+      orderByIndex: operation.options.orderByIndex,
+      after: operation.options.after,
+      before: operation.options.before,
+      pageSize: operation.options.pageSize,
+      children: [],
+    },
+  });
 };
 
 const getRowVersion = async <TContext>(

--- a/packages/lofi/src/submit/queue.test.ts
+++ b/packages/lofi/src/submit/queue.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import superjson from "superjson";
+
+import { loadSubmitQueue } from "./queue";
+
+describe("loadSubmitQueue", () => {
+  it("throws when persisted queue JSON is invalid", async () => {
+    await expect(
+      loadSubmitQueue(
+        {
+          getMeta: async () => "not-json",
+        },
+        "app::submit-queue",
+      ),
+    ).rejects.toThrow("Failed to decode persisted Lofi meta value for app::submit-queue");
+  });
+
+  it("throws when persisted queue entries are malformed", async () => {
+    await expect(
+      loadSubmitQueue(
+        {
+          getMeta: async () =>
+            JSON.stringify(
+              superjson.serialize([{ id: 123, name: "noop", target: { fragment: "app" } }]),
+            ),
+        },
+        "app::submit-queue",
+      ),
+    ).rejects.toThrow("Submit queue entry at index 0 is missing a valid id");
+  });
+});

--- a/packages/lofi/src/submit/queue.ts
+++ b/packages/lofi/src/submit/queue.ts
@@ -1,15 +1,177 @@
 import superjson from "superjson";
 
-import type { LofiAdapter, LofiSubmitCommand } from "../types";
+import type {
+  LofiAdapter,
+  LofiSubmitCommand,
+  LofiSubmitConflictReason,
+  LofiSubmitRequest,
+  LofiSubmitResponse,
+} from "../types";
 
 export type SubmitQueue = LofiSubmitCommand[];
 
+export type PendingSubmitState = {
+  request: LofiSubmitRequest;
+  response?: LofiSubmitResponse;
+};
+
+const CONFLICT_REASONS = new Set<LofiSubmitConflictReason>([
+  "conflict",
+  "write_congestion",
+  "client_far_behind",
+  "no_commands",
+  "already_handled",
+  "limit_exceeded",
+]);
+
 export const defaultQueueKey = (endpointName: string) => `${endpointName}::submit-queue`;
+export const pendingSubmitKey = (endpointName: string) => `${endpointName}::submit-pending`;
 
 export const buildCommandKey = (command: {
   target: { fragment: string; schema: string };
   name: string;
 }): string => `${command.target.fragment}::${command.target.schema}::${command.name}`;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string";
+
+const decodeMetaValue = (raw: string, key: string): unknown => {
+  try {
+    return superjson.deserialize(JSON.parse(raw));
+  } catch (error) {
+    throw new Error(`Failed to decode persisted Lofi meta value for ${key}`, { cause: error });
+  }
+};
+
+const parseSubmitCommand = (value: unknown, index: number): LofiSubmitCommand => {
+  if (!isRecord(value)) {
+    throw new Error(`Submit queue entry at index ${index} must be an object`);
+  }
+
+  const { id, name, target } = value;
+  if (!isNonEmptyString(id)) {
+    throw new Error(`Submit queue entry at index ${index} is missing a valid id`);
+  }
+  if (!isNonEmptyString(name)) {
+    throw new Error(`Submit queue entry at index ${index} is missing a valid name`);
+  }
+  if (!isRecord(target)) {
+    throw new Error(`Submit queue entry at index ${index} is missing a valid target`);
+  }
+  const fragment = target["fragment"];
+  const schema = target["schema"];
+  if (!isNonEmptyString(fragment) || !isNonEmptyString(schema)) {
+    throw new Error(`Submit queue entry at index ${index} has an invalid target`);
+  }
+
+  return {
+    id,
+    name,
+    target: {
+      fragment,
+      schema,
+    },
+    input: value["input"],
+  };
+};
+
+const parseSubmitQueue = (value: unknown, key: string): SubmitQueue => {
+  if (!Array.isArray(value)) {
+    throw new Error(`Persisted submit queue for ${key} must be an array`);
+  }
+
+  return value.map((entry, index) => parseSubmitCommand(entry, index));
+};
+
+const parseSubmitRequest = (value: unknown, key: string): LofiSubmitRequest => {
+  if (!isRecord(value)) {
+    throw new Error(`Persisted submit request for ${key} must be an object`);
+  }
+
+  const { requestId, adapterIdentity, baseVersionstamp, conflictResolutionStrategy, commands } =
+    value;
+
+  if (!isNonEmptyString(requestId)) {
+    throw new Error(`Persisted submit request for ${key} is missing requestId`);
+  }
+  if (!isNonEmptyString(adapterIdentity)) {
+    throw new Error(`Persisted submit request for ${key} is missing adapterIdentity`);
+  }
+  if (!isOptionalString(baseVersionstamp)) {
+    throw new Error(`Persisted submit request for ${key} has an invalid baseVersionstamp`);
+  }
+  if (conflictResolutionStrategy !== "server" && conflictResolutionStrategy !== "disabled") {
+    throw new Error(
+      `Persisted submit request for ${key} has an invalid conflictResolutionStrategy`,
+    );
+  }
+
+  return {
+    requestId,
+    adapterIdentity,
+    baseVersionstamp,
+    conflictResolutionStrategy,
+    commands: parseSubmitQueue(commands, `${key}.commands`),
+  };
+};
+
+const parseSubmitResponse = (value: unknown, key: string): LofiSubmitResponse => {
+  if (!isRecord(value)) {
+    throw new Error(`Persisted submit response for ${key} must be an object`);
+  }
+
+  const { status, requestId, confirmedCommandIds, entries, lastVersionstamp } = value;
+  if (status !== "applied" && status !== "conflict") {
+    throw new Error(`Persisted submit response for ${key} has an invalid status`);
+  }
+  if (!isNonEmptyString(requestId)) {
+    throw new Error(`Persisted submit response for ${key} is missing requestId`);
+  }
+  if (!Array.isArray(confirmedCommandIds) || !confirmedCommandIds.every(isNonEmptyString)) {
+    throw new Error(`Persisted submit response for ${key} has invalid confirmedCommandIds`);
+  }
+  if (!Array.isArray(entries)) {
+    throw new Error(`Persisted submit response for ${key} has invalid entries`);
+  }
+  if (!isOptionalString(lastVersionstamp)) {
+    throw new Error(`Persisted submit response for ${key} has an invalid lastVersionstamp`);
+  }
+
+  if (status === "applied") {
+    return {
+      status,
+      requestId,
+      confirmedCommandIds,
+      entries,
+      lastVersionstamp,
+    };
+  }
+
+  const reason = value["reason"];
+  const conflictCommandId = value["conflictCommandId"];
+  if (!CONFLICT_REASONS.has(reason as LofiSubmitConflictReason)) {
+    throw new Error(`Persisted submit response for ${key} has an invalid reason`);
+  }
+  if (!isOptionalString(conflictCommandId)) {
+    throw new Error(`Persisted submit response for ${key} has an invalid conflictCommandId`);
+  }
+
+  return {
+    status,
+    requestId,
+    confirmedCommandIds,
+    conflictCommandId,
+    entries,
+    lastVersionstamp,
+    reason: reason as LofiSubmitConflictReason,
+  };
+};
 
 export const loadSubmitQueue = async (
   adapter: Pick<LofiAdapter, "getMeta">,
@@ -20,12 +182,7 @@ export const loadSubmitQueue = async (
     return [];
   }
 
-  try {
-    const parsed = superjson.deserialize(JSON.parse(raw));
-    return Array.isArray(parsed) ? (parsed as SubmitQueue) : [];
-  } catch {
-    return [];
-  }
+  return parseSubmitQueue(decodeMetaValue(raw, key), key);
 };
 
 export const storeSubmitQueue = async (
@@ -34,5 +191,47 @@ export const storeSubmitQueue = async (
   queue: SubmitQueue,
 ): Promise<void> => {
   const serialized = superjson.serialize(queue);
+  await adapter.setMeta(key, JSON.stringify(serialized));
+};
+
+export const loadPendingSubmit = async (
+  adapter: Pick<LofiAdapter, "getMeta">,
+  key: string,
+): Promise<PendingSubmitState | undefined> => {
+  const raw = await adapter.getMeta(key);
+  if (!raw) {
+    return undefined;
+  }
+
+  const decoded = decodeMetaValue(raw, key);
+  if (decoded == null) {
+    return undefined;
+  }
+  if (!isRecord(decoded)) {
+    throw new Error(`Persisted submit state for ${key} must be an object`);
+  }
+
+  const request = parseSubmitRequest(decoded["request"], `${key}.request`);
+  const response =
+    decoded["response"] === undefined
+      ? undefined
+      : parseSubmitResponse(decoded["response"], `${key}.response`);
+
+  if (response && response.requestId !== request.requestId) {
+    throw new Error(`Persisted submit state for ${key} has mismatched request ids`);
+  }
+
+  return {
+    request,
+    ...(response === undefined ? {} : { response }),
+  };
+};
+
+export const storePendingSubmit = async (
+  adapter: Pick<LofiAdapter, "setMeta">,
+  key: string,
+  state: PendingSubmitState | undefined,
+): Promise<void> => {
+  const serialized = superjson.serialize(state ?? null);
   await adapter.setMeta(key, JSON.stringify(serialized));
 };

--- a/packages/lofi/src/testing/outbox-sync.test.ts
+++ b/packages/lofi/src/testing/outbox-sync.test.ts
@@ -205,7 +205,11 @@ describe("outbox sync integration", () => {
       expect(count).toBe(3);
 
       const joined = await query.find("posts", (b) =>
-        b.whereIndex("idx_author").join((j) => j.author()),
+        b
+          .whereIndex("idx_author")
+          .joinOne("author", "users", (author) =>
+            author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+          ),
       );
       expect(joined).toHaveLength(1);
       expect(joined[0].author?.email).toBe("beta@example.com");

--- a/packages/lofi/src/testing/outbox-sync.test.ts
+++ b/packages/lofi/src/testing/outbox-sync.test.ts
@@ -39,15 +39,10 @@ const appSchema = schema("app", (s) => {
     .addTable("posts", (t) =>
       t
         .addColumn("id", idColumn())
-        .addColumn("authorId", referenceColumn())
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .addColumn("title", column("string"))
         .createIndex("idx_author", ["authorId"]),
-    )
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
-    });
+    );
 });
 
 const fragmentName = "lofi-outbox-sync-test";

--- a/packages/lofi/src/testing/scenario.test.ts
+++ b/packages/lofi/src/testing/scenario.test.ts
@@ -189,7 +189,11 @@ const retitlePostHandler = async ({ input, tx }: CommandArgs) => {
       ctx
         .forSchema(appSchema)
         .findFirst("posts", (b) =>
-          b.whereIndex("primary", (eb) => eb("id", "=", payload.postId)).join((j) => j["author"]()),
+          b
+            .whereIndex("primary", (eb) => eb("id", "=", payload.postId))
+            .joinOne("author", "users", (author) =>
+              author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+            ),
         ),
     )
     .transformRetrieve(([post]) => post ?? null)
@@ -218,7 +222,11 @@ const secureRetitlePostHandler = async ({ input, tx, ctx }: CommandArgs) => {
       ctx
         .forSchema(appSchema)
         .findFirst("posts", (b) =>
-          b.whereIndex("primary", (eb) => eb("id", "=", payload.postId)).join((j) => j["author"]()),
+          b
+            .whereIndex("primary", (eb) => eb("id", "=", payload.postId))
+            .joinOne("author", "users", (author) =>
+              author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+            ),
         ),
     )
     .transformRetrieve(([post]) => post ?? null)
@@ -559,7 +567,13 @@ describe("Lofi scenario DSL", () => {
         steps.read(
           "b",
           (_ctx, client) =>
-            client.query.find("posts", (b) => b.whereIndex("primary").join((j) => j["author"]())),
+            client.query.find("posts", (b) =>
+              b
+                .whereIndex("primary")
+                .joinOne("author", "users", (author) =>
+                  author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+                ),
+            ),
           "posts",
         ),
         steps.assert((ctx) => {
@@ -662,7 +676,13 @@ describe("Lofi scenario DSL", () => {
         authSteps.read(
           "b",
           (_ctx, client) =>
-            client.query.find("posts", (b) => b.whereIndex("primary").join((j) => j["author"]())),
+            client.query.find("posts", (b) =>
+              b
+                .whereIndex("primary")
+                .joinOne("author", "users", (author) =>
+                  author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+                ),
+            ),
           "posts",
         ),
         authSteps.assert((ctx) => {
@@ -723,7 +743,13 @@ describe("Lofi scenario DSL", () => {
         authSteps.read(
           "b",
           (_ctx, client) =>
-            client.query.find("posts", (b) => b.whereIndex("primary").join((j) => j["author"]())),
+            client.query.find("posts", (b) =>
+              b
+                .whereIndex("primary")
+                .joinOne("author", "users", (author) =>
+                  author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+                ),
+            ),
           "postsBeforeSubmit",
         ),
         authSteps.read(
@@ -738,7 +764,13 @@ describe("Lofi scenario DSL", () => {
         authSteps.read(
           "b",
           (_ctx, client) =>
-            client.query.find("posts", (b) => b.whereIndex("primary").join((j) => j["author"]())),
+            client.query.find("posts", (b) =>
+              b
+                .whereIndex("primary")
+                .joinOne("author", "users", (author) =>
+                  author.onIndex("primary", (eb) => eb("id", "=", eb.parent("authorId"))),
+                ),
+            ),
           "postsAfterSubmit",
         ),
         authSteps.read(

--- a/packages/lofi/src/testing/scenario.test.ts
+++ b/packages/lofi/src/testing/scenario.test.ts
@@ -38,15 +38,10 @@ const appSchema = schema("app", (s) =>
     .addTable("posts", (t) =>
       t
         .addColumn("id", idColumn())
-        .addColumn("authorId", referenceColumn())
+        .addColumn("authorId", referenceColumn({ table: "users" }))
         .addColumn("title", column("string"))
         .createIndex("idx_author", ["authorId"]),
-    )
-    .addReference("author", {
-      type: "one",
-      from: { table: "posts", column: "authorId" },
-      to: { table: "users", column: "id" },
-    }),
+    ),
 );
 
 type CommandArgs = { input: unknown; tx: LofiSyncCommandTxFactory; ctx: unknown };

--- a/packages/lofi/turbo.json
+++ b/packages/lofi/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/pi-fragment/src/pi/test-utils.ts
+++ b/packages/pi-fragment/src/pi/test-utils.ts
@@ -48,7 +48,7 @@ export function createWorkflowsUnitOfWork(adapter: DatabaseAdapter, name: string
 
 export async function findPiSessions(adapter: DatabaseAdapter) {
   const [rows] = await createPiUnitOfWork(adapter, "find-sessions")
-    .find("session")
+    .find("session", (b) => b.whereIndex("primary"))
     .executeRetrieve();
   return rows;
 }
@@ -68,14 +68,14 @@ export async function createPiSessionRow(
 
 export async function findWorkflowInstances(adapter: DatabaseAdapter) {
   const [rows] = await createWorkflowsUnitOfWork(adapter, "find-workflow-instances")
-    .find("workflow_instance")
+    .find("workflow_instance", (b) => b.whereIndex("primary"))
     .executeRetrieve();
   return rows;
 }
 
 export async function findWorkflowSteps(adapter: DatabaseAdapter) {
   const [rows] = await createWorkflowsUnitOfWork(adapter, "find-workflow-steps")
-    .find("workflow_step")
+    .find("workflow_step", (b) => b.whereIndex("primary"))
     .executeRetrieve();
   return rows;
 }

--- a/packages/resend-fragment/src/definition.ts
+++ b/packages/resend-fragment/src/definition.ts
@@ -322,7 +322,9 @@ const createResendServiceMethods = () => {
           uow.findFirst("emailMessage", (b) =>
             b
               .whereIndex("idx_emailMessage_messageId", (eb) => eb("messageId", "=", messageId))
-              .join((j) => j.emailMessageThread()),
+              .joinOne("emailMessageThread", "emailThread", (thread) =>
+                thread.onIndex("primary", (eb) => eb("id", "=", eb.parent("threadId"))),
+              ),
           ),
         )
         .transformRetrieve(([message]) => message?.emailMessageThread ?? null)

--- a/packages/resend-fragment/src/schema.ts
+++ b/packages/resend-fragment/src/schema.ts
@@ -23,7 +23,7 @@ export const resendSchema = schema("resend", (s) => {
       return (
         t
           .addColumn("id", idColumn())
-          .addColumn("threadId", referenceColumn().nullable())
+          .addColumn("threadId", referenceColumn({ table: "emailThread" }).nullable())
           .addColumn("direction", column("string"))
           // status: queued | scheduled | sending | failed | sent | delivered | bounced |
           // complained | opened | clicked | received
@@ -67,9 +67,5 @@ export const resendSchema = schema("resend", (s) => {
           ])
       );
     })
-    .addReference("emailMessageThread", {
-      type: "one",
-      from: { table: "emailMessage", column: "threadId" },
-      to: { table: "emailThread", column: "id" },
-    });
+    .noOp("removed obsolete emailMessageThread addReference history");
 });

--- a/packages/stripe/turbo.json
+++ b/packages/stripe/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/packages/telegram-fragment/src/schema.ts
+++ b/packages/telegram-fragment/src/schema.ts
@@ -41,8 +41,8 @@ export const telegramSchema = schema("telegram-fragment", (s) => {
     .addTable("chatMember", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("chatId", referenceColumn())
-        .addColumn("userId", referenceColumn())
+        .addColumn("chatId", referenceColumn({ table: "chat" }))
+        .addColumn("userId", referenceColumn({ table: "user" }))
         .addColumn("status", column("string"))
         .addColumn("joinedAt", column("timestamp").nullable())
         .addColumn("leftAt", column("timestamp").nullable())
@@ -63,10 +63,10 @@ export const telegramSchema = schema("telegram-fragment", (s) => {
     .addTable("message", (t) => {
       return t
         .addColumn("id", idColumn())
-        .addColumn("chatId", referenceColumn())
-        .addColumn("fromUserId", referenceColumn().nullable())
-        .addColumn("senderChatId", referenceColumn().nullable())
-        .addColumn("replyToMessageId", referenceColumn().nullable())
+        .addColumn("chatId", referenceColumn({ table: "chat" }))
+        .addColumn("fromUserId", referenceColumn({ table: "user" }).nullable())
+        .addColumn("senderChatId", referenceColumn({ table: "chat" }).nullable())
+        .addColumn("replyToMessageId", referenceColumn({ table: "message" }).nullable())
         .addColumn("messageType", column("string"))
         .addColumn("text", column("string").nullable())
         .addColumn("payload", column("json").nullable())
@@ -82,34 +82,10 @@ export const telegramSchema = schema("telegram-fragment", (s) => {
         .createIndex("idx_message_from", ["fromUserId"])
         .createIndex("idx_message_sent", ["sentAt"]);
     })
-    .addReference("chatMemberChat", {
-      type: "one",
-      from: { table: "chatMember", column: "chatId" },
-      to: { table: "chat", column: "id" },
-    })
-    .addReference("chatMemberUser", {
-      type: "one",
-      from: { table: "chatMember", column: "userId" },
-      to: { table: "user", column: "id" },
-    })
-    .addReference("messageChat", {
-      type: "one",
-      from: { table: "message", column: "chatId" },
-      to: { table: "chat", column: "id" },
-    })
-    .addReference("messageAuthor", {
-      type: "one",
-      from: { table: "message", column: "fromUserId" },
-      to: { table: "user", column: "id" },
-    })
-    .addReference("messageSenderChat", {
-      type: "one",
-      from: { table: "message", column: "senderChatId" },
-      to: { table: "chat", column: "id" },
-    })
-    .addReference("messageReplyTo", {
-      type: "one",
-      from: { table: "message", column: "replyToMessageId" },
-      to: { table: "message", column: "id" },
-    });
+    .noOp("removed obsolete chatMemberChat addReference history")
+    .noOp("removed obsolete chatMemberUser addReference history")
+    .noOp("removed obsolete messageChat addReference history")
+    .noOp("removed obsolete messageAuthor addReference history")
+    .noOp("removed obsolete messageSenderChat addReference history")
+    .noOp("removed obsolete messageReplyTo addReference history");
 });

--- a/packages/telegram-fragment/src/services.ts
+++ b/packages/telegram-fragment/src/services.ts
@@ -971,7 +971,9 @@ export const createTelegramServices = (config: TelegramFragmentConfig) => {
             .find("chatMember", (b) =>
               b
                 .whereIndex("idx_chat_member_chat", (eb) => eb("chatId", "=", chatId))
-                .join((j) => j.chatMemberUser()),
+                .joinOne("chatMemberUser", "user", (user) =>
+                  user.onIndex("primary", (eb) => eb("id", "=", eb.parent("userId"))),
+                ),
             ),
         )
         .transformRetrieve(([chat, members]) => ({
@@ -997,7 +999,9 @@ export const createTelegramServices = (config: TelegramFragmentConfig) => {
               .whereIndex("idx_message_chat_sent", (eb) => eb("chatId", "=", input.chatId))
               .orderByIndex("idx_message_chat_sent", input.order)
               .pageSize(input.pageSize)
-              .join((j) => j.messageAuthor());
+              .joinOne("messageAuthor", "user", (author) =>
+                author.onIndex("primary", (eb) => eb("id", "=", eb.parent("fromUserId"))),
+              );
 
             return input.cursor ? query.after(input.cursor) : query;
           }),

--- a/packages/unplugin-fragno/turbo.json
+++ b/packages/unplugin-fragno/turbo.json
@@ -1,9 +1,6 @@
 {
   "extends": ["//"],
   "tasks": {
-    "types:check": {
-      "dependsOn": ["test"]
-    },
     "test": {
       "outputs": ["$TURBO_EXTENDS$", "coverage.json"]
     }

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -81,3 +81,6 @@ Format:
   — Tasks to implement file-on-success upload semantics, retries, and related updates.
 - [Workflows Reliability Fixes — Implementation Plan](./impl-workflows-smoke-fixes.md) —
   Implementation tasks for the workflows reliability fixes spec.
+- [Fragno Lofi Canonical `find()` Rewrite — Implementation Plan](./impl-lofi-canonical-find-rewrite.md)
+  — Implementation tasks to rewrite `@fragno-dev/lofi` around the canonical read API, remove legacy
+  join/builder coupling, and migrate runtime/tests/docs.

--- a/specs/impl-lofi-canonical-find-rewrite.md
+++ b/specs/impl-lofi-canonical-find-rewrite.md
@@ -1,0 +1,185 @@
+# Fragno Lofi Canonical `find()` Rewrite — Implementation Plan
+
+This plan rewrites `@fragno-dev/lofi` to follow the canonical `@fragno-dev/db` read API.
+
+## Scope
+
+The rewrite should make Lofi align with the current Fragno DB read surface:
+
+- `find()` / `findFirst()` / `findWithCursor()` always use an explicit builder
+- joins use `joinOne(...)` / `joinMany(...)`
+- Lofi no longer depends on legacy relation-builder `.join((j) => ...)`
+- Lofi no longer depends on legacy read-builder internals such as `FindBuilder` and
+  `JoinFindBuilder`
+
+This is a full runtime + test + docs migration, not just a search/replace cleanup.
+
+## References
+
+- `specs/spec-lofi.md`
+- `specs/spec-lofi-submit.md`
+- `specs/references/fragno-db-find-migration-checklist.md`
+- `packages/lofi/src/query-types.ts`
+- `packages/lofi/src/query/engine.ts`
+- `packages/lofi/src/adapters/in-memory/query.ts`
+- `packages/lofi/src/adapters/stacked/merge.ts`
+- `packages/lofi/src/submit/local-handler-tx.ts`
+
+## Goals
+
+- Remove Lofi’s dependence on legacy DB read-builder APIs.
+- Make the public Lofi query interface match the canonical DB read API.
+- Preserve current IndexedDB, in-memory, stacked-overlay, optimistic submit, and scenario behavior.
+- Rewrite test coverage so it validates canonical joins instead of legacy relation joins.
+- Unblock later removal of legacy read-builder internals from `@fragno-dev/db`.
+
+## Non-goals
+
+- Reworking Lofi’s submit/conflict semantics.
+- Redesigning overlay behavior or outbox semantics.
+- Broad docs/template cleanup outside Lofi.
+- Supporting both old and new join APIs long-term.
+
+## Success Criteria
+
+- No `packages/lofi/**` runtime code imports `FindBuilder` / `JoinFindBuilder` from
+  `@fragno-dev/db/unit-of-work` for read execution.
+- No `packages/lofi/**` code uses legacy `.join((j) => ...)`.
+- No `packages/lofi/**` code uses builder-less `find("table")`.
+- `packages/lofi` targeted `types:check` and `test` pass.
+- Full repo `types:check`, `build`, `test`, and `lint` pass after the rewrite.
+
+## Work Plan
+
+### 1. Lock the target Lofi query API
+
+- [ ] Update `packages/lofi/src/query-types.ts` so Lofi’s public query interface mirrors the
+      canonical DB API only.
+- [ ] Remove builder-less overloads from `find(...)` / `findFirst(...)` where Lofi still exposes
+      them.
+- [ ] Ensure join typing is expressed in terms of canonical join output, not legacy relation-join
+      builder output.
+- [ ] Audit `packages/lofi/src/types.ts` and related exports so downstream users only see the new
+      read shape.
+
+### 2. Introduce a canonical read-plan representation inside Lofi
+
+- [ ] Add a shared internal representation for Lofi reads that captures:
+  - root table
+  - selected index / predicates
+  - select clause
+  - ordering
+  - cursor pagination
+  - nested `joinOne(...)` / `joinMany(...)`
+- [ ] Build this around the canonical API shape instead of reconstructing legacy relation joins.
+- [ ] If Lofi needs new support from `@fragno-dev/db`, add a minimal stable surface for the built
+      canonical read description rather than reusing legacy read-builder internals.
+- [ ] Keep this representation shared across IndexedDB, in-memory, stacked merge, and local submit
+      execution so the semantics stay aligned.
+
+### 3. Rewrite the IndexedDB query engine
+
+- [ ] Refactor `packages/lofi/src/query/engine.ts` to execute canonical reads without instantiating
+      legacy `FindBuilder`.
+- [ ] Preserve support for:
+  - `whereIndex(...)`
+  - `select(...)`
+  - `selectCount()`
+  - `orderByIndex(...)`
+  - `after(...)` / `before(...)`
+  - `pageSize(...)`
+  - nested `joinOne(...)` / `joinMany(...)`
+- [ ] Keep `findFirst(...)` semantics aligned with the canonical API.
+- [ ] Ensure returned row typing still matches current `FragnoId` / reference decoding behavior.
+
+### 4. Rewrite the in-memory query engine
+
+- [ ] Refactor `packages/lofi/src/adapters/in-memory/query.ts` to use the same canonical read-plan
+      representation.
+- [ ] Preserve parity with IndexedDB behavior for filtering, sorting, selection, counts, and
+      pagination.
+- [ ] Re-implement nested join expansion using canonical joins instead of legacy relation-builder
+      callbacks.
+- [ ] Keep behavior aligned for null / missing join targets and array joins.
+
+### 5. Rewrite stacked merge around canonical joins
+
+- [ ] Refactor `packages/lofi/src/adapters/stacked/merge.ts` so overlay/base merge logic works from
+      canonical join nodes rather than relation-builder joins.
+- [ ] Preserve existing stacked behaviors covered by tests, including:
+  - overlay patching of joined rows
+  - tombstones suppressing base rows
+  - nested join patching
+  - backfilling overlay-only rows
+  - pagination with overlay rows present
+  - join filters and ordering
+- [ ] Make canonical join handling the only path in merge/backfill logic.
+- [ ] Remove any dependency on legacy relation metadata that exists only to support old joins.
+
+### 6. Rewrite local optimistic handler execution
+
+- [ ] Refactor `packages/lofi/src/submit/local-handler-tx.ts` so optimistic local reads execute via
+      the canonical Lofi read path.
+- [ ] Remove translation through `JoinFindBuilder` / legacy compiled joins.
+- [ ] Keep support for replaying browser-side `handlerTx()` reads used by submit/rebase flows.
+- [ ] Preserve optimistic execution semantics for commands that read related rows before mutating.
+
+### 7. Migrate tests to the canonical API
+
+- [ ] Rewrite `packages/lofi/src/query/query.test.ts` to use canonical joins.
+- [ ] Rewrite `packages/lofi/src/adapters/in-memory/query.test.ts` to use canonical joins.
+- [ ] Rewrite `packages/lofi/src/adapters/stacked/adapter.test.ts` to use canonical joins.
+- [ ] Rewrite `packages/lofi/src/adapters/stacked/merge.test.ts` to use canonical joins.
+- [ ] Rewrite `packages/lofi/src/submit/local-handler-tx.test.ts` to use canonical joins.
+- [ ] Rewrite `packages/lofi/src/testing/outbox-sync.test.ts` to use canonical joins.
+- [ ] Rewrite `packages/lofi/src/testing/scenario.test.ts` remaining legacy reads to use canonical
+      joins.
+- [ ] Replace remaining builder-less test reads in:
+  - `packages/lofi/src/adapters/in-memory/adapter.test.ts`
+  - `packages/lofi/src/optimistic/overlay-manager.test.ts`
+  - `packages/lofi/src/submit/client.test.ts`
+
+### 8. Update public docs and examples in Lofi
+
+- [ ] Update `packages/lofi/README.md` to show explicit-builder `find(...)` usage.
+- [ ] Update README join examples to use `joinOne(...)` / `joinMany(...)`.
+- [ ] Audit any exported snippets/examples in Lofi for legacy joins or builder-less reads.
+
+### 9. Remove legacy coupling from Lofi runtime code
+
+- [ ] Remove read-path imports of `FindBuilder` / `JoinFindBuilder` from Lofi runtime modules.
+- [ ] Ensure any remaining DB dependency is on stable canonical read surfaces only.
+- [ ] Verify Lofi no longer requires old relation-join helper behavior from `@fragno-dev/db`.
+
+### 10. Validation and follow-up cleanup
+
+- [ ] Run `pnpm exec turbo types:check --filter=@fragno-dev/lofi --output-logs=errors-only`
+- [ ] Run `pnpm exec turbo test --filter=@fragno-dev/lofi --output-logs=errors-only`
+- [ ] Re-scan `packages/lofi/**` for legacy `.join((j) => ...)` usage
+- [ ] Re-scan `packages/lofi/**` for builder-less `find("table")` usage
+- [ ] Update `specs/references/fragno-db-find-migration-checklist.md`
+- [ ] Run `pnpm exec turbo types:check --output-logs=errors-only`
+- [ ] Run `pnpm exec turbo build --output-logs=errors-only`
+- [ ] Run `pnpm exec turbo test --output-logs=errors-only`
+- [ ] Run `pnpm run lint`
+
+## Suggested Execution Order
+
+1. Lock the public/query typing surface.
+2. Introduce the shared canonical read-plan representation.
+3. Migrate IndexedDB and in-memory query engines.
+4. Migrate stacked merge.
+5. Migrate `local-handler-tx.ts`.
+6. Rewrite tests.
+7. Update README and migration checklist.
+8. Run package-targeted validation, then repo-wide validation.
+
+## Notes
+
+- The biggest risk area is `packages/lofi/src/adapters/stacked/merge.test.ts`; treat it as the main
+  semantic regression suite for overlay + join behavior.
+- The most important runtime file is `packages/lofi/src/submit/local-handler-tx.ts`; once that is
+  off legacy builders, the remaining DB-internal cleanup becomes much safer.
+- If a small new helper/export is needed from `@fragno-dev/db` to represent built canonical reads,
+  prefer adding that explicitly instead of letting Lofi keep reaching into legacy unit-of-work
+  internals.

--- a/specs/references/fragno-db-find-migration-checklist.md
+++ b/specs/references/fragno-db-find-migration-checklist.md
@@ -1,0 +1,118 @@
+# Fragno DB `find()` migration checklist
+
+The query-tree read API is now the canonical `find()` / `findFirst()` / `findWithCursor()` API in
+`@fragno-dev/db`. `@fragno-dev/db` itself type-checks and tests cleanly after the rename, but the
+rest of the monorepo still contains callers that rely on old relation-join behavior, builder-less
+`find(...)` usage, or outdated docs/examples. This checklist tracks the remaining work before the
+migration can be considered complete.
+
+## Current status
+
+- `@fragno-dev/db` package validation passes
+- full repo `build` passes
+- full repo `types:check` passes again after clearing the next surfaced blockers in
+  `packages/resend-fragment`, `packages/github-app-fragment`, `packages/cloudflare-fragment`, and
+  `packages/pi-fragment`
+- targeted `test` runs now pass for `@fragno-dev/resend-fragment`,
+  `@fragno-dev/github-app-fragment`, `@fragno-dev/cloudflare-fragment`, and
+  `@fragno-dev/pi-fragment`
+- `packages/fragno-test` blockers are fixed
+- `packages/telegram-fragment` blockers are fixed
+- `packages/lofi` typecheck blockers are fixed, and its local handler transaction bridge now
+  translates relation-backed query-tree joins for optimistic execution
+- `packages/auth` targeted `types:check` and `test` now pass after migrating remaining legacy joins
+- latest repo scan shows the remaining old-style relation joins are concentrated in `packages/lofi`
+  (40 hits, mostly tests plus the local-handler relation bridge)
+- the same scan shows remaining builder-less `find(...)` calls in `packages/lofi` (4 test hits plus
+  `packages/lofi/README.md`)
+
+## Checklist
+
+### Immediate repo type-check blockers
+
+- [x] Migrate `packages/fragno-test/src/adapter-conformance.test.ts` off legacy `.join((j) => ...)`
+      calls and rewrite the nested-read assertions to use query-tree joins
+- [x] Migrate `packages/fragno-test/src/db-roundtrip-guard.test.ts` off builder-less
+      `.find("users")` calls to explicit query-tree builders
+- [x] Re-run full repo type-check after fixing the first `@fragno-dev/test` blockers
+- [x] Migrate the first `packages/telegram-fragment` legacy relation joins surfaced by type-check
+- [x] Continue with the next repo-wide blocker in `packages/auth`
+- [x] Continue with the next repo-wide blocker in `packages/resend-fragment`
+- [x] Continue with the next repo-wide blocker in `packages/github-app-fragment`
+- [x] Continue with the next repo-wide blocker in `packages/cloudflare-fragment`
+- [x] Continue with the next repo-wide blocker in `packages/pi-fragment`
+
+### Remaining legacy relation-join migrations (`.join((j) => ...)`)
+
+- [x] Migrate remaining legacy relation joins in `packages/auth/**`
+- [x] Migrate remaining legacy relation joins in `packages/cloudflare-fragment/**`
+- [x] Migrate remaining legacy relation joins in `packages/github-app-fragment/**`
+- [x] Migrate remaining legacy relation joins in `packages/resend-fragment/**`
+- [x] Migrate remaining legacy relation joins in `packages/telegram-fragment/**` (current scan is
+      clean)
+- [x] Migrate remaining legacy relation joins in `apps/docs/**` code examples and snippets
+- [~] Decide what to do with legacy relation-join usage in `packages/lofi/**` (typecheck blockers
+  fixed and optimistic execution now has a relation-backed query-tree bridge; current scan still
+  finds 40 relation-join usages, mostly in tests plus the bridge)
+- [ ] Remove old relation-join-only tests that no longer match the canonical API, or rewrite them as
+      query-tree tests where equivalent coverage is desired
+
+### Remaining builder-less `find(...)` call migrations
+
+- [x] Replace builder-less `find(...)` usage in `apps/backoffice/app/fragno/automation/routes.ts`
+- [x] Replace builder-less `find(...)` usage in `packages/pi-fragment/src/pi/test-utils.ts`
+- [x] Replace builder-less `find(...)` usage in
+      `packages/fragno-test/src/db-roundtrip-guard.test.ts`
+- [~] Replace builder-less `find(...)` usage in `packages/lofi/**` where applicable (current scan
+  finds 4 test call sites plus `packages/lofi/README.md`)
+- [x] Replace builder-less `find(...)` usage in `packages/github-app-fragment/**` tests
+- [~] Replace builder-less `find(...)` usage in docs/README examples such as
+  `packages/lofi/README.md` (current scan only finds `packages/lofi/README.md`)
+
+### Package-by-package migration backlog from the earlier repo scan
+
+- [x] `apps/backoffice`
+- [x] `apps/docs`
+- [x] `example-fragments/fragno-db-library` (current scan clean)
+- [x] `example-fragments/otp-fragment` (current scan clean)
+- [x] `example-fragments/workflow-usage-fragment` (current scan clean)
+- [x] `packages/auth`
+- [x] `packages/cloudflare-fragment`
+- [x] `packages/forms` (current scan clean)
+- [x] `packages/fragment-mailing-list` (current scan clean)
+- [x] `packages/fragment-upload` (current scan clean)
+- [x] `packages/fragment-workflows` (current scan clean)
+- [x] `packages/github-app-fragment`
+- [x] `packages/pi-fragment`
+- [x] `packages/resend-fragment`
+- [x] `packages/stripe` (current scan clean)
+- [x] `packages/telegram-fragment` (current scan clean)
+
+### Documentation and examples cleanup
+
+- [~] Update docs/examples that still describe the migration in terms of `findNew()` (current repo
+  search only finds `specs/references/fragno-db-query-tree-join-api.md`)
+- [x] Update docs/examples that still show relation-builder joins instead of query-tree joins
+- [x] Update templates and example fragments to use canonical `find()` naming consistently
+      (currently tracked examples are clean; deferred template follow-up is out of scope here)
+- [~] Audit README / CLAUDE / MDX snippets for builder-less `find(...)` examples (current scan only
+  finds `packages/lofi/README.md`)
+
+### Internal cleanup after callers are migrated
+
+- [ ] Remove the remaining legacy read-builder internals from
+      `packages/fragno-db/src/query/unit-of-work/unit-of-work.ts` (`FindBuilder`, `JoinFindBuilder`,
+      related old retrieval plumbing) once no callers depend on them
+- [ ] Remove old relation-join helper types from `packages/fragno-db/src/query/mod.ts` and
+      `packages/fragno-db/src/query/find-options.ts` if they are no longer needed
+- [ ] Decide whether legacy relation metadata should remain part of the query type surface, or only
+      runtime schema metadata for non-query features
+- [ ] Revisit `referenceColumn()` / reference-metadata follow-up if the long-term goal is to reduce
+      schema-reference coupling further
+
+### Final validation
+
+- [x] Run `pnpm exec turbo types:check --output-logs=errors-only`
+- [x] Run `pnpm exec turbo build --output-logs=errors-only`
+- [ ] Run `pnpm exec turbo test --output-logs=errors-only`
+- [ ] Run `pnpm run lint`

--- a/specs/references/fragno-db-query-tree-join-api.md
+++ b/specs/references/fragno-db-query-tree-join-api.md
@@ -1,9 +1,10 @@
 # Fragno DB query-tree join API sketch
 
-This document captures the desired shape of a new `findNew()` API for the Fragno DB query engine.
+This document captures the shape of the query-tree `find()` API for the Fragno DB query engine.
 
-The goal is to replace the current relation-join builder with a new **query tree** model while
-keeping the old API around during migration.
+It originally described the `findNew()` migration path. The query-tree API is now the canonical
+`find()` / `findFirst()` / `findWithCursor()` surface, and this document remains the reference for
+its nested-join model.
 
 ## Goals
 
@@ -15,7 +16,7 @@ keeping the old API around during migration.
 
 ## High-level model
 
-- `findNew()` creates a root query node
+- `find()` creates a root query node
 - `joinOne()` creates a child object node
 - `joinMany()` creates a child array node
 - Each child node is attached through `onIndex(...)`
@@ -80,7 +81,7 @@ Later, references may be used as optional sugar, but they should not be required
 ## Root
 
 ```ts
-uow.findNew("posts", (q) =>
+uow.find("posts", (q) =>
   q.whereIndex("primary", (eb) => eb("id", "=", postId)).select(["id", "title", "content"]),
 );
 ```
@@ -164,7 +165,7 @@ Example:
 ## Example: post with comments and comment authors
 
 ```ts
-uow.findNew("posts", (q) =>
+uow.find("posts", (q) =>
   q
     .whereIndex("primary", (eb) => eb("id", "=", postId))
     .select(["id", "title", "content"])
@@ -208,7 +209,7 @@ Equivalent shape for:
 - `comments -> commenter`
 
 ```ts
-uow.findNew("comments", (q) =>
+uow.find("comments", (q) =>
   q
     .whereIndex("primary")
     .select(["id", "text", "post_id", "user_id"])
@@ -286,6 +287,6 @@ This is not a classic flat SQL join API. It is a structured, index-aware graph q
 ## Migration stance
 
 - keep current `find()` join API working
-- add `findNew()` alongside it
-- use `findNew()` to validate the new query tree representation and compiler
+- add `find()` alongside it
+- use `find()` to validate the new query tree representation and compiler
 - later decide whether old joins become sugar over the new tree model

--- a/specs/references/fragno-db-query-tree-join-api.md
+++ b/specs/references/fragno-db-query-tree-join-api.md
@@ -1,0 +1,291 @@
+# Fragno DB query-tree join API sketch
+
+This document captures the desired shape of a new `findNew()` API for the Fragno DB query engine.
+
+The goal is to replace the current relation-join builder with a new **query tree** model while
+keeping the old API around during migration.
+
+## Goals
+
+- Build a **query tree**, not a flat join list
+- Keep joins constrained to **indexes**, like `whereIndex()` and `orderByIndex()`
+- Support nested object/array results naturally
+- Match how the SQL adapter already builds nested results with `json_agg`
+- Avoid requiring the schema `references` system, though references may later become optional sugar
+
+## High-level model
+
+- `findNew()` creates a root query node
+- `joinOne()` creates a child object node
+- `joinMany()` creates a child array node
+- Each child node is attached through `onIndex(...)`
+- `onIndex(...)` uses a new correlated variant of `IndexSpecificConditionBuilder`
+- Correlated join conditions may reference the **direct parent only**
+
+## Core decisions
+
+### Query tree, not flat joins
+
+The new API should model nested results directly:
+
+- root row
+- child objects via `joinOne`
+- child arrays via `joinMany`
+- recursively nested children
+
+### Explicit cardinality
+
+Cardinality is explicit in the API:
+
+- `joinOne(...)` => `T | null`
+- `joinMany(...)` => `T[]`
+
+Do not infer cardinality from references or index uniqueness.
+
+### Direct-parent correlation only
+
+`onIndex(...)` may reference only the **immediate parent**.
+
+This keeps each edge locally plannable and avoids introducing root / ancestor scoping rules in v1.
+
+### `joinOne` first-row semantics
+
+`joinOne()` should not require uniqueness.
+
+If multiple rows match, it should return the first row the database happens to produce.
+
+There should be:
+
+- **no default ordering**
+- no implicit `orderByIndex(...)`
+- no attempt to enforce deterministic selection unless the user explicitly adds ordering/limiting
+
+### Left-join style expansion
+
+For missing children:
+
+- `joinOne(...)` => `null`
+- `joinMany(...)` => `[]`
+
+This API is for shape expansion, not for filtering parents by child existence.
+
+### References are optional sugar
+
+The new API must work without schema references.
+
+Later, references may be used as optional sugar, but they should not be required by the query model.
+
+## Proposed API surface
+
+## Root
+
+```ts
+uow.findNew("posts", (q) =>
+  q.whereIndex("primary", (eb) => eb("id", "=", postId)).select(["id", "title", "content"]),
+);
+```
+
+### Root builder methods
+
+```ts
+whereIndex(indexName, condition?)
+select(columns)
+orderByIndex(indexName, direction)
+pageSize(n)
+joinOne(alias, tableName, builder)
+joinMany(alias, tableName, builder)
+```
+
+## Child nodes
+
+### `joinOne`
+
+```ts
+.joinOne("author", "users", (author) =>
+  author
+    .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+    .select(["id", "name"]),
+)
+```
+
+### `joinMany`
+
+```ts
+.joinMany("comments", "comments", (comments) =>
+  comments
+    .onIndex("comments_post_idx", (eb) => eb("post_id", "=", eb.parent("id")))
+    .select(["id", "text", "user_id"]),
+)
+```
+
+### Child builder methods
+
+```ts
+onIndex(indexName, condition);
+select(columns);
+orderByIndex(indexName, direction);
+pageSize(n);
+joinOne(alias, tableName, builder);
+joinMany(alias, tableName, builder);
+```
+
+## Correlated condition builder
+
+`onIndex(...)` should use a new variant of `IndexSpecificConditionBuilder`.
+
+Suggested mental model:
+
+```ts
+CorrelatedIndexSpecificConditionBuilder<TChildTable, TParentTable, TIndexName>;
+```
+
+It should behave like the existing index-specific builder, but add:
+
+```ts
+eb.parent("columnName");
+```
+
+Example:
+
+```ts
+.onIndex("comments_post_idx", (eb) =>
+  eb("post_id", "=", eb.parent("id")),
+)
+```
+
+## Rules for `eb.parent(...)`
+
+- only references the **direct parent**
+- uses logical column names
+- only valid inside `onIndex(...)`
+- intended primarily for equality-based correlation
+- compiler may perform the same column/id coercions already used elsewhere in the query engine
+
+## Example: post with comments and comment authors
+
+```ts
+uow.findNew("posts", (q) =>
+  q
+    .whereIndex("primary", (eb) => eb("id", "=", postId))
+    .select(["id", "title", "content"])
+    .joinMany("comments", "comments", (comments) =>
+      comments
+        .onIndex("comments_post_idx", (eb) => eb("post_id", "=", eb.parent("id")))
+        .select(["id", "text", "user_id"])
+        .joinOne("author", "users", (author) =>
+          author
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+            .select(["id", "name"]),
+        ),
+    ),
+);
+```
+
+Expected result shape:
+
+```ts
+{
+  id: FragnoId;
+  title: string;
+  content: string;
+  comments: Array<{
+    id: FragnoId;
+    text: string;
+    user_id: FragnoReference;
+    author: {
+      id: FragnoId;
+      name: string;
+    } | null;
+  }>;
+}
+```
+
+## Example: current nested join test rewritten
+
+Equivalent shape for:
+
+- `comments -> post -> author`
+- `comments -> commenter`
+
+```ts
+uow.findNew("comments", (q) =>
+  q
+    .whereIndex("primary")
+    .select(["id", "text", "post_id", "user_id"])
+    .joinOne("post", "posts", (post) =>
+      post
+        .onIndex("primary", (eb) => eb("id", "=", eb.parent("post_id")))
+        .select(["id", "title", "content", "user_id"])
+        .joinOne("author", "users", (author) =>
+          author
+            .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+            .select(["id", "name", "age"]),
+        ),
+    )
+    .joinOne("commenter", "users", (commenter) =>
+      commenter
+        .onIndex("primary", (eb) => eb("id", "=", eb.parent("user_id")))
+        .select(["id", "name"]),
+    ),
+);
+```
+
+## Index constraints
+
+The API should preserve the existing indexed-query philosophy.
+
+### Root
+
+Root queries continue to use `whereIndex(...)` and optional `orderByIndex(...)`.
+
+### Child nodes
+
+Child nodes use `onIndex(...)` as the indexed access path.
+
+At least in v1:
+
+- child nodes should not also have a separate `whereIndex(...)`
+- `onIndex(...)` is both the correlation and the child lookup predicate
+
+This keeps planning simple.
+
+## Ordering and pagination semantics
+
+### `joinMany`
+
+- `orderByIndex(...)` defines array order when specified
+- `pageSize(n)` limits child rows before aggregation
+- if no ordering is specified, result order is database-dependent
+
+### `joinOne`
+
+- no default ordering
+- if multiple rows match, first row wins according to database behavior
+- `orderByIndex(...)` and `pageSize(1)` may still be allowed when callers want deterministic
+  selection
+
+## SQL compilation model
+
+The new tree should map naturally to the current SQL approach:
+
+- root query selects root rows
+- `joinOne` compiles to a correlated subquery producing a single JSON object or `null`
+- `joinMany` compiles to a correlated subquery using `json_agg`
+- nested child nodes recurse inside the child subquery
+
+This is not a classic flat SQL join API. It is a structured, index-aware graph query API.
+
+## Non-goals for v1
+
+- ancestor / root references from inside `onIndex(...)`
+- filtering parents by child existence
+- requiring references for join definition
+- enforcing uniqueness for `joinOne`
+- deterministic row selection for `joinOne` unless explicitly requested
+
+## Migration stance
+
+- keep current `find()` join API working
+- add `findNew()` alongside it
+- use `findNew()` to validate the new query tree representation and compiler
+- later decide whether old joins become sugar over the new tree model

--- a/specs/references/fragno-db-relation-typing-and-addreference-plan.md
+++ b/specs/references/fragno-db-relation-typing-and-addreference-plan.md
@@ -1,0 +1,575 @@
+# Fragno DB FK model rewrite, relation typing removal, and schema `noOp()` plan
+
+## Status
+
+Current working plan after the explicit query-tree join API landed.
+
+This reflects the decisions made so far:
+
+- remove relation-name-driven public APIs and typing
+- make real foreign keys authored at the column site via `referenceColumn({ table })`
+- remove `addReference(...)` completely
+- remove old relation-driven join APIs completely
+- make query-tree the only public join API
+- preserve schema history length with one-for-one `noOp()` replacements
+- treat this as a full repo-wide breaking change fixed forward
+
+---
+
+## Final direction
+
+## 1. Querying no longer depends on schema-declared relations
+
+Explicit query-tree joins are the canonical and only public join API.
+
+That means joins are defined by:
+
+- alias
+- target table name
+- cardinality (`joinOne` / `joinMany`)
+- indexed correlation via `onIndex(...)`
+
+Consequences:
+
+- remove the old relation-key-driven join DSLs
+- remove legacy `find`-surface join support
+- relation names are no longer part of the public query authoring model
+- public `table.relations` ergonomics are intentionally gone
+
+## 2. Remove relation precision from public table types
+
+Target public shape:
+
+```ts
+interface Table<TColumns, TIndexes> {
+  columns: TColumns;
+  indexes: TIndexes;
+}
+```
+
+Consequences:
+
+- remove public `relations` from `Table`
+- remove exact relation-map typing entirely
+- remove `TableWithRelations<...>`
+- remove relation-map widening from schema builder return types
+- remove public `relations.author`-style typing completely
+
+## 3. Real FK declarations move onto `referenceColumn(...)`
+
+New authored FK declaration model:
+
+```ts
+.addColumn("userId", referenceColumn({ table: "user" }))
+```
+
+This replaces the old split model:
+
+```ts
+.addColumn("userId", referenceColumn())
+.addReference("sessionOwner", {
+  from: { table: "session", column: "userId" },
+  to: { table: "user", column: "id" },
+  type: "one",
+})
+```
+
+### Agreed rules
+
+- `referenceColumn({ table: "..." })` is the authored FK declaration
+- bare `referenceColumn()` is removed
+- target table is required
+- author input uses a table name string
+- validation happens after full schema assembly, so forward references to later tables are allowed
+- local table/column order during builder use does not matter; final built state is what is
+  validated
+- target must be another table in the same schema
+- target table must have the standard Fragno `idColumn()`
+- source must be an actual `referenceColumn(...)`, not an arbitrary column
+- nullable reference columns remain supported
+- self-referencing foreign keys remain supported
+- retargeting an existing FK in place is not supported
+- in `alterTable(...)`, adding a new reference column is allowed; mutating an existing non-reference
+  column into an FK column is not supported
+- renaming an FK-bearing reference column preserves its FK semantics
+- changing nullability of an FK-bearing reference column remains allowed
+- defaults are disallowed on `referenceColumn({ table: ... })`
+- the public/authored model is explicitly single-column only
+
+## 4. No separate `addForeignKey(...)` API
+
+We considered adding `addForeignKey(...)`, but the chosen direction is simpler:
+
+- **no `addForeignKey(...)` API**
+- the FK declaration lives entirely on `referenceColumn({ table })`
+
+This gives a single authored source of truth.
+
+## 5. Remove `addReference(...)` completely
+
+This is a hard breaking change.
+
+- remove `addReference(...)` from the schema builder
+- remove `add-reference` from `SchemaOperation`
+- remove all internal handling for `add-reference`
+- rewrite all first-party packages, tests, docs, templates, and examples forward
+- no deprecation wrapper / shim
+
+## 6. Remove join-only and old convenience relation metadata aggressively
+
+Current stance:
+
+- do not keep join-only relations for documentation
+- do not keep old query-only relation metadata
+- do not keep non-FK relation metadata unless a concrete runtime consumer exists
+
+Based on current codegen/runtime research, there is no in-repo consumer that justifies preserving
+the old `foreignKey: false` query-era references.
+
+---
+
+## Research result: do Drizzle/Prisma outputs need non-FK relations?
+
+## Answer
+
+No.
+
+The current generators already ignore join-only / non-FK relations.
+
+### Drizzle
+
+`packages/fragno-db/src/schema-output/drizzle.ts`
+
+- skips relations with `foreignKey === false`
+- derives inverse relations only from real FK-like one-side edges
+
+There is already a test asserting join-only relations do not produce Drizzle relation output.
+
+### Prisma
+
+`packages/fragno-db/src/schema-output/prisma.ts`
+
+- skips join-only relations
+- derives inverse sides from real FK-like one-side edges
+
+There is already a test asserting join-only relations do not produce Prisma relation output.
+
+## Conclusion
+
+- non-FK relation metadata is not needed for current codegen
+- removing it does not reduce current Drizzle/Prisma output fidelity
+
+---
+
+## What replaces public relations?
+
+## 1. Hidden internal FK metadata on built tables
+
+Public `table.relations` goes away, but internal runtime code still needs efficient FK metadata.
+
+Chosen direction:
+
+- store hidden internal derived FK metadata on the built table object
+- treat it as an internal property only
+- internal code should access it via helper functions, not direct property reads
+
+## 2. Internal FK model is forward-only and real-FK-only
+
+Chosen direction:
+
+- internal metadata represents only real forward FK edges
+- no authored `many`
+- no join-only relations
+- no public relation names
+- inverse sides are derived where needed by scanning tables / FK metadata
+
+## 3. Internal FK metadata shape
+
+Chosen direction:
+
+- use a **minimal FK-specific structure**, not the old broad `Relation` shape
+- organize metadata as a **map keyed by source reference column name**
+- do **not** redundantly store the source column name inside each entry
+- keep migration internals array-shaped for now, but the public/authored model remains single-column
+  only
+
+## 4. Internal identifiers are opaque
+
+Chosen direction:
+
+- any internal FK/relation identifiers are opaque implementation details
+- they are not used as public field names
+- Prisma/Drizzle generated public relation field names are derived independently from columns/tables
+
+---
+
+## FK naming and codegen
+
+## 1. No authored FK names in the new public API
+
+Since `addReference("sessionOwner", ...)` goes away, there is no public FK/relation naming
+declaration in the first pass.
+
+Chosen direction:
+
+- generated/user-facing names are auto-derived only
+- no explicit naming metadata on `referenceColumn(...)` in the first pass
+
+## 2. Derived FK operation names
+
+Even though FK declarations live on columns, operation history still needs deterministic FK names.
+
+Chosen direction:
+
+- derive FK operation names deterministically from source table + source column
+- do not depend on old relation names
+
+## 3. Generated Prisma/Drizzle relation fields stay supported
+
+Chosen direction:
+
+- keep generated relation fields in Prisma/Drizzle output
+- generate both forward and inverse relation fields
+- derive public field names from columns/tables, not old relation names
+- treat the new derived naming rules as a **stable contract** after this breaking release
+- resolve collisions automatically with deterministic disambiguation rules
+
+Generated names are allowed to change in this breaking release, but the new derivation rules should
+then be considered stable.
+
+---
+
+## Schema history and `noOp()`
+
+## Purpose
+
+We need a safe way to remove old schema-level `addReference(...)` calls without shrinking schema
+history length.
+
+## API
+
+```ts
+.noOp()
+.noOp("removed obsolete query-only relation metadata")
+```
+
+## Chosen semantics
+
+- `noOp()` increments schema version
+- `noOp()` records a real schema operation, e.g. `{ type: "no-op", reason?: string }`
+- reason is optional
+- `noOp()` should not necessarily be documented as a public feature
+- use it as an internal/advanced schema-history tool
+
+## Replacement rule
+
+This is strict:
+
+- every removed historical `addReference(...)` becomes exactly one `noOp()`
+- this includes both:
+  - removed query-only references
+  - removed real FK `addReference(...)` calls whose semantics are now encoded on the column
+
+## Important invariant
+
+We are preserving:
+
+- **history length**
+
+We are **not** preserving:
+
+- the exact old version when a real FK first became active
+
+That is acceptable for this breaking rewrite.
+
+---
+
+## Operation recording and migration model
+
+## 1. FK declarations are still recorded as explicit table sub-operations
+
+Even though the authored declaration lives on the column, schema history should still record
+explicit derived FK sub-operations.
+
+Chosen direction:
+
+- derive `add-foreign-key` table sub-operations from `referenceColumn({ table })`
+- keep FK operations as table sub-operations, not schema-level operations
+
+## 2. Table sub-operation ordering
+
+Chosen direction:
+
+- when recording table ops, a derived `add-foreign-key` sub-operation appears **immediately after
+  its source `add-column`**
+
+This is the chosen schema-history ordering.
+
+## 3. Migration DDL execution order may differ from schema history order
+
+Chosen direction:
+
+- preserve schema history order exactly as recorded
+- allow migration compilation / dialect preprocessing to reorder or preprocess **DDL execution
+  only** when necessary for correctness
+- this is especially important for forward references to tables declared later
+- SQLite-style preprocessing remains acceptable
+
+So schema-history ordering and SQL execution ordering are intentionally decoupled.
+
+---
+
+## Indexing policy
+
+Chosen direction:
+
+- `referenceColumn({ table: ... })` does **not** auto-create an index
+- indexes remain explicit via `createIndex(...)`
+- unindexed foreign keys are allowed
+
+So FK semantics and indexing/performance stay separate.
+
+---
+
+## Auth schema example: what stays and what goes
+
+Source: `packages/auth/src/schema.ts`
+
+## Keep, but convert to target-aware `referenceColumn({ table })`
+
+These are real FK edges:
+
+- `sessionOwner`
+- `sessionActiveOrganization`
+- `organizationCreator`
+- `organizationMemberOrganization`
+- `organizationMemberUser`
+- `organizationMemberRoleMember`
+- `organizationInvitationOrganization`
+- `organizationInvitationInviter`
+- `oauthAccountUser`
+- `oauthStateLinkUser`
+
+In practice that means moving target info onto these columns:
+
+- `session.userId -> user`
+- `session.activeOrganizationId -> organization`
+- `organization.createdBy -> user`
+- `organizationMember.organizationId -> organization`
+- `organizationMember.userId -> user`
+- `organizationMemberRole.memberId -> organizationMember`
+- `organizationInvitation.organizationId -> organization`
+- `organizationInvitation.inviterId -> user`
+- `oauthAccount.userId -> user`
+- `oauthState.linkUserId -> user`
+
+Each removed historical `addReference(...)` for these becomes a one-for-one `noOp()`.
+
+## Remove entirely
+
+These are old query-only / alias / inverse convenience relations and should be deleted:
+
+- `organizationMembers`
+- `sessionOrganizationMembers`
+- `sessionMembers`
+- `organizationMemberRoles`
+- `roles`
+- `organization` on `organizationMember`
+- `userOrganizationInvitations`
+- `invitations`
+- `organization` on `organizationInvitation`
+- `userOrganizationMembers`
+
+Each removed historical call becomes a one-for-one `noOp()`.
+
+---
+
+## Repo-wide breaking rewrite scope
+
+Chosen direction:
+
+- rewrite the whole repo in one sweep
+- do it as **one atomic repo-wide change**
+- update:
+  - first-party packages
+  - tests
+  - templates
+  - docs
+  - examples
+
+This is not a partial migration.
+
+---
+
+## APIs removed in this breaking change
+
+- `addReference(...)`
+- relation-key-driven join builder APIs in:
+  - `packages/fragno-db/src/query/mod.ts`
+  - `packages/fragno-db/src/query/unit-of-work/unit-of-work.ts`
+- legacy join support on the old `find` surface
+- public `table.relations`
+- bare `referenceColumn()`
+- schema-level `add-reference` operations
+
+---
+
+## APIs added/changed in this breaking change
+
+- `referenceColumn({ table: "..." })`
+- `noOp(reason?)`
+
+---
+
+## Implementation phases
+
+## Phase 1: finalize the public type cleanup
+
+In `packages/fragno-db/src/schema/create.ts` and related typing:
+
+- remove `TableWithRelations<...>`
+- remove relation-map widening from schema builder typing
+- remove public `relations` from `Table`
+- simplify table typing to columns + indexes only
+
+## Phase 2: move FK declaration onto columns
+
+- change `referenceColumn()` to require `{ table: string }`
+- disallow defaults on reference columns
+- store unresolved target table name on the authored column
+- resolve target metadata after full schema assembly
+- validate target table existence and `idColumn()` presence at build time
+- derive hidden internal FK metadata for built tables
+- expose that metadata through internal helper APIs
+
+## Phase 3: remove old relation APIs and legacy join APIs
+
+- remove `addReference(...)`
+- remove `add-reference` schema operations
+- remove old relation-key-driven join DSLs
+- remove legacy join support from the old `find` surface
+- remove public `table.relations`
+
+## Phase 4: update schema history mechanics
+
+- add `noOp(reason?)`
+- record `no-op` in `schema.operations`
+- replace every removed historical `addReference(...)` with one `noOp()`
+- derive `add-foreign-key` table sub-operations from FK-bearing columns
+- record each derived FK sub-op immediately after its source `add-column`
+- allow migration DDL compilation to reorder/preprocess SQL execution as needed without changing
+  recorded schema history order
+
+## Phase 5: update codegen
+
+- derive forward/inverse relation fields from real FK columns
+- remove generator dependence on old relation names
+- implement deterministic naming and deterministic collision handling
+- lock naming behavior down in tests as the new stable contract
+
+## Phase 6: rewrite repo usage
+
+- migrate first-party schemas to `referenceColumn({ table })`
+- remove query-only old relations
+- insert one-for-one `noOp()` replacements
+- update tests, docs, templates, and examples
+
+---
+
+## Remaining open questions
+
+1. What exact minimal internal FK metadata type should replace the current broad `Relation`
+   interface?
+2. What exact forward/inverse naming rules should Prisma/Drizzle generators use once they stop
+   depending on old relation names?
+
+---
+
+## Implementation checklist
+
+### Core schema API and typing
+
+- [ ] Change `referenceColumn()` to require `{ table: string }`
+- [ ] Disallow defaults on `referenceColumn({ table })`
+- [ ] Remove bare `referenceColumn()` support
+- [ ] Remove public `relations` from `Table`
+- [ ] Remove `TableWithRelations<...>`
+- [ ] Remove relation-map widening from schema builder return types
+- [ ] Keep public table typing limited to columns + indexes
+
+### Internal FK metadata
+
+- [ ] Add hidden internal FK metadata to built tables
+- [ ] Keep internal FK metadata forward-only and real-FK-only
+- [ ] Use a minimal FK-specific internal structure keyed by source column name
+- [ ] Expose internal FK metadata through helper APIs
+- [ ] Resolve FK targets after full schema assembly
+- [ ] Rebuild hidden FK metadata through the normal build/clone path
+
+### Schema operations and history
+
+- [ ] Add `noOp(reason?)` to `SchemaBuilder`
+- [ ] Add `no-op` to `SchemaOperation`
+- [ ] Remove `addReference(...)` from `SchemaBuilder`
+- [ ] Remove `add-reference` from `SchemaOperation`
+- [ ] Remove all internal `add-reference` handling
+- [ ] Derive `add-foreign-key` table sub-operations from FK-bearing columns
+- [ ] Record each derived FK sub-op immediately after its source `add-column`
+- [ ] Preserve schema history length with one-for-one `noOp()` replacements for every removed
+      historical `addReference(...)`
+
+### Migration engine and SQL generation
+
+- [ ] Update migration generation to read derived FK sub-operations from table operations
+- [ ] Preserve recorded schema history order
+- [ ] Allow DDL execution order to be reordered/preprocessed for correctness
+- [ ] Keep migration FK internals array-shaped for now
+- [ ] Preserve rename/drop behavior for FK-bearing columns
+
+### Query API cleanup
+
+- [ ] Remove relation-key-driven join DSLs from `packages/fragno-db/src/query/mod.ts`
+- [ ] Remove relation-key-driven join DSLs from
+      `packages/fragno-db/src/query/unit-of-work/unit-of-work.ts`
+- [ ] Remove legacy join support from the old `find` surface
+- [ ] Keep query-tree as the only public join API
+
+### Codegen
+
+- [ ] Update Drizzle generation to derive relation fields from FK-bearing columns
+- [ ] Update Prisma generation to derive relation fields from FK-bearing columns
+- [ ] Generate both forward and inverse relation fields
+- [ ] Remove generator dependence on old relation names
+- [ ] Define deterministic forward naming rules
+- [ ] Define deterministic inverse naming rules
+- [ ] Implement deterministic collision handling
+- [ ] Lock the new naming behavior down in tests as a stable contract
+
+### Repo-wide migration
+
+- [ ] Rewrite `packages/auth/src/schema.ts`
+- [ ] Replace kept real FK references with `referenceColumn({ table })`
+- [ ] Remove old query-only / alias / inverse convenience relations
+- [ ] Insert one-for-one `noOp()` replacements in auth schema history
+- [ ] Rewrite all first-party package schemas
+- [ ] Rewrite tests across the repo
+- [ ] Rewrite docs, templates, and examples
+- [ ] Remove all remaining `addReference(...)` call sites
+- [ ] Remove all remaining bare `referenceColumn()` call sites
+
+### Validation and verification
+
+- [ ] Run `pnpm exec turbo types:check --filter=./packages/fragno-db --output-logs=errors-only`
+- [ ] Run `pnpm exec turbo test --filter=./packages/fragno-db --output-logs=errors-only`
+- [ ] Run broader repo checks for affected packages
+- [ ] Verify generated Prisma/Drizzle output snapshots after renaming changes
+- [ ] Verify auth schema history length remains unchanged after replacing removed references with
+      `noOp()`
+
+## Immediate next steps
+
+1. Change `referenceColumn()` to require `{ table }`.
+2. Add `noOp()` and `no-op` schema operations.
+3. Remove public relation typing and old/legacy join APIs.
+4. Rewrite `packages/auth/src/schema.ts` and then the rest of the repo forward.
+5. Lock down the new generator naming behavior in tests.

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,7 @@
     },
     "test": {
       "dependsOn": ["build"],
-      "outputs": ["coverage.json"]
+      "outputs": []
     },
     "test:watch": {
       "cache": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query-tree driven finds with explicit joinOne/joinMany semantics, nested reads, counts, and cursor pagination.
* **Documentation**
  * Updated examples and guides to show explicit join usage, referenceColumn({ table: "…" }) patterns, and query-tree best practices.
* **Tests**
  * Expanded and updated tests to cover canonical join/query-tree behaviors, pagination, and adapter parity.
* **Chores**
  * Schema/examples tightened to require explicit reference targets; read-plan and in-memory/query engines migrated to the canonical query-tree model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->