### PR TITLE
fix(db): properly type onAfterRetrieve callback in UOW

### DIFF
--- a/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
@@ -673,6 +673,40 @@ describe("Unified Tx API", () => {
       expect(onAfterRetrieve.mock.calls[0]?.[1]).toEqual([mockUsers]);
     });
 
+    it("should call afterRetrieve with typed handler retrieve results", async () => {
+      const compiler = createMockCompiler();
+      const mockUsers = [
+        {
+          id: FragnoId.fromExternal("1", 1),
+          email: "alice@example.com",
+          name: "Alice",
+          balance: 100,
+        },
+      ];
+      const executor: UOWExecutor<unknown, unknown> = {
+        executeRetrievalPhase: async () => [mockUsers],
+        executeMutationPhase: async () => ({ success: true, createdInternalIds: [] }),
+      };
+      const decoder = createMockDecoder();
+      let capturedUsers: unknown;
+
+      await createHandlerTxBuilder({
+        createUnitOfWork: () => createUnitOfWork(compiler, executor, decoder),
+      })
+        .retrieve(({ forSchema }) =>
+          forSchema(testSchema).find("users", (b) => b.whereIndex("idx_email")),
+        )
+        .afterRetrieve((_uow, [users]) => {
+          expectTypeOf(users).toEqualTypeOf<
+            { id: FragnoId; email: string; name: string; balance: number }[]
+          >();
+          capturedUsers = users;
+        })
+        .execute();
+
+      expect(capturedUsers).toEqual(mockUsers);
+    });
+
     it("should execute a simple mutate-only transaction", async () => {
       const compiler = createMockCompiler();
       const executor: UOWExecutor<unknown, unknown> = {

--- a/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.ts
+++ b/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.ts
@@ -290,6 +290,12 @@ export interface HandlerTxCallbacks<
   ) => TypedUnitOfWork<AnySchema, TRetrieveResults, unknown, HooksMap> | void;
 
   /**
+   * Callback invoked after handler retrieve results are available, before service calls are
+   * processed. Throwing aborts the transaction attempt.
+   */
+  afterRetrieve?: (uow: IUnitOfWork, retrieveResult: TRetrieveResults) => void | Promise<void>;
+
+  /**
    * Optional early-return after handler retrieve results are available, before service calls are
    * processed. Returning control.return(value) skips service calls, mutate, and success.
    */
@@ -844,6 +850,10 @@ async function executeTx(
       const retrieveResult: TRetrieveResults = typedUowFromRetrieve
         ? await typedUowFromRetrieve.retrievalPhase
         : ([] as unknown as TRetrieveResults);
+
+      if (callbacks.afterRetrieve) {
+        await callbacks.afterRetrieve(baseUow, retrieveResult);
+      }
 
       if (callbacks.earlyReturn) {
         const earlyReturnResult = callbacks.earlyReturn({
@@ -1636,6 +1646,7 @@ interface HandlerTxBuilderState<
     idempotencyKey: string;
     currentAttempt: number;
   }) => TypedUnitOfWork<AnySchema, TRetrieveResults, unknown, HooksMap> | void;
+  afterRetrieveFn?: (uow: IUnitOfWork, retrieveResult: TRetrieveResults) => void | Promise<void>;
   earlyReturnFn?: (ctx: {
     retrieveResult: TRetrieveResults;
     control: EarlyReturnControl;
@@ -1776,6 +1787,7 @@ export class HandlerTxBuilder<
     return new HandlerTxBuilder({
       ...this.#state,
       retrieveFn: fn,
+      afterRetrieveFn: undefined, // Clear any existing afterRetrieve since results shape changed
       transformRetrieveFn: undefined, // Clear any existing transformRetrieve since results shape changed
     } as unknown as HandlerTxBuilderState<
       TServiceCalls,
@@ -1785,6 +1797,30 @@ export class HandlerTxBuilder<
       TTransformResult,
       THooks
     >);
+  }
+
+  /**
+   * Run a side-effect after handler retrieve results are available, before declared service calls
+   * are processed. The results are typed from this builder's retrieve() callback.
+   */
+  afterRetrieve(
+    fn: (uow: IUnitOfWork, retrieveResult: TRetrieveResults) => void | Promise<void>,
+  ): HandlerTxBuilder<
+    TServiceCalls,
+    TRetrieveResults,
+    TRetrieveSuccessResult,
+    TMutateResult,
+    TTransformResult,
+    HasRetrieve,
+    HasTransformRetrieve,
+    HasMutate,
+    HasTransform,
+    THooks
+  > {
+    return new HandlerTxBuilder({
+      ...this.#state,
+      afterRetrieveFn: fn,
+    });
   }
 
   /**
@@ -1956,6 +1992,7 @@ export class HandlerTxBuilder<
       THooks
     > = {
       serviceCalls: state.withServiceCallsFn,
+      afterRetrieve: state.afterRetrieveFn,
       retrieve: state.retrieveFn
         ? (context) => {
             return state.retrieveFn!({

--- a/packages/fragno-db/src/query/unit-of-work/tx-builder.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/tx-builder.test.ts
@@ -669,6 +669,26 @@ describe("HandlerTxBuilder type inference", () => {
       // retrieveResult is the transformed type
       expectTypeOf<MutateCtx["retrieveResult"]>().toEqualTypeOf<{ id: string } | null>();
     });
+
+    it("afterRetrieve receives raw handler retrieve results", () => {
+      type Builder = HandlerTxBuilder<
+        readonly [],
+        [{ id: string } | null, { id: string }[]], // retrieve results
+        [{ id: string } | null, { id: string }[]],
+        unknown,
+        unknown,
+        true, // HasRetrieve
+        false,
+        false,
+        false,
+        {}
+      >;
+
+      type AfterRetrieveParam = Parameters<Builder["afterRetrieve"]>[0];
+      type ResultsParam = Parameters<AfterRetrieveParam>[1];
+
+      expectTypeOf<ResultsParam>().toEqualTypeOf<[{ id: string } | null, { id: string }[]]>();
+    });
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `afterRetrieve` lifecycle hook for query transactions, enabling developers to execute custom logic after data retrieval completes but before subsequent operations. Hook receives transaction context and retrieval results.

* **Tests**
  * Added test coverage verifying hook parameter typing and callback execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->