### PR TITLE
Wilco/workflow create instance mutate only

### DIFF
--- a/.changeset/db-constraint-normalization.md
+++ b/.changeset/db-constraint-normalization.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/db": patch
+"@fragno-dev/telegram-fragment": patch
+---
+
+fix: normalize database constraint errors for duplicate handling.

--- a/.changeset/workflow-instance-mutate-only.md
+++ b/.changeset/workflow-instance-mutate-only.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/workflows": patch
+---
+
+fix: allow workflow instances to be created without a read phase.

--- a/packages/fragment-workflows/src/definition.ts
+++ b/packages/fragment-workflows/src/definition.ts
@@ -338,18 +338,7 @@ export const workflowsFragmentDefinition = defineFragment<WorkflowsFragmentConfi
         const params = options?.params ?? {};
 
         return this.serviceTx(workflowsSchema)
-          .retrieve((uow) =>
-            uow.findFirst("workflow_instance", (b) =>
-              b.whereIndex("idx_workflow_instance_workflowName_id", (eb) =>
-                eb.and(eb("workflowName", "=", workflowName), eb("id", "=", instanceId)),
-              ),
-            ),
-          )
-          .mutate(({ uow, retrieveResult: [existing] }) => {
-            if (existing) {
-              throw new Error("INSTANCE_ID_ALREADY_EXISTS");
-            }
-
+          .mutate(({ uow }) => {
             const instanceRef = uow.create("workflow_instance", {
               id: instanceId,
               workflowName,

--- a/packages/fragment-workflows/src/index.test.ts
+++ b/packages/fragment-workflows/src/index.test.ts
@@ -322,6 +322,25 @@ describe("Workflows Fragment", () => {
       expect(instance?.id.toString()).toBe("route-1");
     });
 
+    test("POST /:workflowName/instances should return conflict for duplicate instance id", async () => {
+      const first = await fragment.callRoute("POST", "/:workflowName/instances", {
+        pathParams: { workflowName: "demo-workflow" },
+        body: { id: "route-duplicate" },
+      });
+      assert(first.type === "json");
+
+      const second = await fragment.callRoute("POST", "/:workflowName/instances", {
+        pathParams: { workflowName: "demo-workflow" },
+        body: { id: "route-duplicate" },
+      });
+
+      expect(second.type).toBe("error");
+      if (second.type === "error") {
+        expect(second.status).toBe(409);
+        expect(second.error.code).toBe("INSTANCE_ID_ALREADY_EXISTS");
+      }
+    });
+
     test("GET /:workflowName/instances/:instanceId/history should return history", async () => {
       const instanceRef = await (async () => {
         const uow = db.createUnitOfWork("wf").forSchema(workflowsSchema);

--- a/packages/fragment-workflows/src/routes.ts
+++ b/packages/fragment-workflows/src/routes.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { defineRoutes } from "@fragno-dev/core";
-import { decodeCursor } from "@fragno-dev/db";
+import { decodeCursor, isUniqueConstraintError } from "@fragno-dev/db";
 
 import { workflowsFragmentDefinition } from "./definition";
 import { workflowsSchema } from "./schema";
@@ -217,7 +217,7 @@ export const workflowsRoutesFactory = defineRoutes(workflowsFragmentDefinition).
         return error({ message: "Instance is terminal", code: "INSTANCE_TERMINAL" as Code }, 409);
       }
 
-      if (err.message === "INSTANCE_ID_ALREADY_EXISTS") {
+      if (isUniqueConstraintError(err)) {
         return error(
           { message: "Instance already exists", code: "INSTANCE_ID_ALREADY_EXISTS" as Code },
           409,

--- a/packages/fragment-workflows/src/runner.test.ts
+++ b/packages/fragment-workflows/src/runner.test.ts
@@ -7,9 +7,6 @@ import { z } from "zod";
 
 import { defineFragment, instantiate, type AnyFragnoInstantiatedFragment } from "@fragno-dev/core";
 import { withDatabase, type DatabaseRequestContext } from "@fragno-dev/db";
-// TODO: Missing coverage areas for the runner test suite:
-// 1. Instance status fields beyond status/output (error shape, currentStep)
-// 2. Concurrency conflict handling / idempotency of duplicate ticks
 import { buildDatabaseFragmentsTest, drainDurableHooks } from "@fragno-dev/test";
 
 import { createWorkflowStepLivePump, workflowStepLivePumpKey } from "./runner/step-live-pump";
@@ -1025,6 +1022,87 @@ describe("Workflows Runner", () => {
         .executeRetrieve()
     )[0];
     expect(rows).toHaveLength(0);
+  });
+
+  test("can create a new workflow instance from a step using serviceCalls", async () => {
+    const ChildWorkflow = defineWorkflow({ name: "service-call-child-workflow" }, async () => {
+      return { createdByParent: true };
+    });
+
+    let services: WorkflowsTestHarness["services"] | undefined;
+    const ParentWorkflow = defineWorkflow(
+      { name: "service-call-parent-workflow" },
+      async (event, step) => {
+        const childId = `child-${event.instanceId}`;
+        await step.do("create child", (tx) => {
+          const workflowServices = services;
+          if (!workflowServices) {
+            throw new Error("MISSING_WORKFLOW_SERVICES");
+          }
+          tx.serviceCalls(() => [
+            workflowServices.createInstance("service-call-child-workflow", {
+              id: childId,
+            }),
+          ]);
+          return childId;
+        });
+        return { childId };
+      },
+    );
+
+    const harness = await createWorkflowsTestHarness({
+      workflows: { PARENT: ParentWorkflow, CHILD: ChildWorkflow },
+      adapter: { type: "in-memory" },
+      testBuilder: buildDatabaseFragmentsTest(),
+      autoTickHooks: false,
+    });
+    services = harness.services;
+
+    const parentId = await harness.createInstance("PARENT");
+    const [parentInstance] = (
+      await harness.db
+        .createUnitOfWork("read")
+        .forSchema(workflowsSchema)
+        .find("workflow_instance", (b) =>
+          b.whereIndex("idx_workflow_instance_workflowName_id", (eb) =>
+            eb.and(
+              eb("workflowName", "=", "service-call-parent-workflow"),
+              eb("id", "=", parentId),
+            ),
+          ),
+        )
+        .executeRetrieve()
+    )[0];
+    expect(parentInstance).toBeTruthy();
+
+    await harness.tick(buildPayload(parentInstance!, "create"));
+
+    const childId = `child-${parentId}`;
+    expect(await harness.getStatus("PARENT", parentId)).toMatchObject({
+      status: "complete",
+      output: { childId },
+    });
+    expect(await harness.getStatus("CHILD", childId)).toMatchObject({ status: "active" });
+
+    const [childInstance] = (
+      await harness.db
+        .createUnitOfWork("read")
+        .forSchema(workflowsSchema)
+        .find("workflow_instance", (b) =>
+          b.whereIndex("idx_workflow_instance_workflowName_id", (eb) =>
+            eb.and(eb("workflowName", "=", "service-call-child-workflow"), eb("id", "=", childId)),
+          ),
+        )
+        .executeRetrieve()
+    )[0];
+    expect(childInstance).toBeTruthy();
+
+    await harness.tick(buildPayload(childInstance!, "create"));
+
+    expect(await harness.getStatus("CHILD", childId)).toMatchObject({
+      status: "complete",
+      output: { createdByParent: true },
+    });
   });
 
   test("marks workflow errored when a step throws a falsy value", async () => {

--- a/packages/fragno-db/src/adapters/generic-sql/driver-config.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/driver-config.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { DatabaseConstraintError, DatabaseTransactionError } from "../../errors";
+import {
+  BetterSQLite3DriverConfig,
+  CloudflareDurableObjectsDriverConfig,
+  MySQL2DriverConfig,
+  NodePostgresDriverConfig,
+  PGLiteDriverConfig,
+  SQLocalDriverConfig,
+  type DriverConfig,
+} from "./driver-config";
+
+const withProps = (message: string, props: Record<string, unknown>) =>
+  Object.assign(new Error(message), props);
+
+describe("DriverConfig.normalizeError", () => {
+  it.each([
+    [new BetterSQLite3DriverConfig(), "better-sqlite3"],
+    [new SQLocalDriverConfig(), "sqlocal"],
+    [new CloudflareDurableObjectsDriverConfig(), "cloudflare_durable_objects"],
+  ] as const)("normalizes sqlite unique errors for %s", (config, _driver) => {
+    const normalized = config.normalizeError(
+      withProps("UNIQUE constraint failed: users.email", { code: "SQLITE_CONSTRAINT_UNIQUE" }),
+    );
+
+    expect(normalized).toBeInstanceOf(DatabaseConstraintError);
+    expect(normalized).toMatchObject({ kind: "unique", table: "users", columns: ["email"] });
+  });
+
+  it.each([
+    [new BetterSQLite3DriverConfig(), "better-sqlite3"],
+    [new SQLocalDriverConfig(), "sqlocal"],
+    [new CloudflareDurableObjectsDriverConfig(), "cloudflare_durable_objects"],
+  ] as const)("normalizes sqlite foreign-key errors for %s", (config, _driver) => {
+    const normalized = config.normalizeError(
+      withProps("FOREIGN KEY constraint failed", { code: "SQLITE_CONSTRAINT_FOREIGNKEY" }),
+    );
+
+    expect(normalized).toBeInstanceOf(DatabaseConstraintError);
+    expect(normalized).toMatchObject({ kind: "foreign-key" });
+  });
+
+  it.each([
+    [new NodePostgresDriverConfig(), "pg"],
+    [new PGLiteDriverConfig(), "pglite"],
+  ] as const)("normalizes postgres unique errors for %s", (config, _driver) => {
+    const normalized = config.normalizeError(
+      withProps('duplicate key value violates unique constraint "users_email_key"', {
+        code: "23505",
+        table: "users",
+        constraint: "users_email_key",
+        detail: "Key (email)=(a@example.com) already exists.",
+      }),
+    );
+
+    expect(normalized).toBeInstanceOf(DatabaseConstraintError);
+    expect(normalized).toMatchObject({
+      kind: "unique",
+      table: "users",
+      constraint: "users_email_key",
+      columns: ["email"],
+    });
+  });
+
+  it.each([
+    [new NodePostgresDriverConfig(), "pg"],
+    [new PGLiteDriverConfig(), "pglite"],
+  ] as const)("normalizes retryable postgres transaction errors for %s", (config, _driver) => {
+    const serializationFailure = config.normalizeError(
+      withProps("serialization failure", { code: "40001" }),
+    );
+    const deadlock = config.normalizeError(withProps("deadlock", { code: "40P01" }));
+    const unique = config.normalizeError(withProps("unique", { code: "23505" }));
+
+    expect(serializationFailure).toBeInstanceOf(DatabaseTransactionError);
+    expect(serializationFailure).toMatchObject({ isRetryable: true });
+    expect(deadlock).toBeInstanceOf(DatabaseTransactionError);
+    expect(deadlock).toMatchObject({ isRetryable: true });
+    expect(unique).toBeInstanceOf(DatabaseConstraintError);
+    expect(unique).toMatchObject({ isRetryable: false });
+  });
+
+  it("normalizes mysql unique errors", () => {
+    const config = new MySQL2DriverConfig();
+    const normalized = config.normalizeError(
+      withProps("Duplicate entry 'a@example.com' for key 'users.email'", {
+        code: "ER_DUP_ENTRY",
+        errno: 1062,
+      }),
+    );
+
+    expect(normalized).toBeInstanceOf(DatabaseConstraintError);
+    expect(normalized).toMatchObject({ kind: "unique" });
+  });
+
+  it.each([
+    ["ER_LOCK_DEADLOCK", 1213, "deadlock"],
+    ["ER_LOCK_WAIT_TIMEOUT", 1205, "lock wait timeout"],
+  ] as const)("normalizes retryable mysql transaction errors for %s", (code, errno, message) => {
+    const config = new MySQL2DriverConfig();
+
+    const byCode = config.normalizeError(withProps(message, { code }));
+    const byErrno = config.normalizeError(withProps(message, { errno }));
+
+    expect(byCode).toBeInstanceOf(DatabaseTransactionError);
+    expect(byCode).toMatchObject({ isRetryable: true });
+    expect(byErrno).toBeInstanceOf(DatabaseTransactionError);
+    expect(byErrno).toMatchObject({ isRetryable: true });
+  });
+
+  it("keeps unknown errors as regular errors", () => {
+    const config: DriverConfig = new MySQL2DriverConfig();
+    const error = new Error("unknown");
+    expect(config.normalizeError(error)).toBe(error);
+  });
+});

--- a/packages/fragno-db/src/adapters/generic-sql/driver-config.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/driver-config.ts
@@ -1,3 +1,4 @@
+import { DatabaseConstraintError, DatabaseTransactionError } from "../../errors";
 import {
   schemaNamingStrategy,
   suffixNamingStrategy,
@@ -52,6 +53,155 @@ export abstract class DriverConfig<T extends SupportedDriverType = SupportedDriv
    * @throws Error if affected rows information is not found in the result
    */
   extractAffectedRows?(result: Record<string, unknown>): bigint;
+
+  abstract normalizeError(error: unknown): Error;
+}
+
+function parseSqliteUniqueColumns(message: string): { table?: string; columns?: string[] } {
+  const match = /^UNIQUE constraint failed: (.+)$/.exec(message);
+  if (!match) {
+    return {};
+  }
+
+  const refs = match[1]
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const columns = refs
+    .map((ref) => ref.split(".").pop())
+    .filter((column): column is string => !!column);
+  const table = refs[0]?.split(".").slice(0, -1).join(".") || undefined;
+  return { table, columns };
+}
+
+function parsePostgresDetailColumns(detail: unknown): string[] | undefined {
+  if (typeof detail !== "string") {
+    return undefined;
+  }
+  const match = /^Key \(([^)]+)\)=/.exec(detail);
+  return match?.[1]
+    ?.split(",")
+    .map((column) => column.trim())
+    .filter(Boolean);
+}
+
+function normalizePostgresError(error: unknown): Error {
+  if (!error || typeof error !== "object") {
+    return new Error(typeof error === "string" ? error : "UNKNOWN_DATABASE_ERROR");
+  }
+
+  const { code, table, constraint, column, detail } = error as Record<string, unknown>;
+  const tableName = typeof table === "string" ? table : undefined;
+  const constraintName = typeof constraint === "string" ? constraint : undefined;
+
+  if (code === "40001" || code === "40P01") {
+    return new DatabaseTransactionError({
+      message: error instanceof Error ? error.message : "Database transaction conflict.",
+      retryable: true,
+      cause: error,
+    });
+  }
+
+  if (code === "23505") {
+    return new DatabaseConstraintError({
+      kind: "unique",
+      table: tableName,
+      constraint: constraintName,
+      columns: parsePostgresDetailColumns(detail),
+      cause: error,
+    });
+  }
+  if (code === "23503") {
+    return new DatabaseConstraintError({
+      kind: "foreign-key",
+      table: tableName,
+      constraint: constraintName,
+      cause: error,
+    });
+  }
+  if (code === "23502") {
+    return new DatabaseConstraintError({
+      kind: "not-null",
+      table: tableName,
+      constraint: constraintName,
+      columns: typeof column === "string" ? [column] : undefined,
+      cause: error,
+    });
+  }
+  if (code === "23514") {
+    return new DatabaseConstraintError({
+      kind: "check",
+      table: tableName,
+      constraint: constraintName,
+      cause: error,
+    });
+  }
+
+  return error instanceof Error
+    ? error
+    : new Error(typeof error === "string" ? error : "UNKNOWN_DATABASE_ERROR");
+}
+
+function normalizeSqliteError(error: unknown): Error {
+  if (!error || typeof error !== "object") {
+    return new Error(typeof error === "string" ? error : "UNKNOWN_DATABASE_ERROR");
+  }
+
+  const { code } = error as Record<string, unknown>;
+  const message = error instanceof Error ? error.message : undefined;
+
+  if (
+    code === "SQLITE_CONSTRAINT_UNIQUE" ||
+    code === "SQLITE_CONSTRAINT_PRIMARYKEY" ||
+    message?.startsWith("UNIQUE constraint failed:")
+  ) {
+    const parsed = message ? parseSqliteUniqueColumns(message) : {};
+    return new DatabaseConstraintError({ kind: "unique", ...parsed, cause: error });
+  }
+  if (
+    code === "SQLITE_CONSTRAINT_FOREIGNKEY" ||
+    message?.includes("FOREIGN KEY constraint failed")
+  ) {
+    return new DatabaseConstraintError({ kind: "foreign-key", cause: error });
+  }
+  if (code === "SQLITE_CONSTRAINT_NOTNULL" || message?.includes("NOT NULL constraint failed")) {
+    return new DatabaseConstraintError({ kind: "not-null", cause: error });
+  }
+  if (code === "SQLITE_CONSTRAINT_CHECK" || message?.includes("CHECK constraint failed")) {
+    return new DatabaseConstraintError({ kind: "check", cause: error });
+  }
+
+  return error instanceof Error
+    ? error
+    : new Error(typeof error === "string" ? error : "UNKNOWN_DATABASE_ERROR");
+}
+
+function normalizeMysqlError(error: unknown): Error {
+  if (!error || typeof error !== "object") {
+    return new Error(typeof error === "string" ? error : "UNKNOWN_DATABASE_ERROR");
+  }
+
+  const { code, errno } = error as Record<string, unknown>;
+
+  if (code === "ER_LOCK_DEADLOCK" || errno === 1213) {
+    return new DatabaseTransactionError({ retryable: true, cause: error });
+  }
+  if (code === "ER_LOCK_WAIT_TIMEOUT" || errno === 1205) {
+    return new DatabaseTransactionError({ retryable: true, cause: error });
+  }
+  if (code === "ER_DUP_ENTRY" || errno === 1062) {
+    return new DatabaseConstraintError({ kind: "unique", cause: error });
+  }
+  if (errno === 1451 || errno === 1452) {
+    return new DatabaseConstraintError({ kind: "foreign-key", cause: error });
+  }
+  if (code === "ER_BAD_NULL_ERROR" || errno === 1048) {
+    return new DatabaseConstraintError({ kind: "not-null", cause: error });
+  }
+
+  return error instanceof Error
+    ? error
+    : new Error(typeof error === "string" ? error : "UNKNOWN_DATABASE_ERROR");
 }
 
 export const defaultNamingStrategyForDatabase = (
@@ -79,6 +229,10 @@ export class SQLocalDriverConfig extends DriverConfig<"sqlocal"> {
   override readonly supportsJson = false;
   override readonly internalIdColumn = "_internalId";
   override readonly outboxVersionstampStrategy = "insert-on-conflict-returning";
+
+  override normalizeError(error: unknown): Error {
+    return normalizeSqliteError(error);
+  }
 }
 
 export class CloudflareDurableObjectsDriverConfig extends DriverConfig<"cloudflare_durable_objects"> {
@@ -88,6 +242,10 @@ export class CloudflareDurableObjectsDriverConfig extends DriverConfig<"cloudfla
   override readonly supportsJson = false;
   override readonly internalIdColumn = "_internalId";
   override readonly outboxVersionstampStrategy = "insert-on-conflict-returning";
+
+  override normalizeError(error: unknown): Error {
+    return normalizeSqliteError(error);
+  }
 }
 
 export class BetterSQLite3DriverConfig extends DriverConfig<"better-sqlite3"> {
@@ -97,6 +255,10 @@ export class BetterSQLite3DriverConfig extends DriverConfig<"better-sqlite3"> {
   override readonly supportsJson = false;
   override readonly internalIdColumn = "_internalId";
   override readonly outboxVersionstampStrategy = "insert-on-conflict-returning";
+
+  override normalizeError(error: unknown): Error {
+    return normalizeSqliteError(error);
+  }
 
   override extractAffectedRows(result: Record<string, unknown>): bigint {
     if ("numAffectedRows" in result) {
@@ -122,6 +284,10 @@ export class NodePostgresDriverConfig extends DriverConfig<"pg"> {
   override readonly supportsJson = true;
   override readonly internalIdColumn = "_internalId";
   override readonly outboxVersionstampStrategy = "insert-on-conflict-returning";
+
+  override normalizeError(error: unknown): Error {
+    return normalizePostgresError(error);
+  }
 
   override extractAffectedRows(result: Record<string, unknown>): bigint {
     if ("numAffectedRows" in result) {
@@ -156,6 +322,10 @@ export class PGLiteDriverConfig extends DriverConfig<"pglite"> {
   override readonly internalIdColumn = "_internalId";
   override readonly outboxVersionstampStrategy = "insert-on-conflict-returning";
 
+  override normalizeError(error: unknown): Error {
+    return normalizePostgresError(error);
+  }
+
   override extractAffectedRows(result: Record<string, unknown>): bigint {
     if ("affectedRows" in result) {
       const value = result["affectedRows"];
@@ -179,4 +349,8 @@ export class MySQL2DriverConfig extends DriverConfig<"mysql2"> {
   override readonly supportsJson = true;
   override readonly internalIdColumn = undefined;
   override readonly outboxVersionstampStrategy = "insert-on-duplicate-last-insert-id";
+
+  override normalizeError(error: unknown): Error {
+    return normalizeMysqlError(error);
+  }
 }

--- a/packages/fragno-db/src/adapters/generic-sql/generic-sql-uow-executor.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/generic-sql-uow-executor.ts
@@ -1,5 +1,6 @@
 import superjson from "superjson";
 
+import { isRetryableDatabaseError } from "../../errors";
 import { SETTINGS_NAMESPACE, internalSchema } from "../../fragments/internal-fragment.schema";
 import { createId } from "../../id";
 import { type SqlNamingStrategy } from "../../naming/sql-naming";
@@ -30,6 +31,13 @@ export interface ExecutorOptions {
   dialect: Dialect;
   outbox?: OutboxConfig;
   namingStrategy?: SqlNamingStrategy;
+}
+
+class SqlVersionConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SqlVersionConflictError";
+  }
 }
 
 export async function executeRetrieval(
@@ -116,7 +124,7 @@ export async function executeMutation(
           if (affectedRows !== compiledMutation.expectedAffectedRows) {
             // Version conflict detected - the UPDATE/DELETE didn't affect the expected number of rows
             // This means either the row doesn't exist or the version has changed
-            throw new Error(
+            throw new SqlVersionConflictError(
               `Version conflict: expected ${compiledMutation.expectedAffectedRows} rows affected, but got ${affectedRows}`,
             );
           }
@@ -130,7 +138,7 @@ export async function executeMutation(
           if (returnedRowCount !== BigInt(compiledMutation.expectedReturnedRows)) {
             // Version conflict detected - the SELECT didn't return the expected number of rows
             // This means either the row doesn't exist or the version has changed
-            throw new Error(
+            throw new SqlVersionConflictError(
               `Version conflict: expected ${compiledMutation.expectedReturnedRows} rows returned, but got ${returnedRowCount}`,
             );
           }
@@ -172,21 +180,17 @@ export async function executeMutation(
   } catch (error) {
     // Transaction failed - could be version conflict or other constraint violation
     // Return success=false to indicate the UOW should be retried
-    if (error instanceof Error && error.message.includes("Version conflict")) {
+    if (error instanceof SqlVersionConflictError) {
       return { success: false };
     }
 
-    const errorCode =
-      typeof error === "object" && error !== null && "code" in error
-        ? (error as { code?: unknown }).code
-        : undefined;
-
-    if (errorCode === "40001" || errorCode === "40P01") {
+    const normalizedError = driverConfig.normalizeError(error);
+    if (isRetryableDatabaseError(normalizedError)) {
       return { success: false };
     }
 
-    // Other database errors should be thrown
-    throw error;
+    // Other database errors should be normalized and thrown for callers to map.
+    throw normalizedError;
   }
 }
 

--- a/packages/fragno-db/src/adapters/in-memory/errors.ts
+++ b/packages/fragno-db/src/adapters/in-memory/errors.ts
@@ -1,13 +1,15 @@
-export class UniqueConstraintError extends Error {
+import { DatabaseConstraintError } from "../../errors";
+
+export class UniqueConstraintError extends DatabaseConstraintError {
   constructor(message: string) {
-    super(message);
+    super({ kind: "unique", message });
     this.name = "UniqueConstraintError";
   }
 }
 
-export class ForeignKeyConstraintError extends Error {
+export class ForeignKeyConstraintError extends DatabaseConstraintError {
   constructor(message: string) {
-    super(message);
+    super({ kind: "foreign-key", message });
     this.name = "ForeignKeyConstraintError";
   }
 }

--- a/packages/fragno-db/src/errors.ts
+++ b/packages/fragno-db/src/errors.ts
@@ -1,0 +1,90 @@
+export class DatabaseError extends Error {
+  override readonly cause?: unknown;
+
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message, { cause: options.cause });
+    this.name = "DatabaseError";
+    this.cause = options.cause;
+  }
+
+  get isRetryable(): boolean {
+    return false;
+  }
+}
+
+export type DatabaseConstraintKind = "unique" | "foreign-key" | "not-null" | "check";
+
+export type DatabaseConstraintErrorOptions = {
+  kind: DatabaseConstraintKind;
+  message?: string;
+  table?: string;
+  constraint?: string;
+  columns?: string[];
+  cause?: unknown;
+};
+
+export class DatabaseConstraintError extends DatabaseError {
+  readonly kind: DatabaseConstraintKind;
+  readonly table?: string;
+  readonly constraint?: string;
+  readonly columns?: string[];
+
+  constructor(options: DatabaseConstraintErrorOptions) {
+    super(options.message ?? buildConstraintErrorMessage(options), { cause: options.cause });
+    this.name = "DatabaseConstraintError";
+    this.kind = options.kind;
+    this.table = options.table;
+    this.constraint = options.constraint;
+    this.columns = options.columns;
+  }
+}
+
+export type DatabaseTransactionErrorOptions = {
+  message?: string;
+  retryable?: boolean;
+  cause?: unknown;
+};
+
+export class DatabaseTransactionError extends DatabaseError {
+  readonly #retryable: boolean;
+
+  constructor(options: DatabaseTransactionErrorOptions = {}) {
+    super(options.message ?? "Database transaction failed.", { cause: options.cause });
+    this.name = "DatabaseTransactionError";
+    this.#retryable = options.retryable ?? false;
+  }
+
+  override get isRetryable(): boolean {
+    return this.#retryable;
+  }
+}
+
+const buildConstraintErrorMessage = (options: DatabaseConstraintErrorOptions): string => {
+  const parts = [`Database ${options.kind} constraint violation`];
+  if (options.table) {
+    parts.push(`on table ${options.table}`);
+  }
+  if (options.columns && options.columns.length > 0) {
+    parts.push(`for columns ${options.columns.join(", ")}`);
+  }
+  if (options.constraint) {
+    parts.push(`(${options.constraint})`);
+  }
+  return `${parts.join(" ")}.`;
+};
+
+export function isDatabaseError(error: unknown): error is DatabaseError {
+  return error instanceof DatabaseError;
+}
+
+export function isRetryableDatabaseError(error: unknown): error is DatabaseError {
+  return isDatabaseError(error) && error.isRetryable;
+}
+
+export function isDatabaseConstraintError(error: unknown): error is DatabaseConstraintError {
+  return error instanceof DatabaseConstraintError;
+}
+
+export function isUniqueConstraintError(error: unknown): error is DatabaseConstraintError {
+  return isDatabaseConstraintError(error) && error.kind === "unique";
+}

--- a/packages/fragno-db/src/mod.ts
+++ b/packages/fragno-db/src/mod.ts
@@ -22,6 +22,18 @@ export type { DatabaseAdapter, CursorResult };
 export { Cursor };
 export { dbNow, dbInterval };
 export type { DbNow, DbInterval, DbIntervalInput };
+export {
+  DatabaseError,
+  DatabaseConstraintError,
+  DatabaseTransactionError,
+  isDatabaseError,
+  isRetryableDatabaseError,
+  isDatabaseConstraintError,
+  isUniqueConstraintError,
+  type DatabaseConstraintKind,
+  type DatabaseConstraintErrorOptions,
+  type DatabaseTransactionErrorOptions,
+} from "./errors";
 export { InMemoryAdapter, type InMemoryAdapterOptions } from "./adapters/in-memory";
 export { internalSchema } from "./fragments/internal-fragment";
 export { getInternalFragment } from "./internal/adapter-registry";

--- a/packages/telegram-fragment/src/routes.ts
+++ b/packages/telegram-fragment/src/routes.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { defineRoutes } from "@fragno-dev/core";
 import { decodeCursor } from "@fragno-dev/db";
-import { ExponentialBackoffRetryPolicy } from "@fragno-dev/db";
+import { ExponentialBackoffRetryPolicy, isUniqueConstraintError } from "@fragno-dev/db";
 
 import { telegramFragmentDefinition } from "./definition";
 import { telegramSchema } from "./schema";
@@ -137,18 +137,6 @@ const webhookOutputSchema = z.object({
   duplicate: z.boolean().optional(),
 });
 
-const isDuplicateHookError = (error: unknown): boolean => {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  const code = "code" in error ? String(error.code) : "";
-  const message = "message" in error ? String(error.message) : "";
-  if (code === "SQLITE_CONSTRAINT" || code === "23505") {
-    return message.includes("fragno_hooks") || message.includes("hook");
-  }
-  return message.toLowerCase().includes("duplicate") || message.toLowerCase().includes("unique");
-};
-
 const filterUndefined = (payload: Record<string, unknown>) =>
   Object.fromEntries(Object.entries(payload).filter(([, value]) => value !== undefined));
 
@@ -192,7 +180,7 @@ export const telegramRoutesFactory = defineRoutes(telegramFragmentDefinition).cr
             return json({ ok: true });
           } catch (err) {
             console.error("telegram webhook hook insert error", err);
-            if (isDuplicateHookError(err)) {
+            if (isUniqueConstraintError(err)) {
               return json({ ok: true, duplicate: true });
             }
             throw err;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,18 +15,21 @@ catalog:
   typescript: ^5.9.3
   vite: ^8.0.0
   vitest: ^4.1.4
+
 overrides:
   esbuild@<=0.24.2: ">=0.25.0"
   unicorn-magic: 0.4.0
   zod@^4.0.0: 4.3.5
+
 patchedDependencies:
   "@earendil-works/pi-ai": patches/@earendil-works__pi-ai.patch
+
 allowBuilds:
+  better-sqlite3: true
   "@mongodb-js/zstd": false
   "@parcel/watcher": false
   "@prisma/client": false
   "@prisma/engines": false
-  better-sqlite3: false
   core-js: false
   esbuild: false
   fallow: false
@@ -37,6 +40,7 @@ allowBuilds:
   protobufjs: false
   sharp: false
   workerd: false
+
 minimumReleaseAgeExclude:
   - "@earendil-works/pi-agent-core@0.75.4"
   - "@earendil-works/pi-ai@0.75.4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow instances can now be created without a prior read phase.

* **Bug Fixes**
  * Database constraint errors are normalized and detected more reliably across engines.
  * Duplicate webhook/instance creations consistently surface as duplicate/409 responses.
  * Transaction conflicts and retryable DB errors are handled more consistently.

* **Tests**
  * Added coverage for constraint normalization, transaction retry behavior, and workflow instance creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rejot-dev/fragno/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->