### PR TITLE
fix(workflows,pi-fragment): filter stale step emissions

### DIFF
--- a/.changeset/slow-buses-restore.md
+++ b/.changeset/slow-buses-restore.md
@@ -1,0 +1,7 @@
+---
+"@fragno-dev/db": patch
+"@fragno-dev/workflows": patch
+"@fragno-dev/pi-fragment": patch
+---
+
+fix: restore interrupted Pi agent turns from live step emissions and publish commit markers.

--- a/.changeset/stale-step-emissions.md
+++ b/.changeset/stale-step-emissions.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/workflows": patch
+"@fragno-dev/pi-fragment": patch
+---
+
+fix: filter stale live step emissions after a competing epoch commits.

--- a/apps/backoffice/app/routes/backoffice/sessions/session-detail.tsx
+++ b/apps/backoffice/app/routes/backoffice/sessions/session-detail.tsx
@@ -107,6 +107,8 @@ export default function BackofficeOrganisationPiSessionDetail() {
     return true;
   };
 
+  const handleContinue = () => liveSession.sendCommand({ kind: "continue" });
+
   const handleStop = () =>
     liveSession.sendCommand({ kind: "abort", reason: "Stopped from backoffice UI" });
 
@@ -160,6 +162,8 @@ export default function BackofficeOrganisationPiSessionDetail() {
         readyForInput={liveSession.readyForInput}
         disabledReason={disabledReason}
         error={liveSession.sendError}
+        needsNudge={liveSession.needsNudge}
+        onContinue={handleContinue}
         onSend={handleSend}
         onStop={handleStop}
       />

--- a/apps/backoffice/app/routes/backoffice/sessions/session-detail/components.tsx
+++ b/apps/backoffice/app/routes/backoffice/sessions/session-detail/components.tsx
@@ -261,6 +261,8 @@ export function SessionConversationPanel({
 export function SessionComposer({
   busy,
   error,
+  needsNudge,
+  onContinue,
   onSend,
   onStop,
   readyForInput,
@@ -269,6 +271,8 @@ export function SessionComposer({
   readyForInput: boolean;
   disabledReason?: string | null;
   error: string | null;
+  needsNudge: boolean;
+  onContinue: () => Promise<unknown> | unknown;
   onSend: (command: { kind: "followUp" | "steer"; text: string }) => Promise<boolean> | boolean;
   onStop: () => Promise<unknown> | unknown;
 }) {
@@ -322,14 +326,26 @@ export function SessionComposer({
         />
 
         <div className="flex flex-wrap items-center justify-between gap-2 border-t border-[color:var(--bo-border)] bg-[var(--bo-panel)] px-2 py-1.5">
-          <button
-            type="button"
-            disabled={busy || readyForInput}
-            onClick={onStop}
-            className="min-h-8 border border-red-400/40 bg-red-500/10 px-2.5 text-[10px] font-semibold tracking-[0.14em] text-red-500 uppercase transition-[border-color,background-color,transform,opacity] duration-150 hover:border-red-400 hover:bg-red-500/15 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100"
-          >
-            Stop
-          </button>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              disabled={busy || readyForInput}
+              onClick={onStop}
+              className="min-h-8 border border-red-400/40 bg-red-500/10 px-2.5 text-[10px] font-semibold tracking-[0.14em] text-red-500 uppercase transition-[border-color,background-color,transform,opacity] duration-150 hover:border-red-400 hover:bg-red-500/15 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100"
+            >
+              Stop
+            </button>
+            {needsNudge ? (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onContinue}
+                className="min-h-8 border border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] px-2.5 text-[10px] font-semibold tracking-[0.14em] text-[var(--bo-accent-fg)] uppercase transition-[border-color,background-color,transform,opacity] duration-150 hover:border-[color:var(--bo-accent-strong)] active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100"
+              >
+                Continue
+              </button>
+            ) : null}
+          </div>
           <div className="flex items-center gap-1.5">
             <div className="grid grid-cols-2 border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] p-0.5">
               <button

--- a/packages/fragment-workflows/package.json
+++ b/packages/fragment-workflows/package.json
@@ -77,6 +77,7 @@
   "dependencies": {
     "@fragno-dev/core": "workspace:*",
     "@fragno-dev/db": "workspace:*",
+    "nanostores": "^1.2.0",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/packages/fragment-workflows/src/client/clients.ts
+++ b/packages/fragment-workflows/src/client/clients.ts
@@ -1,14 +1,58 @@
 import { createClientBuilder } from "@fragno-dev/core/client";
 import type { FragnoPublicClientConfig } from "@fragno-dev/core/client";
+import { computed } from "nanostores";
 
 import { currentStepLabel, isTerminalStatus, isWaitingStatus, statusLabel } from "../workflow";
 import { workflowsFragmentDefinitionClient } from "./definition";
 import { workflowsRoutesFactoryClient } from "./routes";
 
+type CurrentStepEmission = {
+  stepKey: string;
+  epoch: string;
+  payload: unknown;
+};
+
+const isStepCommittedEmission = (emission: CurrentStepEmission) => {
+  const payload = emission.payload;
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "control" in payload &&
+    payload.control === "step-committed"
+  );
+};
+
+const filterCurrentStepEmissions = <TEmission extends CurrentStepEmission>(
+  emissions: TEmission[],
+) => {
+  const committedEpochsByStep = new Map<string, string>();
+  for (const emission of emissions) {
+    if (isStepCommittedEmission(emission)) {
+      committedEpochsByStep.set(emission.stepKey, emission.epoch);
+    }
+  }
+
+  return emissions.filter((emission) => {
+    const committedEpoch = committedEpochsByStep.get(emission.stepKey);
+    return !committedEpoch || committedEpoch === emission.epoch;
+  });
+};
+
 export function createWorkflowsClients(fragnoConfig: FragnoPublicClientConfig = {}) {
   const builder = createClientBuilder(workflowsFragmentDefinitionClient, fragnoConfig, [
     workflowsRoutesFactoryClient,
   ]);
+  const rawCurrentStepEmissions = builder.createHook(
+    "/:workflowName/instances/:instanceId/current-step/emissions",
+  );
+  const currentStepEmissions = builder.createStore(
+    (args: Parameters<typeof rawCurrentStepEmissions.store>[0]) => {
+      const store = rawCurrentStepEmissions.store(args);
+      return computed(store, (state) =>
+        state.data ? { ...state, data: filterCurrentStepEmissions(state.data) } : state,
+      );
+    },
+  );
 
   return {
     useWorkflows: builder.createHook("/"),
@@ -40,9 +84,7 @@ export function createWorkflowsClients(fragnoConfig: FragnoPublicClientConfig = 
       },
     ),
     useInstance: builder.createHook("/:workflowName/instances/:instanceId"),
-    useCurrentStepEmissions: builder.createHook(
-      "/:workflowName/instances/:instanceId/current-step/emissions",
-    ),
+    useCurrentStepEmissions: currentStepEmissions,
     useInstanceHistory: builder.createHook("/:workflowName/instances/:instanceId/history"),
     usePauseInstance: builder.createMutator(
       "POST",

--- a/packages/fragment-workflows/src/new-runner.ts
+++ b/packages/fragment-workflows/src/new-runner.ts
@@ -5,9 +5,12 @@ import type { StandardSchemaV1 } from "@fragno-dev/core/api";
 import type { DatabaseRequestContext, IUnitOfWork } from "@fragno-dev/db";
 
 import { applyOutcome, applyRunnerMutations, type RunnerTaskOutcome } from "./runner/plan-writes";
-import { createRunnerState } from "./runner/state";
+import { createRunnerState, type RunnerState } from "./runner/state";
 import { RunnerStep, RunnerStepSuspended } from "./runner/step";
-import type { WorkflowStepLivePumpRegistry } from "./runner/step-live-pump";
+import {
+  workflowStepLivePumpKey,
+  type WorkflowStepLivePumpRegistry,
+} from "./runner/step-live-pump";
 import type {
   RunnerTaskKind,
   WorkflowEventRecord,
@@ -286,6 +289,28 @@ function planEarlyReschedule(
   return null;
 }
 
+function addStepCommittedEmissions(uow: IUnitOfWork, state: RunnerState) {
+  const mutatedStepKeys = new Set<string>([
+    ...state.mutations.stepCreates.keys(),
+    ...state.mutations.stepUpdates.keys(),
+  ]);
+  const schemaUow = uow.forSchema(workflowsSchema);
+
+  for (const request of state.mutations.stepEmissionCleanupRequests) {
+    if (!mutatedStepKeys.has(request.stepKey)) {
+      continue;
+    }
+    schemaUow.create("workflow_step_emission", {
+      instanceRef: request.instanceRef,
+      stepKey: request.stepKey,
+      epoch: request.epoch,
+      sequence: 0,
+      actor: "system",
+      payload: { control: "step-committed", epoch: request.epoch },
+    });
+  }
+}
+
 async function planRunTask(
   selection: RunnerTickSelectionResult,
   ctx: RunnerTickContext,
@@ -306,6 +331,7 @@ async function planRunTask(
     operations: [
       (uow) => {
         applyRunnerMutations(uow, state);
+        addStepCommittedEmissions(uow, state);
         applyOutcome(uow, selection.instance, outcome);
       },
     ],
@@ -549,6 +575,14 @@ export async function runWorkflowsTick(options: {
       return 0;
     }
     throw err;
+  }
+
+  const livePump = options.stepEmissions?.get(
+    workflowStepLivePumpKey(options.payload.workflowName, options.payload.instanceId),
+  );
+  if (livePump) {
+    livePump.setHandlerTx(options.busHandlerTx ?? options.handlerTx);
+    await livePump.flushNow();
   }
 
   return processed;

--- a/packages/fragment-workflows/src/new-runner.ts
+++ b/packages/fragment-workflows/src/new-runner.ts
@@ -9,12 +9,14 @@ import { createRunnerState, type RunnerState } from "./runner/state";
 import { RunnerStep, RunnerStepSuspended } from "./runner/step";
 import {
   workflowStepLivePumpKey,
+  type WorkflowStepEmission,
   type WorkflowStepLivePumpRegistry,
 } from "./runner/step-live-pump";
 import type {
   RunnerTaskKind,
   WorkflowEventRecord,
   WorkflowInstanceRecord,
+  WorkflowStepEmissionRecord,
   WorkflowStepRecord,
 } from "./runner/types";
 import { toError } from "./runner/utils";
@@ -38,6 +40,7 @@ type RunnerTickSelection = {
   instance: WorkflowInstanceRecord | null;
   steps: WorkflowStepRecord[];
   events: WorkflowEventRecord[];
+  stepEmissions: WorkflowStepEmissionRecord[];
 };
 
 type RunnerTickPlan = {
@@ -51,12 +54,14 @@ type RunnerTickContext = {
   busHandlerTx: DatabaseRequestContext["handlerTx"];
   createEpoch: () => string;
   stepEmissions?: WorkflowStepLivePumpRegistry;
+  stepEmissionsToPublish: WorkflowStepEmission[];
 };
 
 type RunnerTickSelectionResult = {
   instance: WorkflowInstanceRecord;
   steps: WorkflowStepRecord[];
   events: WorkflowEventRecord[];
+  stepEmissions: WorkflowStepEmissionRecord[];
 };
 
 class WorkflowOutputValidationError extends Error {
@@ -144,6 +149,7 @@ function selectTickInput(selection: RunnerTickSelection): RunnerTickSelectionRes
     instance,
     steps: selection.steps,
     events: selection.events,
+    stepEmissions: selection.stepEmissions,
   };
 }
 
@@ -289,7 +295,11 @@ function planEarlyReschedule(
   return null;
 }
 
-function addStepCommittedEmissions(uow: IUnitOfWork, state: RunnerState) {
+function addStepCommittedEmissions(
+  uow: IUnitOfWork,
+  state: RunnerState,
+  publishedStepEmissions: WorkflowStepEmission[],
+) {
   const mutatedStepKeys = new Set<string>([
     ...state.mutations.stepCreates.keys(),
     ...state.mutations.stepUpdates.keys(),
@@ -300,13 +310,25 @@ function addStepCommittedEmissions(uow: IUnitOfWork, state: RunnerState) {
     if (!mutatedStepKeys.has(request.stepKey)) {
       continue;
     }
-    schemaUow.create("workflow_step_emission", {
+    const createdAt = new Date();
+    const payload = { control: "step-committed" as const, epoch: request.epoch };
+    const id = schemaUow.create("workflow_step_emission", {
       instanceRef: request.instanceRef,
       stepKey: request.stepKey,
       epoch: request.epoch,
       sequence: 0,
       actor: "system",
-      payload: { control: "step-committed", epoch: request.epoch },
+      payload,
+      createdAt,
+    });
+    publishedStepEmissions.push({
+      id: id.toString(),
+      actor: "system",
+      stepKey: request.stepKey,
+      epoch: request.epoch,
+      sequence: 0,
+      payload,
+      createdAt,
     });
   }
 }
@@ -317,7 +339,12 @@ async function planRunTask(
   payload: WorkflowEnqueuedHookPayload & { timestamp: Date },
 ): Promise<RunnerTickPlan> {
   const events = sortEventsForRunner(selection.events);
-  const state = createRunnerState(selection.instance, selection.steps, events);
+  const state = createRunnerState(
+    selection.instance,
+    selection.steps,
+    events,
+    selection.stepEmissions,
+  );
   const outcome = await runTask(
     selection.instance,
     coerceTaskKind(payload.reason),
@@ -331,7 +358,7 @@ async function planRunTask(
     operations: [
       (uow) => {
         applyRunnerMutations(uow, state);
-        addStepCommittedEmissions(uow, state);
+        addStepCommittedEmissions(uow, state, ctx.stepEmissionsToPublish);
         applyOutcome(uow, selection.instance, outcome);
       },
     ],
@@ -506,6 +533,7 @@ export async function runWorkflowsTick(options: {
   // Instance-scoped tick: we only fetch data for the payload's instance/run.
   let processed = 0;
   let mutatePhase = false;
+  const stepEmissionsToPublish: WorkflowStepEmission[] = [];
 
   try {
     await options
@@ -517,12 +545,14 @@ export async function runWorkflowsTick(options: {
             WorkflowInstanceRecord[],
             WorkflowStepRecord[],
             WorkflowEventRecord[],
+            WorkflowStepEmissionRecord[],
           ];
-          const [instances, steps, events] = retrieveResults;
+          const [instances, steps, events, stepEmissions] = retrieveResults;
           const selection: RunnerTickSelection = {
             instance: instances[0] ?? null,
             steps: steps ?? [],
             events: events ?? [],
+            stepEmissions: stepEmissions ?? [],
           };
           const plan = await buildTickPlan(
             selection,
@@ -532,6 +562,7 @@ export async function runWorkflowsTick(options: {
               busHandlerTx: options.busHandlerTx ?? options.handlerTx,
               createEpoch,
               stepEmissions: options.stepEmissions,
+              stepEmissionsToPublish,
             },
             options.payload,
           );
@@ -562,6 +593,13 @@ export async function runWorkflowsTick(options: {
                 eb("instanceRef", "=", options.payload.instanceRef),
               )
               .orderByIndex("idx_workflow_event_instanceRef_createdAt", "asc"),
+          )
+          .find("workflow_step_emission", (b) =>
+            b
+              .whereIndex("idx_workflow_step_emission_instance_createdAt_sequence_id", (eb) =>
+                eb("instanceRef", "=", options.payload.instanceRef),
+              )
+              .orderByIndex("idx_workflow_step_emission_instance_createdAt_sequence_id", "asc"),
           ),
       )
       .execute();
@@ -580,10 +618,7 @@ export async function runWorkflowsTick(options: {
   const livePump = options.stepEmissions?.get(
     workflowStepLivePumpKey(options.payload.workflowName, options.payload.instanceId),
   );
-  if (livePump) {
-    livePump.setHandlerTx(options.busHandlerTx ?? options.handlerTx);
-    await livePump.flushNow();
-  }
+  await livePump?.publishObserved(stepEmissionsToPublish);
 
   return processed;
 }

--- a/packages/fragment-workflows/src/runner.test.ts
+++ b/packages/fragment-workflows/src/runner.test.ts
@@ -111,6 +111,57 @@ describe("Workflows Runner", () => {
     expect(await readStepEmissionRows(harness, instanceId)).toHaveLength(0);
   });
 
+  test("WorkflowStepTx previousEmissions returns rows loaded before the current attempt", async () => {
+    const observedPayloads: unknown[][] = [];
+
+    const PreviousEmissionsWorkflow = defineWorkflow<
+      "previous-emissions-workflow",
+      undefined,
+      { ok: true }
+    >({ name: "previous-emissions-workflow" }, async (_event, step) => {
+      await step.do("recoverable", async (tx) => {
+        tx.emit({ type: "current-attempt" });
+        observedPayloads.push(tx.previousEmissions().map((emission) => emission.payload));
+      });
+      return { ok: true };
+    });
+
+    const harness = await createWorkflowsTestHarness({
+      workflows: { PREVIOUS_EMISSIONS: PreviousEmissionsWorkflow },
+      adapter: { type: "in-memory" },
+      testBuilder: buildDatabaseFragmentsTest(),
+      autoTickHooks: false,
+    });
+
+    const instanceId = await harness.createInstance("PREVIOUS_EMISSIONS");
+    const [instance] = (
+      await harness.db
+        .createUnitOfWork("read")
+        .forSchema(workflowsSchema)
+        .find("workflow_instance", (b) => b.whereIndex("primary"))
+        .executeRetrieve()
+    )[0];
+    expect(instance).toBeTruthy();
+
+    const seedUow = harness.db
+      .createUnitOfWork("seed-previous-emission")
+      .forSchema(workflowsSchema);
+    seedUow.create("workflow_step_emission", {
+      instanceRef: instanceId,
+      stepKey: "do:recoverable",
+      epoch: "previous-epoch",
+      sequence: 0,
+      actor: "user",
+      payload: { type: "checkpoint" },
+    });
+    const { success } = await seedUow.executeMutations();
+    expect(success).toBe(true);
+
+    await harness.tick(buildPayload(instance!, "create"));
+
+    expect(observedPayloads).toEqual([[{ type: "checkpoint" }]]);
+  });
+
   test("central step emission bus observes outbound events from the active in-process step", async () => {
     const stepEntered = deferred();
     const releaseStep = deferred();
@@ -176,6 +227,133 @@ describe("Workflows Runner", () => {
       emissionBus.stop();
       releaseStep.resolve();
       await tick;
+    }
+  });
+
+  test("central step emission bus observes step commit marker before the tick resolves", async () => {
+    const observed: unknown[] = [];
+    const stepEmissions = createStepEmissions();
+
+    const CommitFlushWorkflow = defineWorkflow<
+      "central-message-bus-commit-flush-workflow",
+      undefined,
+      { ok: true }
+    >({ name: "central-message-bus-commit-flush-workflow" }, async (_event, step) => {
+      await step.do("commit marker", async (tx) => {
+        tx.emit({ type: "started" });
+      });
+      return { ok: true };
+    });
+
+    const harness = await createWorkflowsTestHarness({
+      workflows: { COMMIT_FLUSH: CommitFlushWorkflow },
+      adapter: { type: "in-memory" },
+      testBuilder: buildDatabaseFragmentsTest(),
+      autoTickHooks: false,
+      fragmentConfig: { stepEmissions },
+    });
+
+    const instanceId = await harness.createInstance("COMMIT_FLUSH");
+    const [instance] = (
+      await harness.db
+        .createUnitOfWork("read")
+        .forSchema(workflowsSchema)
+        .find("workflow_instance", (b) => b.whereIndex("primary"))
+        .executeRetrieve()
+    )[0];
+    expect(instance).toBeTruthy();
+
+    const emissionBus = await harness.fragment.inContext(function () {
+      return openBus(stepEmissions, {
+        handlerTx: this.handlerTx,
+        workflowName: "central-message-bus-commit-flush-workflow",
+        instanceId,
+      });
+    });
+    const unsubscribe = emissionBus.observe((message) => {
+      observed.push(message.payload);
+    });
+    let flushCount = 0;
+    const originalFlushNow = emissionBus.flushNow.bind(emissionBus);
+    emissionBus.flushNow = async () => {
+      flushCount += 1;
+      await originalFlushNow();
+    };
+
+    try {
+      await harness.tick(buildPayload(instance!, "create"));
+      emissionBus.stop();
+
+      expect(observed).toEqual(
+        expect.arrayContaining([expect.objectContaining({ control: "step-committed" })]),
+      );
+      expect(flushCount).toBe(1);
+    } finally {
+      unsubscribe();
+      emissionBus.stop();
+    }
+  });
+
+  test("central step emission bus snapshot dedupes a commit marker already observed by a flush", async () => {
+    const stepEmissions = createStepEmissions();
+
+    const CommitSnapshotWorkflow = defineWorkflow<
+      "central-message-bus-commit-snapshot-workflow",
+      undefined,
+      { ok: true }
+    >({ name: "central-message-bus-commit-snapshot-workflow" }, async (_event, step) => {
+      await step.do("commit marker", async (tx) => {
+        tx.emit({ type: "started" });
+      });
+      return { ok: true };
+    });
+
+    const harness = await createWorkflowsTestHarness({
+      workflows: { COMMIT_SNAPSHOT: CommitSnapshotWorkflow },
+      adapter: { type: "in-memory" },
+      testBuilder: buildDatabaseFragmentsTest(),
+      autoTickHooks: false,
+      fragmentConfig: { stepEmissions },
+    });
+
+    const instanceId = await harness.createInstance("COMMIT_SNAPSHOT");
+    const [instance] = (
+      await harness.db
+        .createUnitOfWork("read")
+        .forSchema(workflowsSchema)
+        .find("workflow_instance", (b) => b.whereIndex("primary"))
+        .executeRetrieve()
+    )[0];
+    expect(instance).toBeTruthy();
+
+    const emissionBus = await harness.fragment.inContext(function () {
+      return openBus(stepEmissions, {
+        handlerTx: this.handlerTx,
+        workflowName: "central-message-bus-commit-snapshot-workflow",
+        instanceId,
+      });
+    });
+    const flushNow = emissionBus.flushNow.bind(emissionBus);
+    const publishObserved = emissionBus.publishObserved.bind(emissionBus);
+    emissionBus.publishObserved = async (messages) => {
+      await flushNow();
+      await publishObserved(messages);
+    };
+
+    try {
+      await harness.tick(buildPayload(instance!, "create"));
+
+      const snapshot = await emissionBus.snapshot();
+      const commitMarkers = snapshot.filter(
+        (message) =>
+          typeof message.payload === "object" &&
+          message.payload !== null &&
+          "control" in message.payload &&
+          message.payload.control === "step-committed",
+      );
+      expect(commitMarkers).toHaveLength(1);
+    } finally {
+      emissionBus.stop();
     }
   });
 

--- a/packages/fragment-workflows/src/runner/state.ts
+++ b/packages/fragment-workflows/src/runner/state.ts
@@ -8,6 +8,7 @@ import type {
   WorkflowEventUpdate,
   WorkflowInstanceRecord,
   WorkflowStepCreateDraft,
+  WorkflowStepEmissionRecord,
   WorkflowStepRecord,
   WorkflowStepUpdateDraft,
 } from "./types";
@@ -41,6 +42,7 @@ export type RunnerState = {
   instance: WorkflowInstanceRecord;
   stepsByKey: Map<string, WorkflowStepSnapshot>;
   events: WorkflowEventRecord[];
+  stepEmissions: WorkflowStepEmissionRecord[];
   mutations: RunnerMutationBuffer;
 };
 
@@ -67,6 +69,7 @@ export function createRunnerState(
   instance: WorkflowInstanceRecord,
   steps: WorkflowStepRecord[],
   events: WorkflowEventRecord[],
+  stepEmissions: WorkflowStepEmissionRecord[],
 ): RunnerState {
   const stepsByKey = new Map<string, WorkflowStepSnapshot>();
   for (const step of steps) {
@@ -77,6 +80,7 @@ export function createRunnerState(
     instance,
     stepsByKey,
     events,
+    stepEmissions,
     mutations: createMutationBuffer(),
   };
 }

--- a/packages/fragment-workflows/src/runner/step-live-pump.ts
+++ b/packages/fragment-workflows/src/runner/step-live-pump.ts
@@ -20,7 +20,7 @@ import type { WorkflowEventRecord } from "./types";
 
 const WORKFLOW_STEP_EMISSION_PUMP_INTERVAL_MS = 100;
 
-const STEP_STARTED_PAYLOAD = { control: "step-started" };
+const STEP_STARTED_PAYLOAD = { control: "step-started" as const };
 
 type StepEmissionOpenScopeMeta = {
   stepKey: string;

--- a/packages/fragment-workflows/src/runner/step.ts
+++ b/packages/fragment-workflows/src/runner/step.ts
@@ -12,6 +12,7 @@ import { parseDurationMs } from "../utils";
 import type {
   AnyTxResult,
   WorkflowDuration,
+  WorkflowStepEmission,
   WorkflowStepEmissionsCleanupHookPayload,
   WorkflowStep,
   WorkflowStepConfig,
@@ -199,6 +200,20 @@ export class RunnerStep implements WorkflowStep {
     return identity;
   }
 
+  #previousEmissionsFor(stepKey: string): WorkflowStepEmission[] {
+    return this.#state.stepEmissions
+      .filter((emission) => emission.stepKey === stepKey)
+      .map((emission) => ({
+        id: emission.id.toString(),
+        actor: emission.actor,
+        stepKey: emission.stepKey,
+        epoch: emission.epoch,
+        sequence: emission.sequence,
+        payload: emission.payload,
+        createdAt: emission.createdAt,
+      }));
+  }
+
   #prepareWaitingDraft(
     identity: StepIdentity,
     base: {
@@ -294,7 +309,7 @@ export class RunnerStep implements WorkflowStep {
     const attempt = (snapshot?.attempts ?? 0) + 1;
     const maxAttempts = config?.retries ? config.retries.limit + 1 : 1;
     const timeoutMs = snapshot?.timeoutMs ?? null;
-    const txQueue = this.#createStepTxQueue();
+    const txQueue = this.#createStepTxQueue(identity);
     const pendingEventConsumptions = new Map<string, WorkflowEventRecord>();
     const queueEventConsumption = (event: WorkflowEventRecord, consumedByStepKey: string) => {
       if (consumedByStepKey !== identity.stepKey) {
@@ -627,7 +642,7 @@ export class RunnerStep implements WorkflowStep {
         payload: (event.payload ?? null) as Readonly<T>,
         timestamp: event.createdAt,
       };
-      const txQueue = this.#createStepTxQueue();
+      const txQueue = this.#createStepTxQueue(identity);
       const livePumpHandle = this.#stepEmissions.getOrCreate(
         workflowStepLivePumpKey(this.#workflowName, this.#instanceId),
         () =>
@@ -656,6 +671,7 @@ export class RunnerStep implements WorkflowStep {
           }));
           emissionScope.enqueueOutgoing(payload);
         },
+        previousEmissions: txQueue.tx.previousEmissions,
       };
 
       try {
@@ -785,7 +801,7 @@ export class RunnerStep implements WorkflowStep {
     this.#state.mutations.stepEmissionCleanupRequests.push(request);
   }
 
-  #createStepTxQueue(): StepTxQueue {
+  #createStepTxQueue(identity: StepIdentity): StepTxQueue {
     const pendingMutations: Array<(ctx: HandlerTxContext<HooksMap>) => void> = [];
     const pendingServiceCalls: AnyTxResult[] = [];
     const pendingTerminalErrorMutations: Array<(ctx: HandlerTxContext<HooksMap>) => void> = [];
@@ -800,6 +816,7 @@ export class RunnerStep implements WorkflowStep {
         },
       },
       emit: () => {},
+      previousEmissions: () => this.#previousEmissionsFor(identity.stepKey),
       onEvent: () => () => {},
       serviceCalls: (factory) => {
         let calls: readonly AnyTxResult[];

--- a/packages/fragment-workflows/src/scenario-runner.test.ts
+++ b/packages/fragment-workflows/src/scenario-runner.test.ts
@@ -1214,6 +1214,8 @@ describe("Workflows Runner (Scenario DSL)", () => {
           secondMessages: undefined as unknown,
           firstSharedMessages: undefined as unknown,
           secondSharedMessages: undefined as unknown,
+          firstCommittedMessages: undefined as unknown,
+          secondCommittedMessages: undefined as unknown,
         };
       },
       runners: ["first", "second", "observer"],
@@ -1392,6 +1394,51 @@ describe("Workflows Runner (Scenario DSL)", () => {
             runners.observer.resolveControl({ key: "shared:release" }),
             runners.observer.resolveControl({ key: "first:release" }),
           ],
+        }),
+        stores.firstCurrentStep.waitFor(
+          (state) =>
+            !state.loading &&
+            hasStepControl(state.data, "do:racy client message", "step-committed"),
+          {
+            storeAs: "firstCommittedMessages",
+            select: (state) => state.data,
+          },
+        ),
+        stores.secondCurrentStep.waitFor(
+          (state) =>
+            !state.loading &&
+            hasStepControl(state.data, "do:racy client message", "step-committed"),
+          {
+            storeAs: "secondCommittedMessages",
+            select: (state) => state.data,
+          },
+        ),
+        workflow.assert((ctx) => {
+          expect(ctx.vars.firstCommittedMessages).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                stepKey: "do:racy client message",
+                actor: "system",
+                payload: expect.objectContaining({ control: "step-committed" }),
+              }),
+            ]),
+          );
+          expect(ctx.vars.firstCommittedMessages).not.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                stepKey: "do:racy client message",
+                payload: { runner: "first", message: "first:started" },
+              }),
+            ]),
+          );
+          expect(ctx.vars.secondCommittedMessages).not.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                stepKey: "do:racy client message",
+                payload: { runner: "first", message: "first:started" },
+              }),
+            ]),
+          );
         }),
 
         workflow.read({

--- a/packages/fragment-workflows/src/workflow.ts
+++ b/packages/fragment-workflows/src/workflow.ts
@@ -54,11 +54,23 @@ export type WorkflowStepEventHandler<TPayload = unknown> = (
   event: WorkflowStepEvent<TPayload>,
 ) => void | Promise<void>;
 
+export type WorkflowStepEmission<TPayload = unknown> = {
+  id: string;
+  actor: string;
+  stepKey: string;
+  epoch: string;
+  sequence: number;
+  payload: TPayload;
+  createdAt: Date;
+};
+
 export type WorkflowStepConsumeTx = {
   serviceCalls: (factory: () => readonly AnyTxResult[]) => void;
   mutate: (fn: (ctx: HandlerTxContext<HooksMap>) => void) => void;
   /** Persist an outbound workflow-authored step emission. */
   emit: (payload: unknown) => void;
+  /** Emissions for this step that were already persisted before the current attempt started. */
+  previousEmissions: () => WorkflowStepEmission[];
 };
 
 export type WorkflowStepTx = WorkflowStepConsumeTx & {

--- a/packages/fragno-db/src/buffered-pump.test.ts
+++ b/packages/fragno-db/src/buffered-pump.test.ts
@@ -425,6 +425,35 @@ describe("BufferedDatabasePump", () => {
     expect(observed).toEqual([{ id: "row-3", payload: "third" }]);
   });
 
+  test("publishObserved appends only newly observed items to snapshots", async () => {
+    type Item = { id: string; payload: string };
+    const pump = new BufferedDatabasePump<Item, unknown, Item>({
+      handlerTx,
+      flush: async () => ({ observedItems: [{ id: "row-1", payload: "first" }] }),
+      cursorForObservedItem: (item) => item.id,
+    });
+    const observed: Item[] = [];
+    pump.observe((item) => {
+      observed.push(item);
+    });
+
+    await pump.flushNow();
+    await pump.publishObserved([
+      { id: "row-1", payload: "stale" },
+      { id: "row-2", payload: "second" },
+      { id: "row-2", payload: "duplicate" },
+    ]);
+
+    expect(observed).toEqual([
+      { id: "row-1", payload: "first" },
+      { id: "row-2", payload: "second" },
+    ]);
+    await expect(pump.snapshot()).resolves.toEqual([
+      { id: "row-1", payload: "first" },
+      { id: "row-2", payload: "second" },
+    ]);
+  });
+
   test("flush failures restore drained outgoing buffers and rethrow", async () => {
     const errors: unknown[] = [];
     let shouldFail = true;

--- a/packages/fragno-db/src/buffered-pump.ts
+++ b/packages/fragno-db/src/buffered-pump.ts
@@ -434,6 +434,22 @@ export class BufferedDatabasePump<
     };
   }
 
+  async publishObserved(messages: readonly TObserved[]): Promise<void> {
+    if (messages.length === 0) {
+      return;
+    }
+    const messagesToPublish = this.#hasFlushed
+      ? this.#unobservedMessages(this.#cursorsFor(this.#lastSnapshot), messages)
+      : messages;
+    if (messagesToPublish.length === 0) {
+      return;
+    }
+    if (this.#hasFlushed) {
+      this.#lastSnapshot = [...this.#lastSnapshot, ...messagesToPublish];
+    }
+    await this.#deliverObserved(messagesToPublish);
+  }
+
   async snapshotState(): Promise<BufferedPumpSnapshot<TObserved>> {
     if (!this.#hasFlushed) {
       await this.flushNow();
@@ -577,6 +593,10 @@ export class BufferedDatabasePump<
     }
     cursors.add(cursor);
     return false;
+  }
+
+  #unobservedMessages(cursors: Set<string>, messages: readonly TObserved[]): TObserved[] {
+    return messages.filter((message) => !this.#isAlreadyObserved(cursors, message));
   }
 
   #cursorsFor(items: readonly TObserved[]): Set<string> {

--- a/packages/pi-fragment/src/client/session.test.ts
+++ b/packages/pi-fragment/src/client/session.test.ts
@@ -9,6 +9,7 @@ import {
   createInitialPiSessionStoreState,
   createPiSessionStore,
   createStorePiSessionTransport,
+  isPiSessionPossiblyStuck,
   reducePiSessionStreamFrame,
   type PiSessionTransport,
 } from "./session";
@@ -30,6 +31,15 @@ const stream = (frames: AgentEvent[] | unknown[]) =>
       yield frame as never;
     }
   })();
+
+const stepEmission = (payload: AgentEvent, options: { stepKey?: string; epoch?: string } = {}) =>
+  ({
+    kind: "step-emission",
+    actor: "user",
+    stepKey: options.stepKey ?? "do:command-0-followUp",
+    epoch: options.epoch ?? "epoch-1",
+    payload,
+  }) as const;
 
 const createStore = (
   transport: PiSessionTransport,
@@ -88,6 +98,381 @@ describe("Pi session stream reducer", () => {
     const toolEndEvent = { type: "tool_execution_end", toolCallId: "tool_1" } as AgentEvent;
     state = reducePiSessionStreamFrame(state, toolEndEvent, { now: 8 });
     expect(state.events).toContain(toolEndEvent);
+  });
+
+  it("replaces an abandoned partial assistant message when recovery starts a new stream", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(state, { type: "message_start" } as AgentEvent, { now: 2 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("abandoned partial") } as AgentEvent,
+      { now: 3 },
+    );
+
+    state = reducePiSessionStreamFrame(state, { type: "agent_start" } as AgentEvent, { now: 4 });
+    state = reducePiSessionStreamFrame(state, { type: "turn_start" } as AgentEvent, { now: 5 });
+    state = reducePiSessionStreamFrame(state, { type: "message_start" } as AgentEvent, { now: 6 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("recovered partial") } as AgentEvent,
+      { now: 7 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("recovered partial")]);
+  });
+
+  it("handles recovery that emits message_update without a new message_start", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(state, { type: "message_start" } as AgentEvent, { now: 2 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("abandoned partial") } as AgentEvent,
+      { now: 3 },
+    );
+
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("recovered partial") } as AgentEvent,
+      { now: 4 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("recovered partial")]);
+  });
+
+  it("handles recovery events before message_update without duplicating the abandoned draft", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(state, { type: "message_start" } as AgentEvent, { now: 2 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("abandoned partial") } as AgentEvent,
+      { now: 3 },
+    );
+
+    state = reducePiSessionStreamFrame(state, { type: "agent_start" } as AgentEvent, { now: 4 });
+    state = reducePiSessionStreamFrame(state, { type: "turn_start" } as AgentEvent, { now: 5 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("recovered partial") } as AgentEvent,
+      { now: 6 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("recovered partial")]);
+  });
+
+  it("keeps a completed message when the next recovered message starts", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_end", message: message("complete") } as AgentEvent,
+      { now: 2 },
+    );
+    state = reducePiSessionStreamFrame(state, { type: "message_start" } as AgentEvent, { now: 3 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("next partial") } as AgentEvent,
+      { now: 4 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("complete"), message("next partial")]);
+  });
+
+  it("drops only the abandoned partial when multiple completed messages exist", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_end", message: message("complete") } as AgentEvent,
+      { now: 2 },
+    );
+    state = reducePiSessionStreamFrame(state, { type: "message_start" } as AgentEvent, { now: 3 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("abandoned") } as AgentEvent,
+      { now: 4 },
+    );
+    state = reducePiSessionStreamFrame(state, { type: "agent_start" } as AgentEvent, { now: 5 });
+    state = reducePiSessionStreamFrame(state, { type: "message_start" } as AgentEvent, { now: 6 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("recovered") } as AgentEvent,
+      { now: 7 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("complete"), message("recovered")]);
+  });
+
+  it("replaces an abandoned step-emission partial when recovery starts in the same epoch", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_start" } as AgentEvent),
+      { now: 2 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_update", message: message("abandoned") } as AgentEvent),
+      { now: 3 },
+    );
+    state = reducePiSessionStreamFrame(state, stepEmission({ type: "agent_start" } as AgentEvent), {
+      now: 4,
+    });
+    state = reducePiSessionStreamFrame(state, stepEmission({ type: "turn_start" } as AgentEvent), {
+      now: 5,
+    });
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_start" } as AgentEvent),
+      { now: 6 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_update", message: message("recovered") } as AgentEvent),
+      { now: 7 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("recovered")]);
+  });
+
+  it("replaces an abandoned step-emission partial when recovery starts in a new uncommitted epoch", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_start" } as AgentEvent, { epoch: "epoch-1" }),
+      { now: 2 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_update", message: message("abandoned") } as AgentEvent, {
+        epoch: "epoch-1",
+      }),
+      { now: 3 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_start" } as AgentEvent, { epoch: "epoch-2" }),
+      { now: 4 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_update", message: message("recovered") } as AgentEvent, {
+        epoch: "epoch-2",
+      }),
+      { now: 5 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("recovered")]);
+  });
+
+  it("does not duplicate recovered step-emission updates after an old epoch commits stale", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission(
+        { type: "message_update", message: message("old epoch partial") } as AgentEvent,
+        { epoch: "epoch-1" },
+      ),
+      { now: 2 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission(
+        { type: "message_update", message: message("new epoch partial") } as AgentEvent,
+        { epoch: "epoch-2" },
+      ),
+      { now: 3 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      {
+        kind: "step-emission",
+        actor: "system",
+        stepKey: "do:command-0-followUp",
+        epoch: "epoch-2",
+        payload: { control: "step-committed", epoch: "epoch-2" },
+      },
+      { now: 4 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("new epoch partial")]);
+    expect(isPiSessionPossiblyStuck(state, { now: 10_000 })).toBe(false);
+  });
+
+  it("does not mark a committed stale step emission as possibly stuck", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_end", message: message("done") } as AgentEvent),
+      { now: 1_000 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      {
+        kind: "step-emission",
+        actor: "system",
+        stepKey: "do:command-0-followUp",
+        epoch: "epoch-1",
+        payload: { control: "step-committed", epoch: "epoch-1" },
+      },
+      { now: 1_001 },
+    );
+
+    expect(isPiSessionPossiblyStuck(state, { now: 10_000 })).toBe(false);
+  });
+
+  it("does not mark old uncommitted step emissions as stuck after a later step commits", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_update", message: message("abandoned") } as AgentEvent, {
+        stepKey: "do:command-0-followUp",
+        epoch: "epoch-1",
+      }),
+      { now: 1_000 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      stepEmission({ type: "message_end", message: message("done") } as AgentEvent, {
+        stepKey: "do:command-1-followUp",
+        epoch: "epoch-2",
+      }),
+      { now: 2_000 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      {
+        kind: "step-emission",
+        actor: "system",
+        stepKey: "do:command-1-followUp",
+        epoch: "epoch-2",
+        payload: { control: "step-committed", epoch: "epoch-2" },
+      },
+      { now: 2_001 },
+    );
+
+    expect(isPiSessionPossiblyStuck(state, { now: 10_000 })).toBe(false);
+  });
+
+  it("does not mark a disconnected stale session as needing a nudge", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("partial") } as AgentEvent,
+      { now: 1_000 },
+    );
+
+    expect(
+      isPiSessionPossiblyStuck({ ...state, connectionStatus: "retrying" }, { now: 10_000 }),
+    ).toBe(false);
+  });
+
+  it("marks a stale tool execution start as possibly stuck", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "tool_execution_start", toolCallId: "tool_1" } as AgentEvent,
+      { now: 1_000 },
+    );
+
+    expect(isPiSessionPossiblyStuck(state, { now: 6_000 })).toBe(true);
+  });
+
+  it("marks a stale tool execution update as possibly stuck", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "tool_execution_update", toolCallId: "tool_1" } as AgentEvent,
+      { now: 1_000 },
+    );
+
+    expect(isPiSessionPossiblyStuck(state, { now: 6_000 })).toBe(true);
+  });
+
+  it("marks a stale agent start as possibly stuck", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(state, { type: "agent_start" } as AgentEvent, {
+      now: 1_000,
+    });
+
+    expect(isPiSessionPossiblyStuck(state, { now: 6_000 })).toBe(true);
+  });
+
+  it("marks a stale message start as possibly stuck", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(state, { type: "message_start" } as AgentEvent, {
+      now: 1_000,
+    });
+
+    expect(isPiSessionPossiblyStuck(state, { now: 6_000 })).toBe(true);
+  });
+
+  it("marks an uncommitted stale step after message_end as possibly stuck", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      {
+        kind: "step-emission",
+        actor: "user",
+        stepKey: "do:command-0-followUp",
+        epoch: "epoch-1",
+        payload: { type: "message_end", message: message("done") } as AgentEvent,
+      },
+      { now: 1_000 },
+    );
+
+    expect(isPiSessionPossiblyStuck(state, { now: 6_000 })).toBe(true);
+  });
+
+  it("marks an uncommitted stale step after agent_end as possibly stuck", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      {
+        kind: "step-emission",
+        actor: "user",
+        stepKey: "do:command-0-followUp",
+        epoch: "epoch-1",
+        payload: { type: "agent_end" } as AgentEvent,
+      },
+      { now: 1_000 },
+    );
+
+    expect(isPiSessionPossiblyStuck(state, { now: 6_000 })).toBe(true);
+  });
+
+  it("detects an open session as possibly stuck when the last event is non-terminal and stale", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+    state = reducePiSessionStreamFrame(
+      state,
+      { type: "message_update", message: message("partial") } as AgentEvent,
+      { now: 1_000 },
+    );
+
+    expect(isPiSessionPossiblyStuck(state, { now: 5_999 })).toBe(false);
+    expect(isPiSessionPossiblyStuck(state, { now: 6_000 })).toBe(true);
+
+    const ended = reducePiSessionStreamFrame(
+      state,
+      { type: "message_end", message: message("done") } as AgentEvent,
+      { now: 6_000 },
+    );
+    expect(isPiSessionPossiblyStuck(ended, { now: 20_000 })).toBe(false);
   });
 
   it("rolls back stale step-emission events when a competing epoch commits", () => {

--- a/packages/pi-fragment/src/client/session.test.ts
+++ b/packages/pi-fragment/src/client/session.test.ts
@@ -89,6 +89,49 @@ describe("Pi session stream reducer", () => {
     state = reducePiSessionStreamFrame(state, toolEndEvent, { now: 8 });
     expect(state.events).toContain(toolEndEvent);
   });
+
+  it("rolls back stale step-emission events when a competing epoch commits", () => {
+    let state = createInitialPiSessionStoreState({ sessionId: "session_1" });
+    state = reducePiSessionStreamFrame(state, { type: "snapshot", state: snapshot }, { now: 1 });
+
+    state = reducePiSessionStreamFrame(
+      state,
+      {
+        kind: "step-emission",
+        actor: "user",
+        stepKey: "do:racy client message",
+        epoch: "first-epoch",
+        payload: { type: "message_update", message: message("first stale") } as AgentEvent,
+      },
+      { now: 2 },
+    );
+    expect(state.agent?.messages).toEqual([message("first stale")]);
+
+    state = reducePiSessionStreamFrame(
+      state,
+      {
+        kind: "step-emission",
+        actor: "user",
+        stepKey: "do:racy client message",
+        epoch: "second-epoch",
+        payload: { type: "message_update", message: message("second valid") } as AgentEvent,
+      },
+      { now: 3 },
+    );
+    state = reducePiSessionStreamFrame(
+      state,
+      {
+        kind: "step-emission",
+        actor: "system",
+        stepKey: "do:racy client message",
+        epoch: "second-epoch",
+        payload: { control: "step-committed", epoch: "second-epoch" },
+      },
+      { now: 4 },
+    );
+
+    expect(state.agent?.messages).toEqual([message("second valid")]);
+  });
 });
 
 describe("createStorePiSessionTransport", () => {

--- a/packages/pi-fragment/src/client/session.ts
+++ b/packages/pi-fragment/src/client/session.ts
@@ -30,6 +30,7 @@ export type PiSessionStoreState = {
   connectionStatus: PiSessionConnectionStatus;
   sessionId: string;
   agent: PiAgentStateSnapshot | null;
+  snapshotAgent: PiAgentStateSnapshot | null;
   events: Array<Exclude<PiSessionEventStreamItem, SnapshotFrame>>;
   lastEvent: AgentEvent | null;
   lastFrameAt: number | null;
@@ -122,11 +123,6 @@ const isFatalStreamError = (error: unknown) => {
 };
 
 type SnapshotFrame = Extract<PiSessionEventStreamItem, { type: "snapshot" }>;
-const isSnapshotFrame = (frame: PiSessionEventStreamItem): frame is SnapshotFrame =>
-  "type" in frame && frame.type === "snapshot";
-
-const isAgentEvent = (frame: PiSessionEventStreamItem): frame is AgentEvent =>
-  "type" in frame && frame.type !== "snapshot";
 
 const replaceLastMessage = (messages: AgentMessage[], message: AgentMessage): AgentMessage[] =>
   messages.length === 0 ? [message] : [...messages.slice(0, -1), message];
@@ -157,6 +153,7 @@ export const createInitialPiSessionStoreState = (options: {
   connectionStatus: "idle",
   sessionId: options.sessionId,
   agent: null,
+  snapshotAgent: null,
   events: [],
   lastEvent: null,
   lastFrameAt: null,
@@ -169,41 +166,99 @@ export const createInitialPiSessionStoreState = (options: {
   },
 });
 
+const committedEpochsByStep = (events: Array<Exclude<PiSessionEventStreamItem, SnapshotFrame>>) => {
+  const committed = new Map<string, string>();
+  for (const event of events) {
+    if ("kind" in event && event.kind === "step-emission") {
+      const payload = event.payload;
+      if (
+        typeof payload === "object" &&
+        payload !== null &&
+        "control" in payload &&
+        payload.control === "step-committed"
+      ) {
+        committed.set(event.stepKey, event.epoch);
+      }
+    }
+  }
+  return committed;
+};
+
+const agentEventFromStreamFrame = (
+  frame: Exclude<PiSessionEventStreamItem, SnapshotFrame>,
+  committedEpochs: ReadonlyMap<string, string>,
+): AgentEvent | null => {
+  if ("type" in frame) {
+    return frame;
+  }
+  if (!("kind" in frame) || frame.kind !== "step-emission") {
+    return null;
+  }
+
+  const payload = frame.payload;
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !("type" in payload) ||
+    payload.type === "snapshot"
+  ) {
+    return null;
+  }
+
+  const committedEpoch = committedEpochs.get(frame.stepKey);
+  if (committedEpoch && committedEpoch !== frame.epoch) {
+    return null;
+  }
+
+  return payload as AgentEvent;
+};
+
+const rebuildAgentState = (
+  snapshotAgent: PiAgentStateSnapshot,
+  events: Array<Exclude<PiSessionEventStreamItem, SnapshotFrame>>,
+): { agent: PiAgentStateSnapshot; lastEvent: AgentEvent | null } => {
+  const committedEpochs = committedEpochsByStep(events);
+  let messages = snapshotAgent.messages;
+  let previousEvent: AgentEvent | null = null;
+
+  for (const event of events) {
+    const agentEvent = agentEventFromStreamFrame(event, committedEpochs);
+    if (!agentEvent) {
+      continue;
+    }
+    messages = reduceMessages(messages, agentEvent, previousEvent);
+    previousEvent = agentEvent;
+  }
+
+  return { agent: { ...snapshotAgent, messages }, lastEvent: previousEvent };
+};
+
 export const reducePiSessionStreamFrame = (
   state: PiSessionStoreState,
   frame: PiSessionEventStreamItem,
   meta: { now: number },
 ): PiSessionStoreState => {
-  if (isSnapshotFrame(frame)) {
+  if ("type" in frame && frame.type === "snapshot") {
     return {
       ...state,
       connectionStatus: "open",
       agent: frame.state,
+      snapshotAgent: frame.state,
       lastFrameAt: meta.now,
       streamError: undefined,
     };
   }
 
-  if (!isAgentEvent(frame)) {
-    return {
-      ...state,
-      connectionStatus: "open",
-      events: [...state.events, frame],
-      lastFrameAt: meta.now,
-      streamError: undefined,
-    };
-  }
+  const events = [...state.events, frame];
+  const snapshotAgent = state.snapshotAgent ?? { messages: [] };
+  const rebuilt = rebuildAgentState(snapshotAgent, events);
 
-  const currentAgent = state.agent ?? { messages: [] };
   return {
     ...state,
     connectionStatus: "open",
-    agent: {
-      ...currentAgent,
-      messages: reduceMessages(currentAgent.messages, frame, state.lastEvent),
-    },
-    events: [...state.events, frame],
-    lastEvent: frame,
+    agent: rebuilt.agent,
+    events,
+    lastEvent: rebuilt.lastEvent,
     lastFrameAt: meta.now,
     streamError: undefined,
   };
@@ -283,8 +338,10 @@ const runningToolsFromEvents = (
   events: Array<Exclude<PiSessionEventStreamItem, SnapshotFrame>>,
 ): PiLiveToolExecution[] => {
   const running = new Map<string, PiLiveToolExecution>();
-  for (const event of events) {
-    if (!isAgentEvent(event)) {
+  const committedEpochs = committedEpochsByStep(events);
+  for (const frame of events) {
+    const event = agentEventFromStreamFrame(frame, committedEpochs);
+    if (!event) {
       continue;
     }
     if (event.type === "tool_execution_start") {
@@ -334,6 +391,7 @@ export const createPiSessionStore = (args: PiSessionStoreArgs, deps: PiSessionSt
   const state = atom<PiSessionStoreState>({
     ...initialState,
     agent: args.initialData?.agent.state ?? initialState.agent,
+    snapshotAgent: args.initialData?.agent.state ?? initialState.snapshotAgent,
     events: args.initialData?.agent.events ?? initialState.events,
   });
 
@@ -381,7 +439,7 @@ export const createPiSessionStore = (args: PiSessionStoreArgs, deps: PiSessionSt
 
           for await (const frame of frames) {
             if (!sawSnapshot) {
-              if (!isSnapshotFrame(frame)) {
+              if (!("type" in frame && frame.type === "snapshot")) {
                 throw new PiSessionProtocolError("Expected /events stream to start with snapshot.");
               }
               sawSnapshot = true;

--- a/packages/pi-fragment/src/client/session.ts
+++ b/packages/pi-fragment/src/client/session.ts
@@ -85,6 +85,8 @@ class PiSessionProtocolError extends Error {
   }
 }
 
+export const PI_SESSION_STUCK_AFTER_MS = 5_000;
+
 const defaultRetryDelay = ({ attempt }: { attempt: number; error: unknown }) =>
   Math.min(10_000, 500 * 2 ** Math.min(attempt, 8));
 
@@ -131,15 +133,23 @@ const reduceMessages = (
   messages: AgentMessage[],
   event: AgentEvent,
   previousEvent: AgentEvent | null,
+  hasOpenMessageDraft: boolean,
 ): AgentMessage[] => {
+  // If a prior stream died after message_update, recovery can emit agent/turn events before the
+  // next message_start. Track the open draft across those events and drop it when the recovered
+  // message starts, so the next update reuses the same visual assistant slot.
+  if (event.type === "message_start" && hasOpenMessageDraft) {
+    return messages.slice(0, -1);
+  }
+
   if (event.type === "message_update") {
-    return previousEvent?.type === "message_update"
+    return hasOpenMessageDraft && previousEvent?.type !== "message_start"
       ? replaceLastMessage(messages, event.message)
       : [...messages, event.message];
   }
 
   if (event.type === "message_end") {
-    return previousEvent?.type === "message_update"
+    return hasOpenMessageDraft
       ? replaceLastMessage(messages, event.message)
       : [...messages, event.message];
   }
@@ -220,17 +230,65 @@ const rebuildAgentState = (
   const committedEpochs = committedEpochsByStep(events);
   let messages = snapshotAgent.messages;
   let previousEvent: AgentEvent | null = null;
+  let hasOpenMessageDraft = false;
 
   for (const event of events) {
     const agentEvent = agentEventFromStreamFrame(event, committedEpochs);
     if (!agentEvent) {
       continue;
     }
-    messages = reduceMessages(messages, agentEvent, previousEvent);
+    messages = reduceMessages(messages, agentEvent, previousEvent, hasOpenMessageDraft);
+
+    if (agentEvent.type === "message_update") {
+      hasOpenMessageDraft = true;
+    }
+    if (agentEvent.type === "message_end") {
+      hasOpenMessageDraft = false;
+    }
     previousEvent = agentEvent;
   }
 
   return { agent: { ...snapshotAgent, messages }, lastEvent: previousEvent };
+};
+
+const latestStepEmissionCommitState = (
+  events: Array<Exclude<PiSessionEventStreamItem, SnapshotFrame>>,
+): "none" | "committed" | "uncommitted" => {
+  const committed = committedEpochsByStep(events);
+  const latestStepEmission = events.findLast(
+    (frame) => "kind" in frame && frame.kind === "step-emission",
+  );
+
+  if (!latestStepEmission || latestStepEmission.kind !== "step-emission") {
+    return "none";
+  }
+
+  return committed.get(latestStepEmission.stepKey) === latestStepEmission.epoch
+    ? "committed"
+    : "uncommitted";
+};
+
+export const isPiSessionPossiblyStuck = (
+  state: PiSessionStoreState,
+  meta: { now: number; stuckAfterMs?: number },
+) => {
+  if (
+    state.connectionStatus !== "open" ||
+    state.lastFrameAt === null ||
+    meta.now - state.lastFrameAt < (meta.stuckAfterMs ?? PI_SESSION_STUCK_AFTER_MS)
+  ) {
+    return false;
+  }
+
+  const latestStepCommitState = latestStepEmissionCommitState(state.events);
+  if (latestStepCommitState === "committed") {
+    return false;
+  }
+
+  return (
+    latestStepCommitState === "uncommitted" ||
+    (state.lastEvent !== null && !state.lastEvent.type.endsWith("_end"))
+  );
 };
 
 export const reducePiSessionStreamFrame = (
@@ -388,6 +446,12 @@ export const createPiSessionStore = (args: PiSessionStoreArgs, deps: PiSessionSt
   const now = deps.now ?? (() => Date.now());
   const retryDelay = deps.retryDelay ?? defaultRetryDelay;
   const initialState = createInitialPiSessionStoreState({ sessionId });
+  const staleCheckNow = atom(now());
+  onMount(staleCheckNow, () => {
+    const interval = setInterval(() => staleCheckNow.set(now()), 1_000);
+    return () => clearInterval(interval);
+  });
+
   const state = atom<PiSessionStoreState>({
     ...initialState,
     agent: args.initialData?.agent.state ?? initialState.agent,
@@ -520,6 +584,9 @@ export const createPiSessionStore = (args: PiSessionStoreArgs, deps: PiSessionSt
   const sendError = computed(state, ($state) =>
     $state.command.error instanceof Error ? $state.command.error.message : null,
   );
+  const needsNudge = computed([state, staleCheckNow], ($state, $now) =>
+    isPiSessionPossiblyStuck($state, { now: $now }),
+  );
   const statusText = computed([state, runningTools], ($state, $runningTools) => {
     if ($state.command.loading) {
       return "Sending…";
@@ -556,6 +623,7 @@ export const createPiSessionStore = (args: PiSessionStoreArgs, deps: PiSessionSt
     events,
     runningTools,
     readyForInput,
+    needsNudge,
     sending,
     error,
     sendError,

--- a/packages/pi-fragment/src/pi/events-route.test.ts
+++ b/packages/pi-fragment/src/pi/events-route.test.ts
@@ -95,15 +95,43 @@ function assertJsonStream<TResponse extends { type: string }>(
   }
 }
 
+const unwrapRouteFrame = <T>(frame: T): T => {
+  if (
+    typeof frame === "object" &&
+    frame !== null &&
+    "kind" in frame &&
+    frame.kind === "step-emission" &&
+    "actor" in frame &&
+    frame.actor === "user" &&
+    "payload" in frame
+  ) {
+    return frame.payload as T;
+  }
+  return frame;
+};
+
+const isSystemStepEmissionFrame = (frame: unknown) =>
+  typeof frame === "object" &&
+  frame !== null &&
+  "kind" in frame &&
+  frame.kind === "step-emission" &&
+  "actor" in frame &&
+  frame.actor === "system";
+
 const readFrame = async <T>(
   stream: AsyncGenerator<T, unknown, unknown>,
   message = "Timed out waiting for stream frame.",
 ): Promise<T> => {
-  const next = await withTimeout(stream.next(), message);
-  if (next.done) {
-    throw new Error("Stream ended before the next frame was written.");
+  while (true) {
+    const next = await withTimeout(stream.next(), message);
+    if (next.done) {
+      throw new Error("Stream ended before the next frame was written.");
+    }
+    if (isSystemStepEmissionFrame(next.value)) {
+      continue;
+    }
+    return unwrapRouteFrame(next.value);
   }
-  return next.value;
 };
 
 const readUntilFrame = async <T, TMatch extends T>(
@@ -337,7 +365,11 @@ describe("pi-fragment /events route", () => {
     });
     assertJsonStream(response);
 
-    expect(await Array.fromAsync(response.stream)).toEqual([
+    expect(
+      (await Array.fromAsync(response.stream))
+        .filter((frame) => !isSystemStepEmissionFrame(frame))
+        .map(unwrapRouteFrame),
+    ).toEqual([
       expect.objectContaining({
         type: "snapshot",
         state: { messages: [] },
@@ -421,7 +453,11 @@ describe("pi-fragment /events route", () => {
     });
     assertJsonStream(response);
 
-    expect(await Array.fromAsync(response.stream)).toEqual([
+    expect(
+      (await Array.fromAsync(response.stream))
+        .filter((frame) => !isSystemStepEmissionFrame(frame))
+        .map(unwrapRouteFrame),
+    ).toEqual([
       expect.objectContaining({
         type: "snapshot",
         state: { messages: [] },

--- a/packages/pi-fragment/src/pi/pi-test-utils.ts
+++ b/packages/pi-fragment/src/pi/pi-test-utils.ts
@@ -58,33 +58,53 @@ const buildAssistantMessage = (
   timestamp: Date.now(),
 });
 
+type ScriptedAssistantTurnOptions = {
+  waitBeforeStart?: Promise<unknown>;
+};
+
 type ScriptedAssistantTurn =
-  | { type: "text"; text: string; stopReason?: Extract<StopReason, "stop" | "length"> }
-  | { type: "toolCall"; toolCall: ToolCall };
+  | ({
+      type: "text";
+      text: string;
+      stopReason?: Extract<StopReason, "stop" | "length">;
+    } & ScriptedAssistantTurnOptions)
+  | ({ type: "toolCall"; toolCall: ToolCall } & ScriptedAssistantTurnOptions);
 
 export const createAssistantStreamScript = () => {
   const turns: ScriptedAssistantTurn[] = [];
+  let nextTurnOptions: ScriptedAssistantTurnOptions = {};
+  const takeNextTurnOptions = () => {
+    const options = nextTurnOptions;
+    nextTurnOptions = {};
+    return options;
+  };
   const builder = {
+    waitBeforeStart(waitBeforeStart: Promise<unknown>) {
+      nextTurnOptions = { ...nextTurnOptions, waitBeforeStart };
+      return builder;
+    },
     text(text: string, options: { stopReason?: Extract<StopReason, "stop" | "length"> } = {}) {
-      turns.push({ type: "text", text, stopReason: options.stopReason });
+      turns.push({ type: "text", text, stopReason: options.stopReason, ...takeNextTurnOptions() });
       return builder;
     },
     toolCall(name: string, options: { id: string; args: Record<string, unknown> }) {
       turns.push({
         type: "toolCall",
         toolCall: { type: "toolCall", id: options.id, name, arguments: options.args },
+        ...takeNextTurnOptions(),
       });
       return builder;
     },
     build(): { streamFn: StreamFn } {
       let nextTurnIndex = 0;
       return {
-        streamFn: () => {
+        streamFn: async () => {
           const turn = turns[nextTurnIndex];
           if (!turn) {
             throw new Error(`No scripted assistant turn available at index ${nextTurnIndex}.`);
           }
           nextTurnIndex += 1;
+          await turn.waitBeforeStart;
 
           const stream = createAssistantMessageEventStream();
           const message =

--- a/packages/pi-fragment/src/pi/scenario.test.ts
+++ b/packages/pi-fragment/src/pi/scenario.test.ts
@@ -10,14 +10,14 @@ import { z } from "zod";
 
 import { instantiate } from "@fragno-dev/core";
 
-import type { StreamFn } from "@earendil-works/pi-agent-core";
+import type { AgentEvent, AgentMessage, StreamFn } from "@earendil-works/pi-agent-core";
 import { createAssistantMessageEventStream, type AssistantMessage } from "@earendil-works/pi-ai";
 
 import { createPiFragmentClient } from "../client/vanilla";
 import { piRoutesFactory } from "../routes";
 import { piFragmentDefinition } from "./definition";
 import { definePiTool, definePiWorkflow } from "./dsl";
-import { createPiWorkflows } from "./factory";
+import { createPiWorkflows, type PiAgentRunner } from "./factory";
 import { createAssistantStreamScript, mockModel } from "./pi-test-utils";
 import type { PiFragmentConfig } from "./types";
 import { interactiveChatWorkflow } from "./workflows/interactive-chat-workflow";
@@ -41,6 +41,241 @@ const createAssistantMessage = (stopReason: AssistantMessage["stopReason"]): Ass
 });
 
 describe("Pi workflow scenarios", () => {
+  test("restores an in-flight prompt step after runner restart without replaying the prompt", async () => {
+    let releaseInFlightAttempt!: () => void;
+    const inFlightAttemptReleased = new Promise<void>((resolve) => {
+      releaseInFlightAttempt = resolve;
+    });
+    const { streamFn } = createAssistantStreamScript()
+      .waitBeforeStart(inFlightAttemptReleased)
+      .text("late stale response")
+      .text("stop")
+      .build();
+    const restoreWorkflow = definePiWorkflow(
+      { name: "pi-restore-prompt-in-flight", schema: z.object({}) },
+      async (ctx) => {
+        const result = await ctx.agent("default").prompt("ask", {
+          input: { text: "hello" },
+        });
+        return {
+          roles: result.messages.map((message) => message.role),
+          text: result.messages
+            .flatMap((message) =>
+              "content" in message && Array.isArray(message.content)
+                ? message.content.flatMap((content) =>
+                    content.type === "text" ? [content.text] : [],
+                  )
+                : [],
+            )
+            .join(" "),
+        };
+      },
+    );
+    const config: PiFragmentConfig = {
+      agents: {
+        default: {
+          name: "default",
+          systemPrompt: "You are helpful.",
+          model: mockModel,
+          streamFn,
+        },
+      },
+      tools: {},
+      workflows: [restoreWorkflow],
+    };
+
+    await runScenario(
+      defineScenario({
+        name: "pi-restore-prompt-in-flight",
+        workflows: createPiWorkflows({
+          agents: config.agents,
+          tools: config.tools,
+          workflows: config.workflows,
+        }),
+        harness: {
+          configureFragments: (harness) => ({
+            pi: instantiate(piFragmentDefinition)
+              .withConfig(config)
+              .withRoutes([piRoutesFactory])
+              .withServices({ workflows: harness.fragment.services }),
+          }),
+        },
+        runners: ["worker", "killer"],
+        steps: ({ workflow, runners, concurrent }) => [
+          workflow.create({ workflow: restoreWorkflow.name, id: "restore-prompt-session" }),
+          concurrent({
+            worker: [
+              runners.worker.tick({
+                workflow: restoreWorkflow.name,
+                instanceId: "restore-prompt-session",
+                reason: "create",
+              }),
+            ],
+            killer: [
+              runners.killer.waitForEmission({
+                workflow: restoreWorkflow.name,
+                instanceId: "restore-prompt-session",
+                match: (emission) => {
+                  const payload = emission.payload as AgentEvent;
+                  return payload.type === "message_end" && payload.message.role === "user";
+                },
+              }),
+              runners.killer.restart(),
+              runners.killer.tick({
+                workflow: restoreWorkflow.name,
+                instanceId: "restore-prompt-session",
+                reason: "create",
+              }),
+              workflow.read({
+                read: () => {
+                  releaseInFlightAttempt();
+                },
+              }),
+            ],
+          }),
+          workflow.read({
+            read: async (ctx) => ({
+              status: await ctx.state.getStatus(restoreWorkflow.name, "restore-prompt-session"),
+              steps: await ctx.state.getSteps(restoreWorkflow.name, "restore-prompt-session"),
+            }),
+            assert: ({ status, steps }) => {
+              expect(status).toMatchObject({
+                status: "complete",
+                output: { roles: ["user", "assistant"], text: "hello stop" },
+              });
+              expect(steps[0]).toMatchObject({
+                stepKey: "do:ask",
+                status: "completed",
+              });
+            },
+          }),
+        ],
+      }),
+    );
+  });
+
+  test("finishes an in-flight prompt step from restored completed events after runner restart", async () => {
+    const promptMessage: Extract<AgentMessage, { role: "user" }> = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 1,
+    };
+    const finalMessage = createAssistantMessage("stop");
+    let releaseInFlightAttempt!: () => void;
+    const inFlightAttemptReleased = new Promise<void>((resolve) => {
+      releaseInFlightAttempt = resolve;
+    });
+    let runnerCallCount = 0;
+    const agentRunner: PiAgentRunner = async (_operation, _runtime, lifecycle) => {
+      runnerCallCount += 1;
+      await lifecycle?.onEvent?.({ type: "agent_start" });
+      await lifecycle?.onEvent?.({ type: "turn_start" });
+      await lifecycle?.onEvent?.({ type: "message_start", message: promptMessage });
+      await lifecycle?.onEvent?.({ type: "message_end", message: promptMessage });
+      await lifecycle?.onEvent?.({ type: "message_start", message: finalMessage });
+      await lifecycle?.onEvent?.({ type: "message_end", message: finalMessage });
+      await lifecycle?.onEvent?.({ type: "agent_end", messages: [promptMessage, finalMessage] });
+      await inFlightAttemptReleased;
+      return {
+        stopReason: "stop",
+        messages: [promptMessage, finalMessage],
+        events: [],
+        errorMessage: null,
+      };
+    };
+    const restoreWorkflow = definePiWorkflow(
+      { name: "pi-restore-completed-in-flight", schema: z.object({}) },
+      async (ctx) => {
+        const result = await ctx.agent("default").prompt("ask", {
+          input: { text: "hello" },
+        });
+        return {
+          stopReason: result.stopReason,
+          roles: result.messages.map((message) => message.role),
+        };
+      },
+    );
+    const config: PiFragmentConfig = {
+      agents: {
+        default: {
+          name: "default",
+          systemPrompt: "You are helpful.",
+          model: mockModel,
+        },
+      },
+      tools: {},
+      workflows: [restoreWorkflow],
+    };
+
+    await runScenario(
+      defineScenario({
+        name: "pi-restore-completed-in-flight",
+        workflows: createPiWorkflows({
+          agents: config.agents,
+          tools: config.tools,
+          workflows: config.workflows,
+          agentRunner,
+        }),
+        harness: {
+          configureFragments: (harness) => ({
+            pi: instantiate(piFragmentDefinition)
+              .withConfig(config)
+              .withRoutes([piRoutesFactory])
+              .withServices({ workflows: harness.fragment.services }),
+          }),
+        },
+        runners: ["worker", "killer"],
+        steps: ({ workflow, runners, concurrent }) => [
+          workflow.create({ workflow: restoreWorkflow.name, id: "restore-completed-session" }),
+          concurrent({
+            worker: [
+              runners.worker.tick({
+                workflow: restoreWorkflow.name,
+                instanceId: "restore-completed-session",
+                reason: "create",
+              }),
+            ],
+            killer: [
+              runners.killer.waitForEmission({
+                workflow: restoreWorkflow.name,
+                instanceId: "restore-completed-session",
+                match: (emission) => (emission.payload as AgentEvent).type === "agent_end",
+              }),
+              runners.killer.restart(),
+              runners.killer.tick({
+                workflow: restoreWorkflow.name,
+                instanceId: "restore-completed-session",
+                reason: "create",
+              }),
+              workflow.read({
+                read: () => {
+                  releaseInFlightAttempt();
+                },
+              }),
+            ],
+          }),
+          workflow.read({
+            read: async (ctx) => ({
+              status: await ctx.state.getStatus(restoreWorkflow.name, "restore-completed-session"),
+              steps: await ctx.state.getSteps(restoreWorkflow.name, "restore-completed-session"),
+            }),
+            assert: ({ status, steps }) => {
+              expect(status).toMatchObject({
+                status: "complete",
+                output: { stopReason: "stop", roles: ["user", "assistant"] },
+              });
+              expect(steps[0]).toMatchObject({
+                stepKey: "do:ask",
+                status: "completed",
+              });
+              expect(runnerCallCount).toBe(1);
+            },
+          }),
+        ],
+      }),
+    );
+  });
+
   test("stops a workflow agent step after a matching tool call", async () => {
     const classifyTool = definePiTool({
       name: "classify",

--- a/packages/pi-fragment/src/pi/types.ts
+++ b/packages/pi-fragment/src/pi/types.ts
@@ -82,9 +82,18 @@ export type PiAgentDefinition = {
 
 export type PiAgentRegistry = Record<string, PiAgentDefinition>;
 
+export type PiSessionStepEmissionFrame = {
+  kind: "step-emission";
+  actor: string;
+  stepKey: string;
+  epoch: string;
+  payload: unknown;
+};
+
 export type PiSessionEventStreamItem =
   | { type: "snapshot"; state: PiAgentStateSnapshot }
   | AgentEvent
+  | PiSessionStepEmissionFrame
   | { kind: "abort"; commandId: string; reason?: string }
   | { kind: "steer"; commandId: string; input: PiPromptInput };
 

--- a/packages/pi-fragment/src/pi/workflow/agent-runner.test.ts
+++ b/packages/pi-fragment/src/pi/workflow/agent-runner.test.ts
@@ -2,11 +2,597 @@ import { describe, expect, expectTypeOf, test } from "vitest";
 
 import { Type } from "typebox";
 
+import type { AgentEvent, AgentMessage } from "@earendil-works/pi-agent-core";
+
 import { definePiTool } from "../dsl";
 import { createAssistantStreamScript, mockModel } from "../pi-test-utils";
 import type { PiAgentDefinition, PiToolRegistry } from "../types";
-import { runAgentTurn } from "./agent-runner";
+import { restoreAgentTurnFromEvents, runAgentTurn } from "./agent-runner";
 import { collectPiToolCallResults, createPiToolCallAccessor } from "./tool-call-results";
+
+const userMessage = (text: string): Extract<AgentMessage, { role: "user" }> => ({
+  role: "user",
+  content: [{ type: "text", text }],
+  timestamp: 1,
+});
+
+const assistantMessage = (
+  content: Extract<AgentMessage, { role: "assistant" }>["content"],
+  stopReason: Extract<AgentMessage, { role: "assistant" }>["stopReason"] = "stop",
+): Extract<AgentMessage, { role: "assistant" }> => ({
+  role: "assistant",
+  content,
+  api: "test",
+  provider: "test",
+  model: "test",
+  usage: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason,
+  timestamp: 2,
+});
+
+const toolResultMessage = (toolCallId: string): Extract<AgentMessage, { role: "toolResult" }> => ({
+  role: "toolResult",
+  toolCallId,
+  toolName: "lookup",
+  content: [{ type: "text", text: "result" }],
+  details: {},
+  isError: false,
+  timestamp: 3,
+});
+
+describe("restoreAgentTurnFromEvents", () => {
+  test("continues instead of replaying a prompt when the prompt message was already emitted", () => {
+    const promptMessage = userMessage("hello");
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage],
+    });
+  });
+
+  test("finishes from a terminal assistant message without another model call", () => {
+    const promptMessage = userMessage("hello");
+    const finalMessage = assistantMessage([{ type: "text", text: "hi" }]);
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: finalMessage },
+        { type: "message_end", message: finalMessage },
+        { type: "agent_end", messages: [promptMessage, finalMessage] },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "finish",
+      stopReason: "stop",
+      messages: [promptMessage, finalMessage],
+      errorMessage: null,
+    });
+  });
+
+  test("keeps base messages when there are no restorable events", () => {
+    const existing = assistantMessage([{ type: "text", text: "base" }]);
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [existing],
+      operation: { mode: "prompt", promptInput: { text: "next" } },
+      events: [],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "prompt", promptInput: { text: "next" } },
+      messages: [existing],
+      events: [],
+    });
+  });
+
+  test("ignores assistant-only prompt restore state", () => {
+    const finalMessage = assistantMessage([{ type: "text", text: "hi" }]);
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      events: [
+        { type: "message_start", message: finalMessage },
+        { type: "message_end", message: finalMessage },
+        { type: "agent_end", messages: [finalMessage] },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      messages: [],
+      events: [],
+    });
+  });
+
+  test("rolls back an assistant tool call that did not finish producing tool results", () => {
+    const promptMessage = userMessage("lookup");
+    const toolCallMessage = assistantMessage(
+      [{ type: "toolCall", id: "call-1", name: "lookup", arguments: {} }],
+      "toolUse",
+    );
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "lookup" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: toolCallMessage },
+        { type: "message_end", message: toolCallMessage },
+        { type: "tool_execution_start", toolCallId: "call-1", toolName: "lookup", args: {} },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage],
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+      ],
+    });
+  });
+
+  test("continues from restored tool results when a tool turn completed", () => {
+    const promptMessage = userMessage("lookup");
+    const toolCallMessage = assistantMessage(
+      [{ type: "toolCall", id: "call-1", name: "lookup", arguments: {} }],
+      "toolUse",
+    );
+    const resultMessage = toolResultMessage("call-1");
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "lookup" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: toolCallMessage },
+        { type: "message_end", message: toolCallMessage },
+        { type: "message_start", message: resultMessage },
+        { type: "message_end", message: resultMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage, toolCallMessage, resultMessage],
+    });
+  });
+
+  test("drops an assistant stream that started but never ended", () => {
+    const promptMessage = userMessage("hello");
+    const partialMessage = assistantMessage([{ type: "text", text: "hel" }]);
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      events: [
+        { type: "agent_start" },
+        { type: "turn_start" },
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: partialMessage },
+        {
+          type: "message_update",
+          message: partialMessage,
+          assistantMessageEvent: { type: "text_delta" },
+        },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage],
+      events: [
+        { type: "agent_start" },
+        { type: "turn_start" },
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+      ],
+    });
+  });
+
+  test("drops all events when no message reached message_end", () => {
+    const baseMessage = userMessage("continue from here");
+    const partialMessage = assistantMessage([{ type: "text", text: "hel" }]);
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [baseMessage],
+      operation: { mode: "continue" },
+      events: [
+        { type: "agent_start" },
+        { type: "turn_start" },
+        { type: "message_start", message: partialMessage },
+        {
+          type: "message_update",
+          message: partialMessage,
+          assistantMessageEvent: { type: "text_delta" },
+        },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [baseMessage],
+      events: [],
+    });
+  });
+
+  test("restores the final message_end payload instead of message_update partials", () => {
+    const promptMessage = userMessage("hello");
+    const partialMessage = assistantMessage([{ type: "text", text: "hel" }]);
+    const finalMessage = assistantMessage([{ type: "text", text: "hello" }]);
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: partialMessage },
+        {
+          type: "message_update",
+          message: partialMessage,
+          assistantMessageEvent: { type: "text_delta" },
+        },
+        { type: "message_end", message: finalMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "finish",
+      messages: [promptMessage, finalMessage],
+      errorMessage: null,
+    });
+  });
+
+  test("restores a message_end even if the matching message_start was not persisted", () => {
+    const promptMessage = userMessage("hello");
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      events: [{ type: "message_end", message: promptMessage }] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage],
+      events: [{ type: "message_end", message: promptMessage }],
+    });
+  });
+
+  test("finishes from a terminal assistant message even before agent_end is emitted", () => {
+    const promptMessage = userMessage("hello");
+    const finalMessage = assistantMessage([{ type: "text", text: "hi" }]);
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: finalMessage },
+        { type: "message_end", message: finalMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "finish",
+      stopReason: "stop",
+      messages: [promptMessage, finalMessage],
+      errorMessage: null,
+    });
+  });
+
+  test("finishes from a restored error assistant message", () => {
+    const promptMessage = userMessage("hello");
+    const errorMessage = {
+      ...assistantMessage([{ type: "text", text: "failed" }], "error"),
+      errorMessage: "provider failed",
+    };
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "hello" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: errorMessage },
+        { type: "message_end", message: errorMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "finish",
+      stopReason: "error",
+      messages: [promptMessage, errorMessage],
+      errorMessage: "provider failed",
+    });
+  });
+
+  test("rolls back a multi-tool assistant message until every requested tool result is present", () => {
+    const promptMessage = userMessage("lookup twice");
+    const toolCallMessage = assistantMessage(
+      [
+        { type: "toolCall", id: "call-1", name: "lookup", arguments: { query: "one" } },
+        { type: "toolCall", id: "call-2", name: "lookup", arguments: { query: "two" } },
+      ],
+      "toolUse",
+    );
+    const firstResultMessage = toolResultMessage("call-1");
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "lookup twice" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: toolCallMessage },
+        { type: "message_end", message: toolCallMessage },
+        { type: "tool_execution_start", toolCallId: "call-1", toolName: "lookup", args: {} },
+        {
+          type: "tool_execution_end",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          result: { content: [{ type: "text", text: "one" }], details: {} },
+          isError: false,
+        },
+        { type: "message_start", message: firstResultMessage },
+        { type: "message_end", message: firstResultMessage },
+        { type: "tool_execution_start", toolCallId: "call-2", toolName: "lookup", args: {} },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage],
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+      ],
+    });
+  });
+
+  test("restores complete parallel tool results in assistant source order", () => {
+    const promptMessage = userMessage("lookup twice");
+    const toolCallMessage = assistantMessage(
+      [
+        { type: "toolCall", id: "call-1", name: "lookup", arguments: { query: "one" } },
+        { type: "toolCall", id: "call-2", name: "lookup", arguments: { query: "two" } },
+      ],
+      "toolUse",
+    );
+    const firstResultMessage = toolResultMessage("call-1");
+    const secondResultMessage = toolResultMessage("call-2");
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "lookup twice" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: toolCallMessage },
+        { type: "message_end", message: toolCallMessage },
+        { type: "tool_execution_start", toolCallId: "call-1", toolName: "lookup", args: {} },
+        { type: "tool_execution_start", toolCallId: "call-2", toolName: "lookup", args: {} },
+        {
+          type: "tool_execution_end",
+          toolCallId: "call-2",
+          toolName: "lookup",
+          result: { content: [{ type: "text", text: "two" }], details: {} },
+          isError: false,
+        },
+        {
+          type: "tool_execution_end",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          result: { content: [{ type: "text", text: "one" }], details: {} },
+          isError: false,
+        },
+        { type: "message_start", message: firstResultMessage },
+        { type: "message_end", message: firstResultMessage },
+        { type: "message_start", message: secondResultMessage },
+        { type: "message_end", message: secondResultMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage, toolCallMessage, firstResultMessage, secondResultMessage],
+    });
+  });
+
+  test("does not synthesize a tool result from tool_execution_end alone", () => {
+    const promptMessage = userMessage("lookup");
+    const toolCallMessage = assistantMessage(
+      [{ type: "toolCall", id: "call-1", name: "lookup", arguments: {} }],
+      "toolUse",
+    );
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "lookup" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: toolCallMessage },
+        { type: "message_end", message: toolCallMessage },
+        { type: "tool_execution_start", toolCallId: "call-1", toolName: "lookup", args: {} },
+        {
+          type: "tool_execution_end",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          result: { content: [{ type: "text", text: "result" }], details: {} },
+          isError: false,
+        },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage],
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+      ],
+    });
+  });
+
+  test("drops a tool result message that started but never reached message_end", () => {
+    const promptMessage = userMessage("lookup");
+    const toolCallMessage = assistantMessage(
+      [{ type: "toolCall", id: "call-1", name: "lookup", arguments: {} }],
+      "toolUse",
+    );
+    const resultMessage = toolResultMessage("call-1");
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "lookup" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: toolCallMessage },
+        { type: "message_end", message: toolCallMessage },
+        { type: "tool_execution_start", toolCallId: "call-1", toolName: "lookup", args: {} },
+        {
+          type: "tool_execution_end",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          result: { content: [{ type: "text", text: "result" }], details: {} },
+          isError: false,
+        },
+        { type: "message_start", message: resultMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage],
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+      ],
+    });
+  });
+
+  test("finishes a continuation run from a restored terminal assistant message", () => {
+    const baseMessage = userMessage("already in context");
+    const finalMessage = assistantMessage([{ type: "text", text: "continued" }]);
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [baseMessage],
+      operation: { mode: "continue" },
+      events: [
+        { type: "agent_start" },
+        { type: "turn_start" },
+        { type: "message_start", message: finalMessage },
+        { type: "message_end", message: finalMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "finish",
+      stopReason: "stop",
+      messages: [baseMessage, finalMessage],
+      errorMessage: null,
+    });
+  });
+
+  test("finishes a completed tool-termination run when agent_end was emitted", () => {
+    const promptMessage = userMessage("lookup");
+    const toolCallMessage = assistantMessage(
+      [{ type: "toolCall", id: "call-1", name: "lookup", arguments: {} }],
+      "toolUse",
+    );
+    const resultMessage = toolResultMessage("call-1");
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "lookup" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: toolCallMessage },
+        { type: "message_end", message: toolCallMessage },
+        { type: "message_start", message: resultMessage },
+        { type: "message_end", message: resultMessage },
+        { type: "turn_end", message: toolCallMessage, toolResults: [resultMessage] },
+        { type: "agent_end", messages: [promptMessage, toolCallMessage, resultMessage] },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "finish",
+      stopReason: "toolUse",
+      messages: [promptMessage, toolCallMessage, resultMessage],
+      errorMessage: null,
+    });
+  });
+
+  test("restores queued steering messages and continues from the latest user message", () => {
+    const promptMessage = userMessage("initial");
+    const firstAssistantMessage = assistantMessage([{ type: "text", text: "working" }]);
+    const steeringMessage = userMessage("also consider docs");
+
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: [],
+      operation: { mode: "prompt", promptInput: { text: "initial" } },
+      events: [
+        { type: "message_start", message: promptMessage },
+        { type: "message_end", message: promptMessage },
+        { type: "message_start", message: firstAssistantMessage },
+        { type: "message_end", message: firstAssistantMessage },
+        { type: "turn_end", message: firstAssistantMessage, toolResults: [] },
+        { type: "turn_start" },
+        { type: "message_start", message: steeringMessage },
+        { type: "message_end", message: steeringMessage },
+      ] as AgentEvent[],
+    });
+
+    expect(restore).toMatchObject({
+      type: "run",
+      operation: { mode: "continue" },
+      messages: [promptMessage, firstAssistantMessage, steeringMessage],
+    });
+  });
+});
 
 describe("runAgentTurn", () => {
   test("passes per-run afterToolCall hooks to the agent", async () => {

--- a/packages/pi-fragment/src/pi/workflow/agent-runner.ts
+++ b/packages/pi-fragment/src/pi/workflow/agent-runner.ts
@@ -75,6 +75,21 @@ export type PiAgentRunResult = {
   errorMessage: string | null;
 };
 
+export type PiAgentTurnRestoreResult =
+  | {
+      type: "run";
+      operation: PiAgentTurnOperation;
+      messages: AgentMessage[];
+      events: AgentEvent[];
+    }
+  | {
+      type: "finish";
+      stopReason: StopReason;
+      messages: AgentMessage[];
+      events: AgentEvent[];
+      errorMessage: string | null;
+    };
+
 export type AgentTurnSessionContext = {
   sessionId: string;
   agentName: string;
@@ -86,6 +101,132 @@ export type AgentTurnContext = {
   tools: PiToolRegistry;
   messages: AgentMessage[];
   turnId: string;
+};
+
+// Tool calls are only safe to restore once their matching tool-result messages were emitted.
+// If a crash happens after the assistant requested tools but before every result reached
+// `message_end`, replay from before that assistant message so the whole tool batch runs again.
+const rollbackIncompleteToolTurn = (options: {
+  baseMessageCount: number;
+  messages: AgentMessage[];
+}) => {
+  for (let index = options.baseMessageCount; index < options.messages.length; index += 1) {
+    const message = options.messages[index];
+    if (message.role !== "assistant") {
+      continue;
+    }
+
+    const callIds = message.content.flatMap((content) =>
+      content.type === "toolCall" ? [content.id] : [],
+    );
+    if (callIds.length === 0) {
+      continue;
+    }
+
+    const resultIds = new Set<string>();
+    for (let resultIndex = index + 1; resultIndex < options.messages.length; resultIndex += 1) {
+      const result = options.messages[resultIndex];
+      if (result.role !== "toolResult") {
+        break;
+      }
+      resultIds.add(result.toolCallId);
+    }
+
+    if (callIds.some((id) => !resultIds.has(id))) {
+      return options.messages.slice(0, index);
+    }
+  }
+  return options.messages;
+};
+
+export const restoreAgentTurnFromEvents = (input: {
+  baseMessages: AgentMessage[];
+  operation: PiAgentTurnOperation;
+  events: AgentEvent[];
+}): PiAgentTurnRestoreResult => {
+  const messages = [...input.baseMessages];
+  const messageStartEventIndexes: number[] = [];
+  const messageEndEventIndexes: number[] = [];
+  let currentMessageStartIndex: number | null = null;
+  let danglingMessageStartIndex: number | null = null;
+  let sawAgentEnd = false;
+
+  // Only `message_end` commits a message to Agent state. `message_start` is still useful
+  // as a rollback boundary, because partial updates after it are UI-only and should be dropped.
+  input.events.forEach((event, index) => {
+    if (event.type === "message_start") {
+      currentMessageStartIndex = index;
+      danglingMessageStartIndex = index;
+    }
+    if (event.type === "message_end") {
+      messages.push(event.message);
+      messageStartEventIndexes.push(currentMessageStartIndex ?? index);
+      messageEndEventIndexes.push(index);
+      currentMessageStartIndex = null;
+      danglingMessageStartIndex = null;
+    }
+    if (event.type === "agent_end") {
+      sawAgentEnd = true;
+    }
+  });
+
+  const toolSafeMessages = rollbackIncompleteToolTurn({
+    baseMessageCount: input.baseMessages.length,
+    messages,
+  });
+  const restoredMessages = toolSafeMessages;
+  const restoredMessageCount = restoredMessages.length - input.baseMessages.length;
+  if (
+    input.operation.mode === "prompt" &&
+    restoredMessageCount > 0 &&
+    restoredMessages[input.baseMessages.length]?.role !== "user"
+  ) {
+    return {
+      type: "run",
+      operation: input.operation,
+      messages: input.baseMessages,
+      events: [],
+    };
+  }
+
+  // Keep events only through the same boundary as the restored messages:
+  // - no restored messages: drop all prior attempt events
+  // - rolled back a committed message: cut before that message's `message_start`
+  // - restored every committed message: keep everything unless there is a dangling
+  //   `message_start`, in which case cut before the partial in-progress message.
+  const eventCutoffIndex =
+    restoredMessageCount === 0
+      ? 0
+      : restoredMessageCount < messageEndEventIndexes.length
+        ? (messageStartEventIndexes[restoredMessageCount] ?? 0)
+        : (danglingMessageStartIndex ?? input.events.length);
+  const events = input.events.slice(0, eventCutoffIndex);
+  const lastMessage = restoredMessages.at(-1);
+  const lastAssistant = restoredMessages.findLast(
+    (message): message is Extract<AgentMessage, { role: "assistant" }> =>
+      message.role === "assistant",
+  );
+  const errorMessage = lastAssistant?.errorMessage ?? null;
+  const stopReason = lastAssistant?.stopReason ?? (errorMessage ? "error" : "stop");
+  const restoredNewMessages = restoredMessages.length > input.baseMessages.length;
+
+  if (sawAgentEnd && eventCutoffIndex === input.events.length) {
+    return { type: "finish", stopReason, messages: restoredMessages, events, errorMessage };
+  }
+
+  if (
+    restoredNewMessages &&
+    lastMessage?.role === "assistant" &&
+    lastMessage.content.every((content) => content.type !== "toolCall")
+  ) {
+    return { type: "finish", stopReason, messages: restoredMessages, events, errorMessage };
+  }
+  const operation =
+    restoredNewMessages && (lastMessage?.role === "user" || lastMessage?.role === "toolResult")
+      ? ({ mode: "continue" } satisfies PiAgentTurnOperation)
+      : input.operation;
+
+  return { type: "run", operation, messages: restoredMessages, events };
 };
 
 const resolveTools = async (options: {

--- a/packages/pi-fragment/src/pi/workflow/pi-agent-step.ts
+++ b/packages/pi-fragment/src/pi/workflow/pi-agent-step.ts
@@ -2,6 +2,7 @@ import {
   type WorkflowEvent,
   type WorkflowStep,
   type WorkflowStepConfig,
+  type WorkflowStepEmission,
 } from "@fragno-dev/workflows/workflow";
 
 import type { AgentEvent, AgentMessage } from "@earendil-works/pi-agent-core";
@@ -10,6 +11,7 @@ import { PiLogger } from "../../debug-log";
 import { piSchema } from "../../schema";
 import type { PiAgentRegistry, PiSessionCommandPayload } from "../types";
 import {
+  restoreAgentTurnFromEvents,
   runAgentTurn,
   type AgentTurnContext,
   type AgentTurnSessionContext,
@@ -61,8 +63,17 @@ export type PiAgentStepBehavior = PiAgentTurnBehavior & {
   controls?: Array<"abort" | "steer">;
 };
 
-export const isEphemeralAgentEvent = (event: AgentEvent) =>
-  event.type === "message_update" || event.type === "tool_execution_update";
+const committedEmissionEpochs = (emissions: WorkflowStepEmission[]) =>
+  new Set(
+    emissions.flatMap((emission) =>
+      typeof emission.payload === "object" &&
+      emission.payload !== null &&
+      "control" in emission.payload &&
+      emission.payload.control === "step-committed"
+        ? [emission.epoch]
+        : [],
+    ),
+  );
 
 export const createPiAgentStepResult = (input: {
   stopReason: PiAgentRunResult["stopReason"];
@@ -94,10 +105,70 @@ export const runPiAgentStep = async (
   runtime.step.do(runtime.stepName, behavior.step ?? defaultStepConfig, async (tx) => {
     const runAgent = runtime.agentRunner ?? runAgentTurn;
     const messagesBeforeStep = runtime.turn.messages.length;
-    const controls = behavior.controls ?? ["abort", "steer"];
-    const result = await runAgent(
+    const previousEmissions = tx.previousEmissions();
+    const committedEpochs = committedEmissionEpochs(previousEmissions);
+    const previousEvents = previousEmissions.flatMap((emission): AgentEvent[] => {
+      if (committedEpochs.has(emission.epoch)) {
+        return [];
+      }
+      const payload = emission.payload;
+      if (typeof payload !== "object" || payload === null || !("type" in payload)) {
+        return [];
+      }
+      switch (payload.type) {
+        case "agent_start":
+        case "agent_end":
+        case "turn_start":
+        case "turn_end":
+        case "message_start":
+        case "message_update":
+        case "message_end":
+        case "tool_execution_start":
+        case "tool_execution_update":
+        case "tool_execution_end":
+          return [payload as AgentEvent];
+        default:
+          return [];
+      }
+    });
+    const restore = restoreAgentTurnFromEvents({
+      baseMessages: runtime.turn.messages,
       operation,
-      runtime,
+      events: previousEvents,
+    });
+    const controls = behavior.controls ?? ["abort", "steer"];
+
+    const finish = (result: PiAgentRunResult) => {
+      tx.mutate(({ forSchema }) => {
+        const uow = forSchema(piSchema);
+        uow.update("session", runtime.event.instanceId, (builder) =>
+          builder.set({ status: "waiting", updatedAt: uow.now() }),
+        );
+      });
+
+      return createPiAgentStepResult({
+        stopReason: result.stopReason,
+        messages: result.messages.slice(messagesBeforeStep),
+        events: result.events.filter(
+          (agentEvent) =>
+            agentEvent.type !== "message_update" && agentEvent.type !== "tool_execution_update",
+        ),
+        errorMessage: result.errorMessage,
+      });
+    };
+
+    if (restore.type === "finish") {
+      return finish({
+        stopReason: restore.stopReason,
+        messages: restore.messages,
+        events: restore.events,
+        errorMessage: restore.errorMessage,
+      });
+    }
+
+    const result = await runAgent(
+      restore.operation,
+      { ...runtime, turn: { ...runtime.turn, messages: restore.messages } },
       {
         onController: (controller) => {
           if (controls.length === 0) {
@@ -127,17 +198,5 @@ export const runPiAgentStep = async (
       behavior,
     );
 
-    tx.mutate(({ forSchema }) => {
-      const uow = forSchema(piSchema);
-      uow.update("session", runtime.event.instanceId, (builder) =>
-        builder.set({ status: "waiting", updatedAt: uow.now() }),
-      );
-    });
-
-    return createPiAgentStepResult({
-      stopReason: result.stopReason,
-      messages: result.messages.slice(messagesBeforeStep),
-      events: result.events.filter((agentEvent) => !isEphemeralAgentEvent(agentEvent)),
-      errorMessage: result.errorMessage,
-    });
+    return finish({ ...result, events: [...restore.events, ...result.events] });
   });

--- a/packages/pi-fragment/src/routes.ts
+++ b/packages/pi-fragment/src/routes.ts
@@ -328,17 +328,15 @@ export const piRoutesFactory = defineRoutes(piFragmentDefinition).create(
 
               const snapshot = await emissionBus.snapshot();
 
-              const inFlightEvents = snapshot
-                .filter(
-                  (emission) =>
-                    emission.actor === "user" &&
-                    !initialDetail.completedStepKeys.has(emission.stepKey),
-                )
-                .map((emission) => emission.payload)
-                .filter(
-                  (payload): payload is PiSessionEventStreamItem =>
-                    !("type" in payload) || payload.type !== "snapshot",
-                );
+              const inFlightEvents: PiSessionEventStreamItem[] = snapshot
+                .filter((emission) => !initialDetail.completedStepKeys.has(emission.stepKey))
+                .map((emission) => ({
+                  kind: "step-emission" as const,
+                  actor: emission.actor,
+                  stepKey: emission.stepKey,
+                  epoch: emission.epoch,
+                  payload: emission.payload,
+                }));
 
               const initialEmissions: PiSessionEventStreamItem[] = [
                 {
@@ -361,11 +359,17 @@ export const piRoutesFactory = defineRoutes(piFragmentDefinition).create(
                   emissionBus: {
                     observe: (handler) =>
                       emissionBus.observe(
-                        (message) => {
-                          if (message.actor === "user") {
-                            return handler(message);
-                          }
-                        },
+                        (message) =>
+                          handler({
+                            ...message,
+                            payload: {
+                              kind: "step-emission" as const,
+                              actor: message.actor,
+                              stepKey: message.stepKey,
+                              epoch: message.epoch,
+                              payload: message.payload,
+                            },
+                          }),
                         { after: snapshot },
                       ),
                   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1859,6 +1859,9 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260414.1
+      nanostores:
+        specifier: ^1.2.0
+        version: 1.2.0
       react:
         specifier: '>=18.0.0'
         version: 19.2.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Step-emission events no longer show stale or superseded messages — only emissions from the latest committed epoch are delivered.
  * Live commit markers for step emissions are published reliably to observers.

* **New Features**
  * Session UI shows a conditional "Continue" button when a session needs a nudge to resume.
  * Improved recovery of in-flight assistant turns and partial messages for more reliable session continuity.

* **Tests**
  * Expanded test coverage validating emission commit/rollback and restoration behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rejot-dev/fragno/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->