### PR TITLE
feat(workflows): add waitForEvent onConsume hook

### DIFF
--- a/.changeset/wait-event-on-consume.md
+++ b/.changeset/wait-event-on-consume.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/workflows": patch
+"@fragno-dev/pi-fragment": patch
+---
+
+feat: add waitForEvent onConsume hooks for event consumption side effects

--- a/packages/fragment-workflows/src/runner/step.ts
+++ b/packages/fragment-workflows/src/runner/step.ts
@@ -15,6 +15,7 @@ import type {
   WorkflowStepEmissionsCleanupHookPayload,
   WorkflowStep,
   WorkflowStepConfig,
+  WorkflowStepConsumeTx,
   WorkflowStepEvent,
   WorkflowStepTx,
 } from "../workflow";
@@ -598,7 +599,14 @@ export class RunnerStep implements WorkflowStep {
 
   async waitForEvent<T = unknown>(
     name: string,
-    options: { type: string; timeout?: WorkflowDuration },
+    options: {
+      type: string;
+      timeout?: WorkflowDuration;
+      onConsume?: (
+        tx: WorkflowStepConsumeTx,
+        event: { type: string; payload: Readonly<T>; timestamp: Date },
+      ) => Promise<void> | void;
+    },
   ): Promise<{ type: string; payload: Readonly<T>; timestamp: Date }> {
     const identity = this.#createStepIdentity("waitForEvent", name);
     const { stepKey } = identity;
@@ -614,16 +622,79 @@ export class RunnerStep implements WorkflowStep {
 
     const event = this.#findPendingEvent(options.type, snapshot?.wakeAt ?? null);
     if (event) {
-      this.#queueEventUpdate(event, {
-        consumedByStepKey: stepKey,
-      });
-      event.consumedByStepKey = stepKey;
-
       const result = {
         type: event.type,
         payload: (event.payload ?? null) as Readonly<T>,
         timestamp: event.createdAt,
       };
+      const txQueue = this.#createStepTxQueue();
+      const livePumpHandle = this.#stepEmissions.getOrCreate(
+        workflowStepLivePumpKey(this.#workflowName, this.#instanceId),
+        () =>
+          createWorkflowStepLivePump({
+            handlerTx: this.#handlerTx,
+            workflowName: this.#workflowName,
+            instanceId: this.#instanceId,
+          }),
+      );
+      livePumpHandle.pump.setHandlerTx(this.#handlerTx);
+      const emissionScope = livePumpHandle.pump.openScope(stepKey, {
+        stepKey,
+        epoch: this.#createEpoch(),
+        queueEventConsumption: () => {},
+        isEventConsumptionQueued: () => false,
+      });
+
+      const consumeTx: WorkflowStepConsumeTx = {
+        serviceCalls: txQueue.tx.serviceCalls,
+        mutate: txQueue.tx.mutate,
+        emit: (payload: unknown) => {
+          WorkflowsLogger.debug("workflow waitForEvent tx.emit", () => ({
+            workflowName: this.#workflowName,
+            instanceId: this.#instanceId,
+            stepKey,
+          }));
+          emissionScope.enqueueOutgoing(payload);
+        },
+      };
+
+      try {
+        await options.onConsume?.(consumeTx, result);
+      } catch (error) {
+        const err = toError(error);
+        this.#upsertStep(stepKey, {
+          name,
+          type: "waitForEvent",
+          status: "errored",
+          attempts: snapshot?.attempts ?? 0,
+          maxAttempts: snapshot?.maxAttempts ?? 1,
+          timeoutMs: snapshot?.timeoutMs ?? null,
+          parentStepKey: identity.parentStepKey,
+          depth: identity.depth,
+          errorName: err.name,
+          errorMessage: err.message,
+          waitEventType: options.type,
+          nextRetryAt: null,
+          wakeAt: null,
+        });
+        throw err;
+      } finally {
+        await emissionScope.flushAndClose();
+        await livePumpHandle.close();
+        this.#queueStepEmissionCleanup({
+          workflowName: this.#workflowName,
+          instanceId: this.#instanceId,
+          instanceRef: this.#state.instance.id.toString(),
+          stepKey,
+          epoch: emissionScope.meta.epoch,
+        });
+      }
+
+      this.#queueEventUpdate(event, {
+        consumedByStepKey: stepKey,
+      });
+      event.consumedByStepKey = stepKey;
+      txQueue.commitSuccess();
 
       this.#upsertStep(stepKey, {
         name,

--- a/packages/fragment-workflows/src/scenario-runner.test.ts
+++ b/packages/fragment-workflows/src/scenario-runner.test.ts
@@ -15,7 +15,12 @@ import type { WorkflowStepLivePump } from "./runner/step-live-pump";
 import { defineScenario, runScenario } from "./scenario";
 import { workflowsSchema } from "./schema";
 import { createWorkflowsTestRuntime } from "./test";
-import { defineWorkflow, WaitForEventTimeoutError, type InstanceStatus } from "./workflow";
+import {
+  defineWorkflow,
+  WaitForEventTimeoutError,
+  type AnyTxResult,
+  type InstanceStatus,
+} from "./workflow";
 
 describe("Workflows Runner (Scenario DSL)", () => {
   test("rejects read steps that both store and assert", async () => {
@@ -2747,6 +2752,158 @@ describe("Workflows Runner (Scenario DSL)", () => {
             const statuses = rows.map((r) => r.status).sort();
             expect(statuses).toEqual(["done", "waiting"]);
             expect(statuses).not.toContain("error-cleanup");
+          },
+        }),
+      ],
+    });
+
+    await runScenario(scenario);
+  });
+
+  test("waitForEvent onConsume can persist data before the wait step completes", async () => {
+    const consumeMutationSchema = schema("wait_for_event_on_consume_test", (s) =>
+      s.addTable("consumed_event", (t) =>
+        t
+          .addColumn("id", idColumn())
+          .addColumn("approvalId", column("string"))
+          .addColumn("decision", column("string"))
+          .addColumn(
+            "createdAt",
+            column("timestamp").defaultTo((b) => b.now()),
+          )
+          .createIndex("idx_consumed_event_approval", ["approvalId"]),
+      ),
+    );
+
+    const consumeMutationFragmentDefinition = defineFragment("wait-for-event-on-consume-fragment")
+      .extend(withDatabase(consumeMutationSchema))
+      .providesService("consumedEvents", ({ defineService }) =>
+        defineService({
+          record: function (approvalId: string, decision: string) {
+            return this.serviceTx(consumeMutationSchema)
+              .mutate(({ uow }) => {
+                uow.create("consumed_event", { approvalId, decision });
+              })
+              .build();
+          },
+        }),
+      )
+      .build();
+
+    let consumeMutationFragment: InstantiatedFragmentFromDefinition<
+      typeof consumeMutationFragmentDefinition
+    >;
+
+    const OnConsumeMutationWorkflow = defineWorkflow(
+      { name: "wait-for-event-on-consume-workflow" },
+      async (_event, step) => {
+        const approval = await step.waitForEvent<{ approvalId: string; decision: string }>(
+          "approval",
+          {
+            type: "approval",
+            onConsume: (tx, event) => {
+              tx.mutate((ctx) => {
+                ctx.forSchema(consumeMutationSchema).create("consumed_event", {
+                  approvalId: event.payload.approvalId,
+                  decision: event.payload.decision,
+                });
+              });
+              tx.serviceCalls(() => [
+                consumeMutationFragment.services.consumedEvents.record(
+                  event.payload.approvalId,
+                  "service-approved",
+                ) as AnyTxResult,
+              ]);
+              tx.emit({
+                type: "approval_consumed",
+                approvalId: event.payload.approvalId,
+                decision: event.payload.decision,
+              });
+            },
+          },
+        );
+        return { decision: approval.payload.decision };
+      },
+    );
+
+    const workflows = { ON_CONSUME_MUTATE: OnConsumeMutationWorkflow };
+    const scenario = defineScenario({
+      name: "wait-for-event-on-consume-mutation",
+      workflows,
+      harness: {
+        configureBuilder: (builder) =>
+          builder.withFragmentFactory(
+            "consumeMutation",
+            consumeMutationFragmentDefinition,
+            ({ adapter }) => {
+              const fragment = instantiate(consumeMutationFragmentDefinition)
+                .withOptions({ databaseAdapter: adapter })
+                .build();
+              consumeMutationFragment = fragment;
+              return fragment;
+            },
+          ),
+      },
+      steps: ({ workflow, runner }) => [
+        workflow.create({ workflow: "ON_CONSUME_MUTATE", id: "on-consume-1" }),
+        workflow.event({
+          workflow: "ON_CONSUME_MUTATE",
+          instanceId: "on-consume-1",
+          event: {
+            type: "approval",
+            payload: { approvalId: "approval-1", decision: "approved" },
+          },
+        }),
+        runner.runUntilIdle({
+          workflow: "ON_CONSUME_MUTATE",
+          instanceId: "on-consume-1",
+          reason: "create",
+        }),
+        workflow.read({
+          read: (ctx) => ctx.state.getStatus("ON_CONSUME_MUTATE", "on-consume-1"),
+          assert: (status) => {
+            expect(status).toMatchObject({ status: "complete", output: { decision: "approved" } });
+          },
+        }),
+        workflow.read({
+          read: async (ctx) => {
+            return (
+              await ctx.harness.fragments["consumeMutation"].db
+                .createUnitOfWork("read")
+                .forSchema(consumeMutationSchema)
+                .find("consumed_event", (b) => b.whereIndex("primary"))
+                .executeRetrieve()
+            )[0];
+          },
+          assert: (rows) => {
+            expect(rows).toHaveLength(2);
+            expect(rows).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  approvalId: "approval-1",
+                  decision: "approved",
+                }),
+                expect.objectContaining({
+                  approvalId: "approval-1",
+                  decision: "service-approved",
+                }),
+              ]),
+            );
+          },
+        }),
+        workflow.read({
+          read: (ctx) => ctx.state.getEmissions("ON_CONSUME_MUTATE", "on-consume-1"),
+          assert: (emissions) => {
+            expect(emissions).toContainEqual(
+              expect.objectContaining({
+                stepKey: "waitForEvent:approval",
+                payload: {
+                  type: "approval_consumed",
+                  approvalId: "approval-1",
+                  decision: "approved",
+                },
+              }),
+            );
           },
         }),
       ],

--- a/packages/fragment-workflows/src/user-scenarios.test.ts
+++ b/packages/fragment-workflows/src/user-scenarios.test.ts
@@ -552,6 +552,54 @@ describe("Workflows Runner (User Scenarios)", () => {
     await runScenario(scenario);
   });
 
+  test("waitForEvent runs onConsume before completing the wait step", async () => {
+    let consumedPayload: { approved: boolean } | undefined;
+    let txWasProvided = false;
+    const ApprovalWorkflow = defineWorkflow(
+      { name: "approval-on-consume-workflow" },
+      async (_event, step) => {
+        const approval = await step.waitForEvent<{ approved: boolean }>("approval", {
+          type: "approval",
+          onConsume: (tx, event) => {
+            txWasProvided = typeof tx.mutate === "function";
+            consumedPayload = event.payload;
+          },
+        });
+        return { approved: approval.payload.approved };
+      },
+    );
+
+    const workflows = { APPROVAL: ApprovalWorkflow };
+    const scenario = defineScenario({
+      name: "wait-for-event-on-consume",
+      workflows,
+      steps: ({ workflow, runner }) => [
+        workflow.create({ workflow: "APPROVAL", id: "approval-on-consume-1" }),
+        workflow.event({
+          workflow: "APPROVAL",
+          instanceId: "approval-on-consume-1",
+          event: { type: "approval", payload: { approved: true } },
+        }),
+        runner.runUntilIdle({
+          workflow: "APPROVAL",
+          instanceId: "approval-on-consume-1",
+          reason: "create",
+        }),
+        workflow.assert(async (ctx) => {
+          const status = await ctx.state.getStatus("APPROVAL", "approval-on-consume-1");
+          const events = await ctx.state.getEvents("APPROVAL", "approval-on-consume-1");
+
+          expect(status).toMatchObject({ status: "complete", output: { approved: true } });
+          expect(events[0]?.consumedByStepKey).toBe("waitForEvent:approval");
+          expect(consumedPayload).toEqual({ approved: true });
+          expect(txWasProvided).toBe(true);
+        }),
+      ],
+    });
+
+    await runScenario(scenario);
+  });
+
   test("duplicate events with same type are consumed only once per wait step", async () => {
     // report: at-least-once webhook delivery may send the same event multiple times;
     // only one should be consumed by the matching waitForEvent step.

--- a/packages/fragment-workflows/src/workflow.ts
+++ b/packages/fragment-workflows/src/workflow.ts
@@ -54,9 +54,14 @@ export type WorkflowStepEventHandler<TPayload = unknown> = (
   event: WorkflowStepEvent<TPayload>,
 ) => void | Promise<void>;
 
-export type WorkflowStepTx = {
+export type WorkflowStepConsumeTx = {
   serviceCalls: (factory: () => readonly AnyTxResult[]) => void;
   mutate: (fn: (ctx: HandlerTxContext<HooksMap>) => void) => void;
+  /** Persist an outbound workflow-authored step emission. */
+  emit: (payload: unknown) => void;
+};
+
+export type WorkflowStepTx = WorkflowStepConsumeTx & {
   onTerminalError: {
     /**
      * Queue DB mutations that should only commit if the enclosing step ends in a terminal error
@@ -65,8 +70,6 @@ export type WorkflowStepTx = {
      */
     mutate: (fn: (ctx: HandlerTxContext<HooksMap>) => void) => void;
   };
-  /** Persist an outbound workflow-authored step emission. */
-  emit: (payload: unknown) => void;
   /**
    * Observe durable workflow events of an exact type while this step is active.
    * Handlers may replay on retry; event.consume() commits only when this step completes.
@@ -86,7 +89,14 @@ export interface WorkflowStep {
   sleepUntil(name: string, timestamp: Date | number): Promise<void>;
   waitForEvent<T = unknown>(
     name: string,
-    options: { type: string; timeout?: WorkflowDuration },
+    options: {
+      type: string;
+      timeout?: WorkflowDuration;
+      onConsume?: (
+        tx: WorkflowStepConsumeTx,
+        event: { type: string; payload: Readonly<T>; timestamp: Date },
+      ) => Promise<void> | void;
+    },
   ): Promise<{ type: string; payload: Readonly<T>; timestamp: Date }>;
 }
 

--- a/packages/pi-fragment/src/pi/dsl.ts
+++ b/packages/pi-fragment/src/pi/dsl.ts
@@ -7,6 +7,7 @@ import {
   type WorkflowsRegistry,
   type WorkflowStep,
   type WorkflowStepConfig,
+  type WorkflowStepConsumeTx,
 } from "@fragno-dev/workflows/workflow";
 import type { TSchema as TypeBoxSchema } from "typebox";
 
@@ -65,6 +66,10 @@ export type PiWorkflowContext<TParams = unknown> = {
     options?: {
       allowed?: PiSessionCommandPayload["kind"][];
       timeout?: WorkflowDuration;
+      onConsume?: (
+        tx: WorkflowStepConsumeTx,
+        command: PiSessionCommandPayload,
+      ) => Promise<void> | void;
     },
   ): Promise<PiSessionCommandPayload>;
   sleep(name: string, duration: WorkflowDuration): Promise<void>;
@@ -218,6 +223,13 @@ export const compilePiWorkflow = <
             {
               type: "command",
               timeout: options?.timeout,
+              onConsume: options?.onConsume
+                ? (tx, event) => {
+                    if (!options.allowed || options.allowed.includes(event.payload.kind)) {
+                      return options.onConsume?.(tx, event.payload);
+                    }
+                  }
+                : undefined,
             },
           );
           const command = commandEvent.payload;

--- a/packages/pi-fragment/src/pi/workflows/interactive-chat-workflow.ts
+++ b/packages/pi-fragment/src/pi/workflows/interactive-chat-workflow.ts
@@ -6,7 +6,6 @@ import { piSchema } from "../../schema";
 import { definePiWorkflow } from "../dsl";
 import type { PiPromptInput, PiSessionCommandPayload } from "../types";
 import type { PiAgentRunMode } from "../workflow/agent-runner";
-import type { PiAgentStepResult } from "../workflow/pi-agent-step";
 
 const WAIT_FOR_COMMAND_TIMEOUT = "1 hour" as const;
 
@@ -134,8 +133,6 @@ const commandPayloadSchema: z.ZodType<PiSessionCommandPayload> = z.discriminated
   z.object({ commandId: z.string(), kind: z.literal("complete"), reason: z.string().optional() }),
 ]);
 
-type CommandStepResult = PiAgentStepResult | { type: "noop" } | { type: "complete" };
-
 const waitStepName = (commandIndex: number) => `wait-command-${commandIndex}`;
 const commandStepName = (commandIndex: number, kind: PiSessionCommandPayload["kind"]) =>
   `command-${commandIndex}-${kind}`;
@@ -176,6 +173,31 @@ export const interactiveChatWorkflow = definePiWorkflow(
       const receivedCommand = commandPayloadSchema.parse(
         await ctx.waitForEvent(waitStepName(commandIndex), {
           timeout: WAIT_FOR_COMMAND_TIMEOUT,
+          onConsume: (tx, payload) => {
+            const consumedCommand = commandPayloadSchema.parse(payload);
+            const normalizedCommand =
+              consumedCommand.kind === "steer"
+                ? ({ ...consumedCommand, kind: "followUp" } as const)
+                : consumedCommand;
+            const consumedCommandRunsAgent =
+              canRunCommand(normalizedCommand, status) &&
+              normalizedCommand.kind !== "complete" &&
+              normalizedCommand.kind !== "abort";
+
+            if (consumedCommandRunsAgent) {
+              return;
+            }
+
+            tx.mutate(({ forSchema }) => {
+              const uow = forSchema(piSchema);
+              uow.update("session", ctx.sessionId, (builder) =>
+                builder.set({
+                  status: normalizedCommand.kind === "complete" ? "complete" : "active",
+                  updatedAt: uow.now(),
+                }),
+              );
+            });
+          },
         }),
       );
 
@@ -189,48 +211,21 @@ export const interactiveChatWorkflow = definePiWorkflow(
       const commandRunsAgent =
         canRunCommand(command, status) && command.kind !== "complete" && command.kind !== "abort";
 
-      let result: CommandStepResult;
-      if (commandRunsAgent) {
-        result = await ctx.agent(params.agentName).run(stepName, {
-          mode: toRunMode(command),
-          input: toPromptInput(command),
-          messages,
-          systemPrompt: params.systemPrompt,
-          turnId: `${ctx.sessionId}:${turn}`,
-        });
-      } else {
-        result = await ctx.step.do(
-          stepName,
-          {
-            retries: { limit: 1, delay: "0 ms", backoff: "constant" },
-          },
-          (tx) => {
-            tx.mutate(({ forSchema }) => {
-              const uow = forSchema(piSchema);
-              uow.update("session", ctx.sessionId, (builder) =>
-                builder.set({
-                  status: command.kind === "complete" ? "complete" : "active",
-                  updatedAt: uow.now(),
-                }),
-              );
-            });
-
-            if (command.kind === "complete") {
-              return { type: "complete" };
-            }
-
-            return { type: "noop" };
-          },
-        );
-      }
-
-      if (result.type === "complete") {
+      if (command.kind === "complete") {
         return { messages };
       }
 
-      if (result.type !== "agent-run") {
+      if (!commandRunsAgent) {
         continue;
       }
+
+      const result = await ctx.agent(params.agentName).run(stepName, {
+        mode: toRunMode(command),
+        input: toPromptInput(command),
+        messages,
+        systemPrompt: params.systemPrompt,
+        turnId: `${ctx.sessionId}:${turn}`,
+      });
 
       messages = [...messages, ...result.messages];
       status = result.stopReason === "error" ? "waiting-to-continue" : "idle";


### PR DESCRIPTION
Adds a waitForEvent onConsume hook that receives a limited transaction object before the consumed event completes the wait step. The hook can queue mutations, service calls, and workflow emissions that commit with the consumed event.