### PR TITLE
Wilco/backoffice mcp 2

### DIFF
--- a/.changeset/async-transform-retrieve.md
+++ b/.changeset/async-transform-retrieve.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/db": patch
+---
+
+fix: await async transformRetrieve callbacks before mutation

--- a/packages-private/oxlint-plugins/package.json
+++ b/packages-private/oxlint-plugins/package.json
@@ -11,7 +11,8 @@
   "exports": {
     "./tsdown-exports-sync": "./tsdown-exports-sync.js",
     "./fragment-dev-browser-exports": "./fragment-dev-browser-exports.js",
-    "./docs-icons-sync": "./docs-icons-sync.js"
+    "./docs-icons-sync": "./docs-icons-sync.js",
+    "./vitest-assert-json-response": "./vitest-assert-json-response.js"
   },
   "scripts": {
     "types:check": "tsgo --noEmit"

--- a/packages-private/oxlint-plugins/vitest-assert-json-response.js
+++ b/packages-private/oxlint-plugins/vitest-assert-json-response.js
@@ -1,0 +1,275 @@
+/**
+ * @import { Rule } from 'eslint'
+ */
+
+/** @type {Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer `assert` over `expect(...).toBe` + guard",
+      category: "Best Practices",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      replaceWithAssert:
+        'Use `assert({{expression}} === "json")` instead of `expect(...).toBe("json")` + guard.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+    let hasRelevantMatch = false;
+
+    /** @param {any} node */
+    const normalize = (node) => {
+      if (!node) {
+        return node;
+      }
+      if (node.type === "ChainExpression") {
+        return node.expression;
+      }
+      if (node.type === "TSNonNullExpression" || node.type === "TSAsExpression") {
+        return node.expression;
+      }
+      return node;
+    };
+
+    /** @param {any} node */
+    const isJsonLiteral = (node) => node?.type === "Literal" && node.value === "json";
+
+    /** @param {any} node */
+    const toBeExpression = (node) => {
+      if (node?.type !== "ExpressionStatement") {
+        return null;
+      }
+
+      const expr = node.expression;
+      if (expr?.type !== "CallExpression") {
+        return null;
+      }
+
+      if (expr.callee?.type !== "MemberExpression" || expr.callee.computed) {
+        return null;
+      }
+
+      if (expr.callee.property.type !== "Identifier" || expr.callee.property.name !== "toBe") {
+        return null;
+      }
+
+      const expectCall = normalize(expr.callee.object);
+      if (expectCall?.type !== "CallExpression") {
+        return null;
+      }
+
+      if (expectCall.callee?.type !== "Identifier" || expectCall.callee.name !== "expect") {
+        return null;
+      }
+
+      if (expectCall.arguments.length !== 1 || expr.arguments.length !== 1) {
+        return null;
+      }
+
+      if (!isJsonLiteral(expr.arguments[0])) {
+        return null;
+      }
+
+      const value = normalize(expectCall.arguments[0]);
+      if (value?.type !== "MemberExpression" || value.computed) {
+        return null;
+      }
+
+      if (value.property.type !== "Identifier" || value.property.name !== "type") {
+        return null;
+      }
+
+      return value;
+    };
+
+    /**
+     * @param {any} a
+     * @param {any} b
+     * @returns {boolean}
+     */
+    const sameExpr = (a, b) => {
+      const left = normalize(a);
+      const right = normalize(b);
+
+      if (!left || !right || left.type !== right.type) {
+        return false;
+      }
+
+      if (left.type === "Identifier") {
+        return left.name === right.name;
+      }
+
+      if (left.type === "ThisExpression") {
+        return true;
+      }
+
+      if (left.type === "Literal") {
+        return left.value === right.value;
+      }
+
+      if (left.type === "MemberExpression") {
+        if (left.computed || right.computed) {
+          return false;
+        }
+
+        return (
+          left.property.type === "Identifier" &&
+          right.property.type === "Identifier" &&
+          left.property.name === right.property.name &&
+          sameExpr(left.object, right.object)
+        );
+      }
+
+      return false;
+    };
+
+    /**
+     * @param {any} node
+     * @param {any} expr
+     */
+    const isJsonGuardIf = (node, expr) => {
+      if (!node || node.type !== "IfStatement") {
+        return false;
+      }
+
+      if (node.consequent.type !== "BlockStatement" || node.consequent.body.length !== 1) {
+        return false;
+      }
+
+      const statement = node.consequent.body[0];
+      if (statement.type !== "ReturnStatement" && statement.type !== "ThrowStatement") {
+        return false;
+      }
+
+      const test = node.test;
+      if (test?.type !== "BinaryExpression" || test.operator !== "!==") {
+        return false;
+      }
+
+      return isJsonLiteral(test.right) && sameExpr(test.left, expr);
+    };
+
+    return {
+      "BlockStatement:exit"(node) {
+        const { body } = node;
+        if (!Array.isArray(body) || body.length < 2) {
+          return;
+        }
+
+        for (let i = 0; i < body.length - 1; i += 1) {
+          const expectStmt = body[i];
+          const ifStmt = body[i + 1];
+
+          const expr = toBeExpression(expectStmt);
+          if (!expr || !isJsonGuardIf(ifStmt, expr)) {
+            continue;
+          }
+
+          hasRelevantMatch = true;
+          context.report({
+            node: ifStmt,
+            messageId: "replaceWithAssert",
+            data: { expression: sourceCode.getText(expr) },
+            fix(fixer) {
+              if (!expectStmt.range || !ifStmt.range) {
+                return null;
+              }
+
+              const replacement = `assert(${sourceCode.getText(expr)} === "json");\n`;
+              return fixer.replaceTextRange([expectStmt.range[0], ifStmt.range[1]], replacement);
+            },
+          });
+        }
+      },
+
+      "Program:exit"(node) {
+        if (!hasRelevantMatch) {
+          return;
+        }
+
+        /** @type {any | null} */
+        const vitestImport = node.body.find(
+          (statement) =>
+            statement.type === "ImportDeclaration" &&
+            statement.source.type === "Literal" &&
+            statement.source.value === "vitest",
+        );
+
+        /** @param {any} importDecl */
+        const hasAssertSpecifier = (importDecl) => {
+          return importDecl?.specifiers?.some(
+            /** @param {any} specifier */
+            (specifier) =>
+              specifier.type === "ImportSpecifier" && specifier.local.name === "assert",
+          );
+        };
+
+        const insertImport = () => {
+          const insertion = `import { assert } from "vitest";\n`;
+          const insertAt = node.body.length > 0 ? node.body[0] : null;
+          if (!insertAt) {
+            context.report({
+              node,
+              message: "Add assert import from vitest",
+              fix: (fixer) => fixer.insertTextAfterRange([0, 0], insertion),
+            });
+            return;
+          }
+
+          context.report({
+            node,
+            message: "Add assert import from vitest",
+            fix(fixer) {
+              return fixer.insertTextBefore(insertAt, insertion);
+            },
+          });
+        };
+
+        if (!vitestImport) {
+          insertImport();
+          return;
+        }
+
+        if (hasAssertSpecifier(vitestImport)) {
+          return;
+        }
+
+        const namedSpecifiers = vitestImport.specifiers.filter(
+          /** @param {any} s */
+          (s) => s.type === "ImportSpecifier",
+        );
+
+        if (namedSpecifiers.length > 0) {
+          const lastSpecifier = namedSpecifiers[namedSpecifiers.length - 1];
+          context.report({
+            node: vitestImport,
+            message: "Add assert import from vitest",
+            fix(fixer) {
+              return fixer.insertTextAfter(lastSpecifier, ", assert");
+            },
+          });
+          return;
+        }
+
+        insertImport();
+      },
+    };
+  },
+};
+
+const plugin = {
+  meta: {
+    name: "vitest-assert-json-response",
+    version: "1.0.0",
+  },
+  rules: {
+    "assert-json-response": rule,
+  },
+};
+
+export default plugin;

--- a/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
@@ -751,6 +751,73 @@ describe("Unified Tx API", () => {
       );
     });
 
+    it("should await async handler transformRetrieve before mutate", async () => {
+      const compiler = createMockCompiler();
+      const mockUser = {
+        id: FragnoId.fromExternal("1", 1),
+        email: "test@example.com",
+        name: "Test",
+        balance: 100,
+      };
+      const executor: UOWExecutor<unknown, unknown> = {
+        executeRetrievalPhase: async () => [[mockUser]],
+        executeMutationPhase: async () => ({ success: true, createdInternalIds: [] }),
+      };
+      const decoder = createMockDecoder();
+
+      const result = await createHandlerTxBuilder({
+        createUnitOfWork: () => createUnitOfWork(compiler, executor, decoder),
+      })
+        .retrieve(({ forSchema }) =>
+          forSchema(testSchema).find("users", (b) => b.whereIndex("idx_email")),
+        )
+        .transformRetrieve(async ([users]) => users[0] ?? null)
+        .mutate(({ retrieveResult }) => {
+          expect(retrieveResult).toEqual(mockUser);
+          return { email: retrieveResult?.email };
+        })
+        .execute();
+
+      expect(result).toEqual({ email: "test@example.com" });
+    });
+
+    it("should await async service transformRetrieve before handler mutate", async () => {
+      const compiler = createMockCompiler();
+      const mockUser = {
+        id: FragnoId.fromExternal("1", 1),
+        email: "test@example.com",
+        name: "Test",
+        balance: 100,
+      };
+      const executor: UOWExecutor<unknown, unknown> = {
+        executeRetrievalPhase: async () => [[mockUser]],
+        executeMutationPhase: async () => ({ success: true, createdInternalIds: [] }),
+      };
+      const decoder = createMockDecoder();
+
+      let currentUow: IUnitOfWork | null = null;
+      const getUserById = () =>
+        createServiceTxBuilder(testSchema, currentUow!)
+          .retrieve((uow) => uow.find("users", (b) => b.whereIndex("idx_email")))
+          .transformRetrieve(async ([users]) => users[0] ?? null)
+          .build();
+
+      const result = await createHandlerTxBuilder({
+        createUnitOfWork: () => {
+          currentUow = createUnitOfWork(compiler, executor, decoder);
+          return currentUow;
+        },
+      })
+        .withServiceCalls(() => [getUserById()] as const)
+        .mutate(({ serviceIntermediateResult: [user] }) => {
+          expect(user).toEqual(mockUser);
+          return { email: user?.email };
+        })
+        .execute();
+
+      expect(result).toEqual({ email: "test@example.com" });
+    });
+
     it("should execute a transaction with serviceCalls as retrieve source", async () => {
       const compiler = createMockCompiler();
       const mockUser = {

--- a/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.ts
+++ b/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.ts
@@ -20,6 +20,8 @@ export function isTxResult(value: unknown): value is TxResult<unknown> {
   );
 }
 
+type MaybePromise<T> = T | Promise<T>;
+
 /**
  * Extract the retrieve success result type from a TxResult.
  * If the TxResult has retrieveSuccess, returns its return type.
@@ -222,7 +224,7 @@ export interface ServiceTxCallbacks<
   retrieveSuccess?: (
     retrieveResult: TRetrieveResults,
     serviceResult: ExtractServiceRetrieveResults<TServiceCalls>,
-  ) => TRetrieveSuccessResult;
+  ) => MaybePromise<TRetrieveSuccessResult>;
 
   /**
    * Mutation phase callback - schedules mutations based on retrieve results.
@@ -310,7 +312,7 @@ export interface HandlerTxCallbacks<
   retrieveSuccess?: (
     retrieveResult: TRetrieveResults,
     serviceResult: ExtractServiceRetrieveResults<TServiceCalls>,
-  ) => TRetrieveSuccessResult;
+  ) => MaybePromise<TRetrieveSuccessResult>;
 
   /**
    * Mutation phase callback - schedules mutations based on retrieve results.
@@ -650,7 +652,7 @@ async function processTxResultAfterRetrieve<T>(
   }
 
   if (callbacks.retrieveSuccess) {
-    internal.retrieveSuccessResult = callbacks.retrieveSuccess(
+    internal.retrieveSuccessResult = await callbacks.retrieveSuccess(
       retrieveResults,
       serviceResults as ExtractServiceRetrieveResults<readonly TxResult<unknown>[]>,
     );
@@ -899,7 +901,7 @@ async function executeTx(
       // Call retrieveSuccess if provided
       let retrieveSuccessResult: TRetrieveSuccessResult;
       if (callbacks.retrieveSuccess) {
-        retrieveSuccessResult = callbacks.retrieveSuccess(
+        retrieveSuccessResult = await callbacks.retrieveSuccess(
           retrieveResult,
           serviceResults as ExtractServiceRetrieveResults<TServiceCalls>,
         );
@@ -1237,7 +1239,7 @@ interface ServiceTxBuilderState<
   transformRetrieveFn?: (
     retrieveResult: TRetrieveResults,
     serviceRetrieveResult: ExtractServiceRetrieveResults<TServiceCalls>,
-  ) => TRetrieveSuccessResult;
+  ) => MaybePromise<TRetrieveSuccessResult>;
   mutateFn?: (
     ctx: ServiceBuilderMutateContext<
       TSchema,
@@ -1392,12 +1394,12 @@ export class ServiceTxBuilder<
     fn: (
       retrieveResult: TRetrieveResults,
       serviceResult: ExtractServiceRetrieveResults<TServiceCalls>,
-    ) => TNewRetrieveSuccessResult,
+    ) => MaybePromise<TNewRetrieveSuccessResult>,
   ): ServiceTxBuilder<
     TSchema,
     TServiceCalls,
     TRetrieveResults,
-    TNewRetrieveSuccessResult,
+    Awaited<TNewRetrieveSuccessResult>,
     TMutateResult,
     TTransformResult,
     HasRetrieve,
@@ -1413,7 +1415,7 @@ export class ServiceTxBuilder<
       TSchema,
       TServiceCalls,
       TRetrieveResults,
-      TNewRetrieveSuccessResult,
+      Awaited<TNewRetrieveSuccessResult>,
       TMutateResult,
       TTransformResult,
       THooks
@@ -1857,11 +1859,11 @@ export class HandlerTxBuilder<
     fn: (
       retrieveResult: TRetrieveResults,
       serviceResult: ExtractServiceRetrieveResults<TServiceCalls>,
-    ) => TNewRetrieveSuccessResult,
+    ) => MaybePromise<TNewRetrieveSuccessResult>,
   ): HandlerTxBuilder<
     TServiceCalls,
     TRetrieveResults,
-    TNewRetrieveSuccessResult,
+    Awaited<TNewRetrieveSuccessResult>,
     TMutateResult,
     TTransformResult,
     HasRetrieve,
@@ -1876,7 +1878,7 @@ export class HandlerTxBuilder<
     } as unknown as HandlerTxBuilderState<
       TServiceCalls,
       TRetrieveResults,
-      TNewRetrieveSuccessResult,
+      Awaited<TNewRetrieveSuccessResult>,
       TMutateResult,
       TTransformResult,
       THooks

--- a/packages/fragno-db/src/query/unit-of-work/tx-builder.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/tx-builder.test.ts
@@ -6,7 +6,7 @@
  * NOTE: These are TYPE tests only. We test that the type inference is correct,
  * not the runtime behavior (which is covered by execute-unit-of-work.test.ts).
  */
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 import type { AnySchema } from "../../schema/create";
 import {
@@ -668,6 +668,34 @@ describe("HandlerTxBuilder type inference", () => {
 
       // retrieveResult is the transformed type
       expectTypeOf<MutateCtx["retrieveResult"]>().toEqualTypeOf<{ id: string } | null>();
+    });
+
+    it("transformRetrieve unwraps async transform results for later callbacks", () => {
+      type Builder = HandlerTxBuilder<
+        readonly [],
+        [{ id: string }[]],
+        [{ id: string }[]],
+        unknown,
+        unknown,
+        true,
+        false,
+        false,
+        false,
+        {}
+      >;
+
+      const assertTypes = () => {
+        const builder = null as unknown as Builder;
+        const transformed = builder.transformRetrieve<{ id: string } | null>(
+          async ([items]) => items[0] ?? null,
+        );
+        type MutateParam = Parameters<typeof transformed.mutate>[0];
+        type MutateCtx = Parameters<MutateParam>[0];
+
+        expectTypeOf<MutateCtx["retrieveResult"]>().toEqualTypeOf<{ id: string } | null>();
+      };
+
+      expect(assertTypes).toBeTypeOf("function");
     });
 
     it("afterRetrieve receives raw handler retrieve results", () => {

--- a/packages/mcp-fragment/CHANGELOG.md
+++ b/packages/mcp-fragment/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @fragno-dev/mcp-fragment
+
+## Unreleased
+
+- Initial scaffold copy prepared for MCP fragment development.

--- a/packages/mcp-fragment/README.md
+++ b/packages/mcp-fragment/README.md
@@ -1,0 +1,271 @@
+# mcp-fragment
+
+A DB-backed Fragno fragment for calling MCP tools over Streamable HTTP.
+
+This fragment is a client for one or more remote MCP servers. It stores server configuration and
+auth state in the fragment database, then connects to MCP servers per operation to list tools or
+call a tool. It supports MCP **tools** only; prompts, resources, roots, sampling, and elicitation
+are out of scope for this package.
+
+## Usage
+
+```ts
+import { createMcpFragment } from "@fragno-dev/mcp-fragment";
+
+const fragment = createMcpFragment(
+  {
+    publicBaseUrl: "https://app.example.com/mcp",
+    // Optional SSRF/tenant allow-list hook.
+    allowedEndpointUrls: (url) => url.protocol === "https:",
+  },
+  {
+    databaseAdapter: yourDatabaseAdapter,
+  },
+);
+```
+
+## CLI
+
+The package ships a small local CLI for trying remote MCP servers from disk-backed SQLite storage.
+It runs the MCP fragment locally, migrates the SQLite database on startup when needed, and stores
+data under `~/.fragno/mcp-fragment` by default.
+
+```bash
+# Terminal 1: start the local fragment server.
+fragno-mcp serve
+
+# From this repository, run the same command through pnpm:
+pnpm --filter @fragno-dev/mcp-fragment cli -- serve
+
+# Terminal 2: register a remote Streamable HTTP MCP server.
+fragno-mcp add my-tools https://mcp.example.com/mcp
+
+# Start OAuth for that server. Keep `serve` running so it can handle the callback.
+fragno-mcp oauth my-tools --scope tools
+
+# Check auth state.
+fragno-mcp status my-tools
+
+# Retrieve the remote MCP tools.
+fragno-mcp tools my-tools
+```
+
+Defaults:
+
+- local base URL: `http://127.0.0.1:3927`
+- fragment mount route: `/api/mcp-fragment`
+- SQLite data directory: `~/.fragno/mcp-fragment`
+
+Useful options:
+
+```bash
+fragno-mcp serve --port 4000 --data-dir ./mcp-data
+fragno-mcp oauth my-tools --client-id ... --client-secret ... --no-open
+fragno-mcp tools my-tools --json
+```
+
+For `add`, the CLI registers the server with `auth: { type: "none" }`; run `oauth` afterwards for
+OAuth-backed servers. Keep `fragno-mcp serve` running while authorizing so the remote OAuth provider
+can redirect back to `/api/mcp-fragment/oauth/callback`.
+
+## Client helpers
+
+```ts
+import { createMcpFragmentClients } from "@fragno-dev/mcp-fragment";
+
+const mcp = createMcpFragmentClients({ baseUrl: "/mcp" });
+
+// Hooks
+mcp.useServers;
+mcp.useServer;
+mcp.useTools;
+
+// Mutators
+mcp.createServer;
+mcp.setToken;
+mcp.startOAuth;
+mcp.deleteAuth;
+mcp.callTool;
+```
+
+## Routes
+
+Server management:
+
+- `POST /servers` - register an MCP server.
+- `GET /servers` - list registered servers.
+- `GET /servers/:slug` - get one registered server.
+- `DELETE /servers/:slug` - delete a server and its auth/cache state.
+
+Auth:
+
+- `GET /servers/:slug/auth/status` - report auth mode and whether usable auth is stored.
+- `POST /servers/:slug/auth/token` - store or replace a bearer token.
+- `POST /servers/:slug/auth/start` - start OAuth authorization-code + PKCE.
+- `GET /oauth/callback` - complete OAuth authorization-code + PKCE.
+- `DELETE /servers/:slug/auth` - delete auth state and switch the server to `none` auth.
+
+Tools:
+
+- `GET /servers/:slug/tools` - connect to the MCP server and list tools.
+- `POST /servers/:slug/tool` - connect to the MCP server and call one tool.
+
+## Registering servers
+
+No auth:
+
+```ts
+await mcp.createServer.mutate({
+  slug: "local-tools",
+  endpointUrl: "https://mcp.example.com/mcp",
+  auth: { type: "none" },
+});
+```
+
+Bearer token auth:
+
+```ts
+await mcp.createServer.mutate({
+  slug: "private-tools",
+  endpointUrl: "https://mcp.example.com/mcp",
+  auth: { type: "bearer", token: "..." },
+});
+
+// Later replacement:
+await mcp.setToken.mutate({ token: "new-token" }, { pathParams: { slug: "private-tools" } });
+```
+
+Client credentials auth:
+
+```ts
+await mcp.createServer.mutate({
+  slug: "machine-tools",
+  endpointUrl: "https://mcp.example.com/mcp",
+  auth: {
+    type: "client_credentials",
+    clientId: "...",
+    clientSecret: "...",
+    scopes: ["tools"],
+  },
+});
+```
+
+The fragment acquires an access token before the first tool operation, stores it with its expiry,
+and reuses it until it is close to expiring.
+
+OAuth auth:
+
+```ts
+await mcp.createServer.mutate({
+  slug: "oauth-tools",
+  endpointUrl: "https://mcp.example.com/mcp",
+  auth: { type: "oauth" },
+});
+```
+
+## OAuth flow
+
+The OAuth flow uses the official MCP TypeScript SDK auth APIs with a fragment-owned DB-backed
+`OAuthClientProvider`.
+
+### 1. Start authorization
+
+Call `POST /servers/:slug/auth/start`:
+
+```ts
+const start = await mcp.startOAuth.mutate(
+  {
+    // Optional OAuth scope string.
+    scope: "tools",
+    // Optional static/pre-registered OAuth client. Persisted for the callback.
+    clientId: "...",
+    clientSecret: "...",
+  },
+  { pathParams: { slug: "oauth-tools" } },
+);
+
+window.location.href = start.authorizationUrl;
+```
+
+The route:
+
+1. Loads the MCP server by slug.
+2. Creates a DB-backed SDK `OAuthClientProvider` for that server.
+3. Calls the SDK `auth(...)` helper.
+4. Lets the SDK discover OAuth protected-resource metadata and authorization-server metadata.
+5. Lets the SDK perform dynamic client registration when required.
+6. Generates PKCE verifier/challenge and an authorization URL.
+7. Stores the OAuth state, PKCE verifier, fragment-owned redirect URI, requested scope, discovery
+   state, and client information in the fragment DB/secret tables.
+8. Returns `{ authorizationUrl, state }`.
+
+### 2. User authorizes with the OAuth server
+
+Redirect the browser to `authorizationUrl`. The OAuth server eventually redirects back to the
+fragment callback URL with `code` and `state` query parameters.
+
+### 3. Complete callback
+
+The mounted fragment handles:
+
+```http
+GET /oauth/callback?code=...&state=...
+```
+
+The callback route:
+
+1. Validates that `code` and `state` exist.
+2. Loads the pending one-time OAuth state from the DB.
+3. Rejects missing, expired, or already consumed states.
+4. Recreates the DB-backed SDK `OAuthClientProvider` for the matching server.
+5. Calls SDK `auth(...)` with the authorization code.
+6. Lets the SDK exchange the code + PKCE verifier for tokens.
+7. Stores access token, refresh token, token type, scope, and expiry in stored secret payloads.
+8. Marks the OAuth state as consumed only after successful token exchange.
+9. Returns `{ authenticated: true, mode: "oauth" }`.
+
+### 4. Tool operations use stored OAuth tokens
+
+After callback completion, `GET /servers/:slug/tools` and `POST /servers/:slug/tool` read the stored
+OAuth token payload from the DB and send the access token as a bearer token when connecting to the
+MCP server.
+
+The fragment still connects per operation. MCP session IDs are used only inside a single operation
+by the SDK transport and are not stored or reused across requests.
+
+## Calling tools
+
+```ts
+const tools = await mcp.useTools.store({ pathParams: { slug: "oauth-tools" } });
+
+const result = await mcp.callTool.mutate(
+  {
+    name: "echo",
+    arguments: { text: "hello" },
+    timeoutMs: 10_000,
+  },
+  { pathParams: { slug: "oauth-tools" } },
+);
+```
+
+## Security notes
+
+- Always provide `allowedEndpointUrls` in production to prevent SSRF.
+- Auth payloads and OAuth state are stored as JSON/plaintext in the fragment database; use
+  database-level controls if those values need protection.
+- OAuth state is one-time use and expires after 10 minutes.
+- Deleting a server deletes stored auth, pending OAuth state, and cached tools.
+- `DELETE /servers/:slug/auth` deletes auth state and switches that server back to `none` auth.
+
+## Build
+
+```bash
+pnpm run types:check
+pnpm run build
+```
+
+## Test
+
+```bash
+pnpm run test
+```

--- a/packages/mcp-fragment/bin/run.js
+++ b/packages/mcp-fragment/bin/run.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { run } from "../dist/cli/cli.js";
+
+const exitCode = await run(process.argv);
+if (typeof exitCode === "number") {
+  process.exitCode = exitCode;
+}

--- a/packages/mcp-fragment/package.json
+++ b/packages/mcp-fragment/package.json
@@ -1,0 +1,149 @@
+{
+  "name": "@fragno-dev/mcp-fragment",
+  "version": "0.0.3",
+  "description": "A Fragno fragment",
+  "keywords": [
+    "fragno",
+    "react",
+    "solidjs",
+    "svelte",
+    "typescript",
+    "vue"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rejot-dev/fragno.git",
+    "directory": "packages/mcp-fragment"
+  },
+  "bin": {
+    "fragno-mcp": "./bin/run.js"
+  },
+  "files": [
+    "dist",
+    "bin"
+  ],
+  "type": "module",
+  "main": "./dist/node/index.js",
+  "module": "./dist/node/index.js",
+  "types": "./dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "default": "./dist/node/index.js"
+    },
+    "./cli": {
+      "types": "./dist/cli/cli.d.ts",
+      "default": "./dist/cli/cli.js"
+    },
+    "./definition": {
+      "development": "./src/definition.ts",
+      "types": "./dist/node/definition.d.ts",
+      "default": "./dist/node/definition.js"
+    },
+    "./dist/node/definition.js": {
+      "types": "./dist/node/definition.d.ts",
+      "default": "./dist/node/definition.js"
+    },
+    "./routes": {
+      "development": "./src/routes.ts",
+      "types": "./dist/node/routes.d.ts",
+      "default": "./dist/node/routes.js"
+    },
+    "./dist/node/routes.js": {
+      "types": "./dist/node/routes.d.ts",
+      "default": "./dist/node/routes.js"
+    },
+    "./schema": {
+      "development": "./src/schema.ts",
+      "types": "./dist/node/schema.d.ts",
+      "default": "./dist/node/schema.js"
+    },
+    "./dist/node/schema.js": {
+      "types": "./dist/node/schema.d.ts",
+      "default": "./dist/node/schema.js"
+    },
+    "./types": {
+      "development": "./src/mcp-types.ts",
+      "types": "./dist/node/mcp-types.d.ts",
+      "default": "./dist/node/mcp-types.js"
+    },
+    "./dist/node/mcp-types.js": {
+      "types": "./dist/node/mcp-types.d.ts",
+      "default": "./dist/node/mcp-types.js"
+    },
+    "./react": {
+      "development": {
+        "browser": "./dist/browser/client/react.js",
+        "default": "./src/client/react.ts"
+      },
+      "types": "./dist/browser/client/react.d.ts",
+      "default": "./dist/browser/client/react.js"
+    },
+    "./vue": {
+      "development": {
+        "browser": "./dist/browser/client/vue.js",
+        "default": "./src/client/vue.ts"
+      },
+      "types": "./dist/browser/client/vue.d.ts",
+      "default": "./dist/browser/client/vue.js"
+    },
+    "./svelte": {
+      "development": {
+        "browser": "./dist/browser/client/svelte.js",
+        "default": "./src/client/svelte.ts"
+      },
+      "types": "./dist/browser/client/svelte.d.ts",
+      "default": "./dist/browser/client/svelte.js"
+    },
+    "./solid": {
+      "development": {
+        "browser": "./dist/browser/client/solid.js",
+        "default": "./src/client/solid.ts"
+      },
+      "types": "./dist/browser/client/solid.d.ts",
+      "default": "./dist/browser/client/solid.js"
+    },
+    "./vanilla": {
+      "development": {
+        "browser": "./dist/browser/client/vanilla.js",
+        "default": "./src/client/vanilla.ts"
+      },
+      "types": "./dist/browser/client/vanilla.d.ts",
+      "default": "./dist/browser/client/vanilla.js"
+    }
+  },
+  "scripts": {
+    "types:check": "tsgo --noEmit",
+    "build": "tsdown",
+    "cli": "tsx src/cli/cli.ts",
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
+  },
+  "dependencies": {
+    "@fragno-dev/core": "workspace:*",
+    "@fragno-dev/db": "workspace:*",
+    "@fragno-dev/node": "workspace:*",
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@standard-schema/spec": "^1.0.0",
+    "better-sqlite3": "^12.5.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@fragno-dev/cli": "workspace:*",
+    "@fragno-dev/test": "workspace:*",
+    "@fragno-dev/unplugin-fragno": "workspace:*",
+    "@fragno-private/typescript-config": "workspace:*",
+    "@fragno-private/vitest-config": "workspace:*",
+    "@types/node": "^25.2.2",
+    "@vitest/coverage-istanbul": "^4.1.0",
+    "tsdown": "^0.20.3",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@typescript/native-preview": "catalog:",
+    "react": ">=18.0.0",
+    "solid-js": ">=1.0.0",
+    "svelte": ">=4.0.0",
+    "vue": ">=3.0.0"
+  }
+}

--- a/packages/mcp-fragment/src/cli/cli.ts
+++ b/packages/mcp-fragment/src/cli/cli.ts
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import { migrate } from "@fragno-dev/db";
+import { toNodeHandler } from "@fragno-dev/node";
+
+import { createMcpFragment } from "../index";
+
+const DEFAULT_PORT = 3927;
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_MOUNT_ROUTE = "/api/mcp-fragment";
+
+const USAGE = `fragno-mcp <command> [options]
+
+Commands:
+  serve                         Run the local MCP fragment server
+  add <slug> <endpoint-url>      Register a remote MCP server
+  oauth <slug>                  Start OAuth and open the authorization URL
+  status <slug>                 Show auth status
+  tools <slug>                  List remote MCP tools
+
+Options:
+  --base-url <url>              Local fragment base URL (default: http://127.0.0.1:3927)
+  --port <port>                 Server port for serve/oauth (default: 3927)
+  --host <host>                 Server host for serve (default: 127.0.0.1)
+  --data-dir <path>             SQLite data directory (default: ~/.fragno/mcp-fragment)
+  --mount-route <path>          Fragment mount route (default: /api/mcp-fragment)
+  --scope <scope>               OAuth scope
+  --client-id <id>              OAuth client id
+  --client-secret <secret>      OAuth client secret
+  --json                        Print JSON
+  --no-open                     Do not open the browser for oauth
+  -h, --help                    Show help`;
+
+type Logger = Pick<Console, "log" | "error">;
+
+type Parsed = {
+  command?: string;
+  args: string[];
+  options: Record<string, string | boolean>;
+};
+
+function parse(argv: string[]): Parsed {
+  const args: string[] = [];
+  const options: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") {
+      args.push(...argv.slice(i + 1));
+      break;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options["help"] = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      const [rawKey, rawValue] = arg.split("=", 2);
+      const key = rawKey.slice(2);
+      if (key === "json" || key === "no-open") {
+        options[key] = rawValue === undefined ? true : rawValue !== "false";
+        continue;
+      }
+      const value = rawValue ?? argv[i + 1];
+      if (rawValue === undefined) {
+        i += 1;
+      }
+      options[key] = value ?? "";
+      continue;
+    }
+    args.push(arg);
+  }
+  const [command, ...rest] = args;
+  return { command, args: rest, options };
+}
+
+function optionString(options: Parsed["options"], key: string): string | undefined {
+  const value = options[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionBoolean(options: Parsed["options"], key: string): boolean {
+  return options[key] === true;
+}
+
+function localBaseUrl(options: Parsed["options"]): string {
+  return (
+    optionString(options, "base-url") ??
+    `http://${DEFAULT_HOST}:${optionString(options, "port") ?? DEFAULT_PORT}`
+  );
+}
+
+function mountRoute(options: Parsed["options"]): string {
+  return optionString(options, "mount-route") ?? DEFAULT_MOUNT_ROUTE;
+}
+
+function dataDir(options: Parsed["options"]): string {
+  return optionString(options, "data-dir") ?? path.join(homedir(), ".fragno", "mcp-fragment");
+}
+
+function fragmentUrl(options: Parsed["options"], route: string): string {
+  return `${localBaseUrl(options).replace(/\/$/, "")}${mountRoute(options)}${route}`;
+}
+
+async function requestJson(method: string, url: string, body?: unknown): Promise<unknown> {
+  const response = await fetch(url, {
+    method,
+    headers: body === undefined ? undefined : { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : undefined;
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === "object" && "message" in payload
+        ? String((payload as { message: unknown }).message)
+        : text || `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return payload;
+}
+
+async function startServer(options: Parsed["options"], logger: Logger): Promise<Server> {
+  const dir = dataDir(options);
+  await mkdir(dir, { recursive: true });
+  process.env["FRAGNO_DATA_DIR"] = dir;
+
+  const baseUrl = localBaseUrl(options).replace(/\/$/, "");
+  const fragment = createMcpFragment(
+    { publicBaseUrl: `${baseUrl}${mountRoute(options)}` },
+    { mountRoute: mountRoute(options), databaseNamespace: "mcp-fragment" },
+  );
+  logger.log("migrating sqlite database if needed...");
+  await migrate(fragment);
+  const handler = toNodeHandler(fragment.handler);
+  const server = createServer((req, res) => {
+    if (req.url?.startsWith(fragment.mountRoute)) {
+      return handler(req, res);
+    }
+    res.writeHead(404, { "content-type": "text/plain" }).end("Not found");
+  });
+  const port = Number(optionString(options, "port") ?? DEFAULT_PORT);
+  const host = optionString(options, "host") ?? DEFAULT_HOST;
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  logger.log(`fragno-mcp listening at ${baseUrl}${fragment.mountRoute}`);
+  logger.log(`sqlite data dir: ${dir}`);
+  return server;
+}
+
+function openBrowser(url: string) {
+  const command =
+    process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  spawn(command, args, { stdio: "ignore", detached: true }).unref();
+}
+
+function print(value: unknown, json: boolean, logger: Logger) {
+  if (json) {
+    logger.log(JSON.stringify(value, null, 2));
+    return;
+  }
+  if (
+    value &&
+    typeof value === "object" &&
+    "tools" in value &&
+    Array.isArray((value as { tools: unknown[] }).tools)
+  ) {
+    for (const tool of (value as { tools: unknown[] }).tools) {
+      const record = tool && typeof tool === "object" ? (tool as Record<string, unknown>) : {};
+      logger.log(
+        `${String(record["name"] ?? "(unnamed)")}\t${String(record["description"] ?? "")}`,
+      );
+    }
+    return;
+  }
+  logger.log(JSON.stringify(value, null, 2));
+}
+
+export async function run(argv: string[], logger: Logger = console): Promise<number> {
+  const parsed = parse(argv.slice(2));
+  if (optionBoolean(parsed.options, "help") || !parsed.command) {
+    logger.log(USAGE);
+    return parsed.command ? 0 : 1;
+  }
+
+  try {
+    switch (parsed.command) {
+      case "serve": {
+        await startServer(parsed.options, logger);
+        await new Promise(() => undefined);
+        return 0;
+      }
+      case "add": {
+        const [slug, endpointUrl] = parsed.args;
+        if (!slug || !endpointUrl) {
+          throw new Error("Usage: fragno-mcp add <slug> <endpoint-url>");
+        }
+        const result = await requestJson("POST", fragmentUrl(parsed.options, "/servers"), {
+          slug,
+          endpointUrl,
+          auth: { type: "none" },
+        });
+        print(result, optionBoolean(parsed.options, "json"), logger);
+        return 0;
+      }
+      case "oauth": {
+        const [slug] = parsed.args;
+        if (!slug) {
+          throw new Error("Usage: fragno-mcp oauth <slug>");
+        }
+        const result = (await requestJson(
+          "POST",
+          fragmentUrl(parsed.options, `/servers/${encodeURIComponent(slug)}/auth/start`),
+          {
+            scope: optionString(parsed.options, "scope"),
+            clientId: optionString(parsed.options, "client-id"),
+            clientSecret: optionString(parsed.options, "client-secret"),
+          },
+        )) as { authorizationUrl: string };
+        logger.log(`Open this URL to authorize:\n${result.authorizationUrl}`);
+        if (!optionBoolean(parsed.options, "no-open")) {
+          openBrowser(result.authorizationUrl);
+        }
+        logger.log(
+          "Keep `fragno-mcp serve` running until the browser redirects back to the local callback.",
+        );
+        return 0;
+      }
+      case "status": {
+        const [slug] = parsed.args;
+        if (!slug) {
+          throw new Error("Usage: fragno-mcp status <slug>");
+        }
+        print(
+          await requestJson(
+            "GET",
+            fragmentUrl(parsed.options, `/servers/${encodeURIComponent(slug)}/auth/status`),
+          ),
+          optionBoolean(parsed.options, "json"),
+          logger,
+        );
+        return 0;
+      }
+      case "tools": {
+        const [slug] = parsed.args;
+        if (!slug) {
+          throw new Error("Usage: fragno-mcp tools <slug>");
+        }
+        print(
+          await requestJson(
+            "GET",
+            fragmentUrl(parsed.options, `/servers/${encodeURIComponent(slug)}/tools`),
+          ),
+          optionBoolean(parsed.options, "json"),
+          logger,
+        );
+        return 0;
+      }
+      default:
+        throw new Error(`Unknown command: ${parsed.command}`);
+    }
+  } catch (error) {
+    logger.error(`${error instanceof Error ? error.message : String(error)}\n\n${USAGE}`);
+    return 1;
+  }
+}
+
+const isDirectCliRun = process.argv[1]
+  ? import.meta.url === new URL(process.argv[1], "file:").href
+  : false;
+
+if (isDirectCliRun) {
+  const exitCode = await run(process.argv);
+  if (typeof exitCode === "number") {
+    process.exitCode = exitCode;
+  }
+}

--- a/packages/mcp-fragment/src/client/react.ts
+++ b/packages/mcp-fragment/src/client/react.ts
@@ -1,0 +1,8 @@
+import type { FragnoPublicClientConfig } from "@fragno-dev/core/client";
+import { useFragno } from "@fragno-dev/core/react";
+
+import { createMcpFragmentClients } from "..";
+
+export function createMcpFragmentClient(config: FragnoPublicClientConfig = {}) {
+  return useFragno(createMcpFragmentClients(config));
+}

--- a/packages/mcp-fragment/src/client/solid.ts
+++ b/packages/mcp-fragment/src/client/solid.ts
@@ -1,0 +1,8 @@
+import type { FragnoPublicClientConfig } from "@fragno-dev/core/client";
+import { useFragno } from "@fragno-dev/core/solid";
+
+import { createMcpFragmentClients } from "..";
+
+export function createMcpFragmentClient(config: FragnoPublicClientConfig = {}) {
+  return useFragno(createMcpFragmentClients(config));
+}

--- a/packages/mcp-fragment/src/client/svelte.ts
+++ b/packages/mcp-fragment/src/client/svelte.ts
@@ -1,0 +1,8 @@
+import type { FragnoPublicClientConfig } from "@fragno-dev/core/client";
+import { useFragno } from "@fragno-dev/core/svelte";
+
+import { createMcpFragmentClients } from "..";
+
+export function createMcpFragmentClient(config: FragnoPublicClientConfig = {}) {
+  return useFragno(createMcpFragmentClients(config));
+}

--- a/packages/mcp-fragment/src/client/vanilla.ts
+++ b/packages/mcp-fragment/src/client/vanilla.ts
@@ -1,0 +1,8 @@
+import type { FragnoPublicClientConfig } from "@fragno-dev/core/client";
+import { useFragno } from "@fragno-dev/core/vanilla";
+
+import { createMcpFragmentClients } from "..";
+
+export function createMcpFragmentClient(config: FragnoPublicClientConfig = {}) {
+  return useFragno(createMcpFragmentClients(config));
+}

--- a/packages/mcp-fragment/src/client/vue.ts
+++ b/packages/mcp-fragment/src/client/vue.ts
@@ -1,0 +1,8 @@
+import type { FragnoPublicClientConfig } from "@fragno-dev/core/client";
+import { useFragno } from "@fragno-dev/core/vue";
+
+import { createMcpFragmentClients } from "..";
+
+export function createMcpFragmentClient(config: FragnoPublicClientConfig = {}) {
+  return useFragno(createMcpFragmentClients(config));
+}

--- a/packages/mcp-fragment/src/definition.ts
+++ b/packages/mcp-fragment/src/definition.ts
@@ -1,0 +1,272 @@
+import { defineFragment } from "@fragno-dev/core";
+import { withDatabase } from "@fragno-dev/db";
+
+import type { McpFragmentConfig } from "./mcp-types";
+import { mcpSchema } from "./schema";
+import {
+  createOAuthCallbackSnapshot,
+  createOAuthStartSnapshot,
+  defaultOAuthRedirectUri,
+  resolveMcpOperationAuth,
+  tokenExpiry,
+} from "./services";
+
+export const mcpFragmentDefinition = defineFragment<McpFragmentConfig>("mcp-fragment")
+  .extend(withDatabase(mcpSchema))
+  .providesBaseService(({ defineService, config }) =>
+    defineService({
+      startOAuth: function (input: {
+        serverId: string;
+        stateId: string;
+        scope?: string;
+        clientId?: string;
+        clientSecret?: string;
+      }) {
+        const redirectUri = defaultOAuthRedirectUri(config);
+        return this.serviceTx(mcpSchema)
+          .retrieve((uow) =>
+            uow
+              .findFirst("server_configuration", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", input.serverId)),
+              )
+              .find("secret", (b) =>
+                b.whereIndex("idx_secret_server_kind", (eb) => eb("serverId", "=", input.serverId)),
+              ),
+          )
+          .transformRetrieve(async ([server, secrets]) => {
+            if (!server) {
+              return { found: false as const };
+            }
+            const { authorizationUrl, changes } = await createOAuthStartSnapshot({
+              config,
+              server,
+              secrets,
+              stateId: input.stateId,
+              redirectUri,
+              scope: input.scope,
+              clientId: input.clientId,
+              clientSecret: input.clientSecret,
+            });
+            return {
+              found: true as const,
+              authorizationUrl: authorizationUrl.toString(),
+              serverId: server.id.toString(),
+              secrets,
+              changes,
+            };
+          })
+          .mutate(({ uow, retrieveResult }) => {
+            if (!retrieveResult.found) {
+              return { found: false as const };
+            }
+
+            const upsertSecret = (kind: string, payload: string, expiresAt: Date | null) => {
+              const existing = retrieveResult.secrets.find((secret) => secret.kind === kind);
+              if (existing) {
+                uow.update("secret", existing.id, (b) =>
+                  b.set({ payload, expiresAt, updatedAt: b.now() }).check(),
+                );
+                return;
+              }
+              uow.create("secret", {
+                id: `${retrieveResult.serverId}:${kind}`,
+                serverId: retrieveResult.serverId,
+                kind,
+                payload,
+                expiresAt,
+              });
+            };
+
+            if (retrieveResult.changes.clientInformationPayload) {
+              upsertSecret("oauth-client", retrieveResult.changes.clientInformationPayload, null);
+            }
+            if (retrieveResult.changes.discoveryStatePayload) {
+              upsertSecret("oauth-discovery", retrieveResult.changes.discoveryStatePayload, null);
+            }
+            if (retrieveResult.changes.oauthState) {
+              uow.create("oauthState", {
+                id: retrieveResult.changes.oauthState.id,
+                serverId: retrieveResult.serverId,
+                codeVerifier: retrieveResult.changes.oauthState.codeVerifier,
+                redirectUri: retrieveResult.changes.oauthState.redirectUri,
+                scope: retrieveResult.changes.oauthState.scope ?? null,
+                expiresAt: retrieveResult.changes.oauthState.expiresAt,
+                consumedAt: null,
+              });
+            }
+
+            return { found: true as const };
+          })
+          .transform(({ retrieveResult }) =>
+            retrieveResult.found
+              ? {
+                  found: true as const,
+                  authorizationUrl: retrieveResult.authorizationUrl,
+                }
+              : { found: false as const },
+          )
+          .build();
+      },
+
+      completeOAuthCallback: function (input: { stateId: string; code: string }) {
+        const serverId = input.stateId.split(":")[0] ?? "";
+        return this.serviceTx(mcpSchema)
+          .retrieve((uow) =>
+            uow
+              .findFirst("oauthState", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", input.stateId)),
+              )
+              .findFirst("server_configuration", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", serverId)),
+              )
+              .find("secret", (b) =>
+                b.whereIndex("idx_secret_server_kind", (eb) => eb("serverId", "=", serverId)),
+              ),
+          )
+          .transformRetrieve(async ([state, server, secrets]) => {
+            if (!state || state.consumedAt || new Date(state.expiresAt).getTime() < Date.now()) {
+              return { found: false as const, reason: "invalid_state" as const };
+            }
+            if (!server) {
+              return { found: false as const, reason: "server_not_found" as const };
+            }
+            const changes = await createOAuthCallbackSnapshot({
+              config,
+              stateId: input.stateId,
+              code: input.code,
+              state,
+              server,
+              secrets,
+            });
+            return { found: true as const, server, secrets, changes };
+          })
+          .mutate(({ uow, retrieveResult }) => {
+            if (!retrieveResult.found) {
+              return { found: false as const, reason: retrieveResult.reason };
+            }
+
+            const serverId = retrieveResult.server.id.toString();
+            const upsertSecret = (kind: string, payload: string, expiresAt: Date | null) => {
+              const existing = retrieveResult.secrets.find((secret) => secret.kind === kind);
+              if (existing) {
+                uow.update("secret", existing.id, (b) =>
+                  b.set({ payload, expiresAt, updatedAt: b.now() }).check(),
+                );
+                return;
+              }
+              uow.create("secret", {
+                id: `${serverId}:${kind}`,
+                serverId,
+                kind,
+                payload,
+                expiresAt,
+              });
+            };
+
+            if (retrieveResult.changes.clientInformationPayload) {
+              upsertSecret("oauth-client", retrieveResult.changes.clientInformationPayload, null);
+            }
+            if (retrieveResult.changes.discoveryStatePayload) {
+              upsertSecret("oauth-discovery", retrieveResult.changes.discoveryStatePayload, null);
+            }
+            if (retrieveResult.changes.tokens && retrieveResult.changes.tokensPayload) {
+              upsertSecret(
+                "auth",
+                retrieveResult.changes.tokensPayload,
+                tokenExpiry(retrieveResult.changes.tokens),
+              );
+              uow.update("server_configuration", retrieveResult.server.id, (b) =>
+                b.set({ authMode: "oauth", updatedAt: b.now() }).check(),
+              );
+            }
+            if (retrieveResult.changes.consumeStateId) {
+              uow.update("oauthState", input.stateId, (b) => b.set({ consumedAt: b.now() }));
+            }
+
+            return { found: true as const };
+          })
+          .transform(({ retrieveResult }) =>
+            retrieveResult.found
+              ? { found: true as const }
+              : { found: false as const, reason: retrieveResult.reason },
+          )
+          .build();
+      },
+
+      prepareMcpOperation: function (input: { serverId: string }) {
+        return this.serviceTx(mcpSchema)
+          .retrieve((uow) =>
+            uow
+              .findFirst("server_configuration", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", input.serverId)),
+              )
+              .find("secret", (b) =>
+                b.whereIndex("idx_secret_server_kind", (eb) => eb("serverId", "=", input.serverId)),
+              ),
+          )
+          .transformRetrieve(async ([server, secrets]) => {
+            if (!server) {
+              return { found: false as const };
+            }
+            const resolved = await resolveMcpOperationAuth({ config, server, secrets });
+            return {
+              found: true as const,
+              serverId: server.id.toString(),
+              endpointUrl: server.endpointUrl,
+              token: resolved.token,
+              secrets,
+              authChanges: resolved.authChanges,
+            };
+          })
+          .mutate(({ uow, retrieveResult }) => {
+            if (!retrieveResult.found) {
+              return { found: false as const };
+            }
+            const authChanges = retrieveResult.authChanges;
+            if (!authChanges) {
+              return { found: true as const };
+            }
+
+            const upsertSecret = (kind: string, payload: string, expiresAt: Date | null) => {
+              const existing = retrieveResult.secrets.find((secret) => secret.kind === kind);
+              if (existing) {
+                uow.update("secret", existing.id, (b) =>
+                  b.set({ payload, expiresAt, updatedAt: b.now() }).check(),
+                );
+                return;
+              }
+              uow.create("secret", {
+                id: `${retrieveResult.serverId}:${kind}`,
+                serverId: retrieveResult.serverId,
+                kind,
+                payload,
+                expiresAt,
+              });
+            };
+
+            if (authChanges.clientInformationPayload) {
+              upsertSecret("oauth-client", authChanges.clientInformationPayload, null);
+            }
+            if (authChanges.discoveryStatePayload) {
+              upsertSecret("oauth-discovery", authChanges.discoveryStatePayload, null);
+            }
+            if (authChanges.authPayload) {
+              upsertSecret("auth", authChanges.authPayload, authChanges.authExpiresAt ?? null);
+            }
+
+            return { found: true as const };
+          })
+          .transform(({ retrieveResult }) =>
+            retrieveResult.found
+              ? {
+                  found: true as const,
+                  endpointUrl: retrieveResult.endpointUrl,
+                  token: retrieveResult.token,
+                }
+              : { found: false as const },
+          )
+          .build();
+      },
+    }),
+  )
+  .build();

--- a/packages/mcp-fragment/src/index.test.ts
+++ b/packages/mcp-fragment/src/index.test.ts
@@ -1,0 +1,471 @@
+import { afterAll, assert, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import { instantiate } from "@fragno-dev/core";
+import { buildDatabaseFragmentsTest } from "@fragno-dev/test";
+
+import { mcpFragmentDefinition } from "./definition";
+import { createMcpFragmentClients } from "./index";
+import { stringifySecretPayload } from "./mcp-api";
+import { mcpRoutesFactory } from "./routes";
+import { mcpSchema } from "./schema";
+import {
+  startStreamableHttpTestMcpServer,
+  type TestMcpServerHandle,
+} from "./testing/streamable-http-mcp-server";
+
+const bearerToken = "secret";
+
+const buildMcpTest = async () =>
+  await buildDatabaseFragmentsTest()
+    .withTestAdapter({ type: "in-memory" })
+    .withDbRoundtripGuard({ maxRoundtrips: 1 })
+    .withFragment(
+      "mcp",
+      instantiate(mcpFragmentDefinition)
+        .withConfig({ publicBaseUrl: "https://app.test" })
+        .withRoutes([mcpRoutesFactory]),
+    )
+    .build();
+
+type McpTestFragmentResult = Awaited<ReturnType<typeof buildMcpTest>>["fragments"]["mcp"];
+
+async function createServer(
+  fragment: McpTestFragmentResult["fragment"],
+  input: {
+    slug: string;
+    endpointUrl: string;
+    name?: string;
+    auth?:
+      | { type: "none" }
+      | { type: "bearer"; token: string }
+      | { type: "oauth" }
+      | { type: "client_credentials"; clientId: string; clientSecret: string; scopes?: string[] };
+  },
+) {
+  return await fragment.callRoute("POST", "/servers", {
+    body: {
+      name: "Test MCP server",
+      auth: { type: "none" },
+      ...input,
+    },
+  });
+}
+
+async function replaceStoredOAuthTokenWithExpiredAccessToken(
+  fragmentResult: McpTestFragmentResult,
+  serverId: string,
+) {
+  const uow = fragmentResult.db.createUnitOfWork("expire-oauth-token").forSchema(mcpSchema);
+  uow.update("secret", `${serverId}:auth`, (b) =>
+    b.set({
+      payload: stringifySecretPayload({
+        type: "oauth",
+        redirectUri: "https://app.test/oauth/callback",
+        tokens: {
+          access_token: "expired-oauth-access-token",
+          refresh_token: "oauth-refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "tools",
+        },
+      }),
+      expiresAt: new Date(Date.now() - 1_000),
+      updatedAt: b.now(),
+    }),
+  );
+  const { success } = await uow.executeMutations();
+  if (!success) {
+    throw new Error("Failed to replace stored OAuth token");
+  }
+}
+
+describe("mcp-fragment", () => {
+  let setup: Awaited<ReturnType<typeof buildMcpTest>>;
+  let fragment: Awaited<ReturnType<typeof buildMcpTest>>["fragments"]["mcp"]["fragment"];
+  let sseMcpServer: TestMcpServerHandle;
+  let jsonMcpServer: TestMcpServerHandle;
+  let noToolsMcpServer: TestMcpServerHandle;
+  let staticOAuthMcpServer: TestMcpServerHandle;
+  let clientCredentialsMcpServer: TestMcpServerHandle;
+
+  beforeAll(async () => {
+    sseMcpServer = await startStreamableHttpTestMcpServer({ requiredBearerToken: bearerToken });
+    jsonMcpServer = await startStreamableHttpTestMcpServer({ enableJsonResponse: true });
+    noToolsMcpServer = await startStreamableHttpTestMcpServer({
+      enableJsonResponse: true,
+      registerEchoTool: false,
+    });
+    staticOAuthMcpServer = await startStreamableHttpTestMcpServer({
+      oauth: true,
+      enableJsonResponse: true,
+      requiredBearerToken: "static-oauth-access-token",
+      disableDynamicRegistration: true,
+      requiredClientId: "static-client",
+      requiredClientSecret: "static-secret",
+    });
+    clientCredentialsMcpServer = await startStreamableHttpTestMcpServer({
+      oauth: true,
+      enableJsonResponse: true,
+      requiredBearerToken: "client-credentials-access-token",
+      requiredClientId: "machine-client",
+      requiredClientSecret: "machine-secret",
+    });
+    setup = await buildMcpTest();
+    fragment = setup.fragments.mcp.fragment;
+  });
+
+  beforeEach(async () => {
+    await setup.test.resetDatabase();
+  });
+
+  afterAll(async () => {
+    await setup.test.cleanup();
+    await sseMcpServer.close();
+    await jsonMcpServer.close();
+    await noToolsMcpServer.close();
+    await staticOAuthMcpServer.close();
+    await clientCredentialsMcpServer.close();
+  });
+
+  test("exports client builders", () => {
+    expect(createMcpFragmentClients).toBeTypeOf("function");
+    const clients = createMcpFragmentClients();
+    expect(clients.createServer).toBeDefined();
+    expect(clients.useServers).toBeDefined();
+    expect(clients.useServer).toBeDefined();
+    expect(clients.useTools).toBeDefined();
+    expect(clients.callTool).toBeDefined();
+    expect(clients.setToken).toBeDefined();
+  });
+
+  test("stores, reads, lists, and reports auth status for bearer MCP servers", async () => {
+    const created = await createServer(fragment, {
+      slug: "local-tools",
+      name: "Local tools",
+      endpointUrl: sseMcpServer.endpointUrl,
+      auth: { type: "bearer", token: bearerToken },
+    });
+
+    assert(created.type === "json");
+
+    expect(created.status).toBe(201);
+    expect(created.data).toMatchObject({
+      slug: "local-tools",
+      name: "Local tools",
+      endpointUrl: sseMcpServer.endpointUrl,
+      authMode: "bearer",
+    });
+
+    const read = await fragment.callRoute("GET", "/servers/:slug", {
+      pathParams: { slug: "local-tools" },
+    });
+    assert(read.type === "json");
+
+    expect(read.data).toMatchObject(created.data);
+
+    const list = await fragment.callRoute("GET", "/servers");
+    assert(list.type === "json");
+
+    expect(list.data.servers).toEqual([expect.objectContaining({ slug: "local-tools" })]);
+
+    const status = await fragment.callRoute("GET", "/servers/:slug/auth/status", {
+      pathParams: { slug: "local-tools" },
+    });
+    assert(status.type === "json");
+
+    expect(status.data).toEqual({ authenticated: true, mode: "bearer" });
+  });
+
+  test("rejects duplicate server slugs", async () => {
+    await createServer(fragment, { slug: "duplicate", endpointUrl: jsonMcpServer.endpointUrl });
+
+    const duplicate = await createServer(fragment, {
+      slug: "duplicate",
+      endpointUrl: sseMcpServer.endpointUrl,
+      auth: { type: "bearer", token: bearerToken },
+    });
+
+    expect(duplicate.type).toBe("error");
+    if (duplicate.type !== "error") {
+      return;
+    }
+    expect(duplicate.status).toBe(409);
+    expect(duplicate.error.code).toBe("SERVER_EXISTS");
+  });
+
+  test("sets and updates bearer tokens without duplicating auth records", async () => {
+    await createServer(fragment, { slug: "token-upsert", endpointUrl: sseMcpServer.endpointUrl });
+
+    const first = await fragment.callRoute("POST", "/servers/:slug/auth/token", {
+      pathParams: { slug: "token-upsert" },
+      body: { token: "wrong" },
+    });
+    expect(first.type).toBe("json");
+
+    const denied = await fragment.callRoute("POST", "/servers/:slug/tool", {
+      pathParams: { slug: "token-upsert" },
+      body: { name: "echo", arguments: { text: "hello" } },
+    });
+    expect(denied.type).toBe("error");
+    if (denied.type !== "error") {
+      return;
+    }
+    expect(denied.status).toBe(502);
+    expect(denied.error.code).toBe("MCP_ERROR");
+
+    const second = await fragment.callRoute("POST", "/servers/:slug/auth/token", {
+      pathParams: { slug: "token-upsert" },
+      body: { token: bearerToken },
+    });
+    assert(second.type === "json");
+
+    expect(second.data).toEqual({ authenticated: true, mode: "bearer" });
+
+    const allowed = await fragment.callRoute("POST", "/servers/:slug/tool", {
+      pathParams: { slug: "token-upsert" },
+      body: { name: "echo", arguments: { text: "hello" } },
+    });
+    assert(allowed.type === "json");
+
+    expect(allowed.data["structuredContent"]).toEqual({ echoed: "hello" });
+  });
+
+  test("lists tools and calls tools against a real SSE streamable HTTP MCP server", async () => {
+    await createServer(fragment, {
+      slug: "sse-tools",
+      endpointUrl: sseMcpServer.endpointUrl,
+      auth: { type: "bearer", token: bearerToken },
+    });
+
+    const tools = await fragment.callRoute("GET", "/servers/:slug/tools", {
+      pathParams: { slug: "sse-tools" },
+    });
+
+    assert(tools.type === "json");
+
+    expect(tools.data.tools).toEqual([
+      expect.objectContaining({
+        name: "echo",
+        title: "Echo",
+      }),
+    ]);
+
+    const result = await fragment.callRoute("POST", "/servers/:slug/tool", {
+      pathParams: { slug: "sse-tools" },
+      body: { name: "echo", arguments: { text: "hello" } },
+    });
+
+    assert(result.type === "json");
+
+    expect(result.data).toEqual({
+      content: [{ type: "text", text: "hello" }],
+      structuredContent: { echoed: "hello" },
+    });
+  });
+
+  test("calls tools against a real JSON-response streamable HTTP MCP server", async () => {
+    await createServer(fragment, { slug: "json-tools", endpointUrl: jsonMcpServer.endpointUrl });
+
+    const result = await fragment.callRoute("POST", "/servers/:slug/tool", {
+      pathParams: { slug: "json-tools" },
+      body: { name: "echo", arguments: { text: "from-json" } },
+    });
+
+    assert(result.type === "json");
+
+    expect(result.data).toMatchObject({
+      content: [{ type: "text", text: "from-json" }],
+      structuredContent: { echoed: "from-json" },
+    });
+  });
+
+  test("persists explicit OAuth client credentials across the auth callback", async () => {
+    await createServer(fragment, {
+      slug: "static-oauth-tools",
+      endpointUrl: staticOAuthMcpServer.endpointUrl,
+      auth: { type: "oauth" },
+    });
+
+    const start = await fragment.callRoute("POST", "/servers/:slug/auth/start", {
+      pathParams: { slug: "static-oauth-tools" },
+      body: {
+        clientId: "static-client",
+        clientSecret: "static-secret",
+        scope: "tools",
+      },
+    });
+    assert(start.type === "json");
+
+    const authorizeResponse = await fetch(start.data.authorizationUrl, { redirect: "manual" });
+    const location = authorizeResponse.headers.get("location");
+    assert(location);
+    const callbackUrl = new URL(location);
+
+    const callback = await fragment.callRoute("GET", "/oauth/callback", {
+      query: Object.fromEntries(callbackUrl.searchParams),
+    });
+    assert(callback.type === "json");
+    expect(callback.data).toEqual({ authenticated: true, mode: "oauth" });
+
+    await replaceStoredOAuthTokenWithExpiredAccessToken(setup.fragments.mcp, "static-oauth-tools");
+
+    const result = await fragment.callRoute("POST", "/servers/:slug/tool", {
+      pathParams: { slug: "static-oauth-tools" },
+      body: { name: "echo", arguments: { text: "from-static-oauth" } },
+    });
+    assert(result.type === "json");
+    expect(result.data["structuredContent"]).toEqual({ echoed: "from-static-oauth" });
+    expect(staticOAuthMcpServer.getTokenRequestCount()).toBe(2);
+  });
+
+  test("acquires and reuses client-credentials tokens for MCP tool operations", async () => {
+    const tokenRequestsBefore = clientCredentialsMcpServer.getTokenRequestCount();
+    await createServer(fragment, {
+      slug: "client-credentials-tools",
+      endpointUrl: clientCredentialsMcpServer.endpointUrl,
+      auth: {
+        type: "client_credentials",
+        clientId: "machine-client",
+        clientSecret: "machine-secret",
+        scopes: ["tools"],
+      },
+    });
+
+    const result = await fragment.callRoute("POST", "/servers/:slug/tool", {
+      pathParams: { slug: "client-credentials-tools" },
+      body: { name: "echo", arguments: { text: "from-client-credentials" } },
+    });
+    assert(result.type === "json");
+    expect(result.data["structuredContent"]).toEqual({ echoed: "from-client-credentials" });
+    expect(clientCredentialsMcpServer.getTokenRequestCount()).toBe(tokenRequestsBefore + 1);
+
+    const tools = await fragment.callRoute("GET", "/servers/:slug/tools", {
+      pathParams: { slug: "client-credentials-tools" },
+    });
+    assert(tools.type === "json");
+    expect(tools.data.tools).toEqual([expect.objectContaining({ name: "echo" })]);
+    expect(clientCredentialsMcpServer.getTokenRequestCount()).toBe(tokenRequestsBefore + 1);
+  });
+
+  test("surfaces upstream authorization failures as MCP errors", async () => {
+    await createServer(fragment, {
+      slug: "bad-auth",
+      endpointUrl: sseMcpServer.endpointUrl,
+      auth: { type: "bearer", token: "wrong" },
+    });
+
+    const result = await fragment.callRoute("GET", "/servers/:slug/tools", {
+      pathParams: { slug: "bad-auth" },
+    });
+
+    expect(result.type).toBe("error");
+    if (result.type !== "error") {
+      return;
+    }
+    expect(result.status).toBe(502);
+    expect(result.error).toMatchObject({ code: "MCP_ERROR" });
+    expect(result.error.message).toContain("Unauthorized");
+  });
+
+  test("rejects MCP servers that do not advertise tools", async () => {
+    await createServer(fragment, { slug: "no-tools", endpointUrl: noToolsMcpServer.endpointUrl });
+
+    const result = await fragment.callRoute("POST", "/servers/:slug/tool", {
+      pathParams: { slug: "no-tools" },
+      body: { name: "echo", arguments: { text: "hello" } },
+    });
+
+    expect(result.type).toBe("error");
+    if (result.type !== "error") {
+      return;
+    }
+    expect(result.status).toBe(502);
+    expect(result.error).toMatchObject({
+      code: "MCP_ERROR",
+      message: "MCP server does not advertise tools capability",
+    });
+  });
+
+  test("returns not found errors for unknown servers", async () => {
+    const read = await fragment.callRoute("GET", "/servers/:slug", {
+      pathParams: { slug: "missing" },
+    });
+    expect(read.type).toBe("error");
+    if (read.type !== "error") {
+      return;
+    }
+    expect(read.status).toBe(404);
+    expect(read.error.code).toBe("SERVER_NOT_FOUND");
+
+    const call = await fragment.callRoute("POST", "/servers/:slug/tool", {
+      pathParams: { slug: "missing" },
+      body: { name: "echo", arguments: { text: "hello" } },
+    });
+    expect(call.type).toBe("error");
+    if (call.type !== "error") {
+      return;
+    }
+    expect(call.status).toBe(404);
+    expect(call.error.code).toBe("SERVER_NOT_FOUND");
+  });
+
+  test("deletes servers and stored auth data", async () => {
+    await createServer(fragment, {
+      slug: "delete-me",
+      endpointUrl: sseMcpServer.endpointUrl,
+      auth: { type: "bearer", token: bearerToken },
+    });
+
+    const deleted = await fragment.callRoute("DELETE", "/servers/:slug", {
+      pathParams: { slug: "delete-me" },
+    });
+    expect(deleted.type).toBe("empty");
+    if (deleted.type !== "empty") {
+      return;
+    }
+    expect(deleted.status).toBe(204);
+
+    const read = await fragment.callRoute("GET", "/servers/:slug", {
+      pathParams: { slug: "delete-me" },
+    });
+    expect(read.type).toBe("error");
+    if (read.type !== "error") {
+      return;
+    }
+    expect(read.status).toBe(404);
+  });
+
+  test("honors endpoint allow-list configuration", async () => {
+    const restricted = await buildDatabaseFragmentsTest()
+      .withTestAdapter({ type: "in-memory" })
+      .withFragment(
+        "mcp",
+        instantiate(mcpFragmentDefinition)
+          .withConfig({
+            publicBaseUrl: "https://app.test",
+            allowedEndpointUrls: () => false,
+          })
+          .withRoutes([mcpRoutesFactory]),
+      )
+      .build();
+
+    try {
+      const result = await restricted.fragments.mcp.fragment.callRoute("POST", "/servers", {
+        body: {
+          slug: "blocked",
+          endpointUrl: jsonMcpServer.endpointUrl,
+          auth: { type: "none" },
+        },
+      });
+
+      expect(result.type).toBe("error");
+      if (result.type !== "error") {
+        return;
+      }
+      expect(result.status).toBe(400);
+      expect(result.error.code).toBe("ENDPOINT_NOT_ALLOWED");
+    } finally {
+      await restricted.test.cleanup();
+    }
+  });
+});

--- a/packages/mcp-fragment/src/index.ts
+++ b/packages/mcp-fragment/src/index.ts
@@ -1,0 +1,36 @@
+import { createClientBuilder, type FragnoPublicClientConfig } from "@fragno-dev/core/client";
+
+import { instantiate } from "@fragno-dev/core";
+import type { FragnoPublicConfigWithDatabase } from "@fragno-dev/db";
+
+import { mcpFragmentDefinition } from "./definition";
+import type { McpFragmentConfig } from "./mcp-types";
+import { mcpRoutesFactory } from "./routes";
+
+const routes = [mcpRoutesFactory] as const;
+
+export function createMcpFragment(
+  config: McpFragmentConfig,
+  fragnoConfig: FragnoPublicConfigWithDatabase,
+) {
+  return instantiate(mcpFragmentDefinition)
+    .withConfig(config)
+    .withRoutes(routes)
+    .withOptions(fragnoConfig)
+    .build();
+}
+
+export function createMcpFragmentClients(fragnoConfig: FragnoPublicClientConfig = {}) {
+  const builder = createClientBuilder(mcpFragmentDefinition, fragnoConfig, routes);
+
+  return {
+    useServers: builder.createHook("/servers"),
+    useServer: builder.createHook("/servers/:slug"),
+    useTools: builder.createHook("/servers/:slug/tools"),
+    createServer: builder.createMutator("POST", "/servers"),
+    callTool: builder.createMutator("POST", "/servers/:slug/tool"),
+    setToken: builder.createMutator("POST", "/servers/:slug/auth/token"),
+    startOAuth: builder.createMutator("POST", "/servers/:slug/auth/start"),
+    deleteAuth: builder.createMutator("DELETE", "/servers/:slug/auth"),
+  };
+}

--- a/packages/mcp-fragment/src/mcp-api.ts
+++ b/packages/mcp-fragment/src/mcp-api.ts
@@ -1,0 +1,99 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import type { McpFragmentConfig } from "./mcp-types";
+
+export interface StoredServerAuth {
+  mode: string;
+  payload?: unknown;
+}
+
+export interface McpOperationResult<T> {
+  result: T;
+}
+
+export function assertAllowedEndpoint(endpointUrl: string, config: McpFragmentConfig) {
+  const url = new URL(endpointUrl);
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("MCP endpoint must be an HTTP(S) URL");
+  }
+  if (config.allowedEndpointUrls && !config.allowedEndpointUrls(url)) {
+    throw new Error("MCP endpoint is not allowed");
+  }
+  return url;
+}
+
+export function stringifySecretPayload(value: unknown) {
+  return JSON.stringify(value);
+}
+
+export function parseSecretPayload<T>(value: string) {
+  return JSON.parse(value) as T;
+}
+
+function bearerRequestInit(token: string | undefined): RequestInit | undefined {
+  if (!token) {
+    return undefined;
+  }
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
+async function withMcpClient<T>(args: {
+  endpointUrl: string;
+  token?: string;
+  timeoutMs?: number;
+  fetchImplementation?: typeof fetch;
+  operation: (client: Client) => Promise<T>;
+}): Promise<McpOperationResult<T>> {
+  const client = new Client(
+    { name: "fragno-mcp-fragment", version: "0.1.0" },
+    { capabilities: {} },
+  );
+  const transport = new StreamableHTTPClientTransport(new URL(args.endpointUrl), {
+    fetch: args.fetchImplementation,
+    requestInit: bearerRequestInit(args.token),
+  });
+
+  try {
+    await client.connect(transport, { timeout: args.timeoutMs });
+    const capabilities = client.getServerCapabilities();
+    if (!capabilities?.tools) {
+      throw new Error("MCP server does not advertise tools capability");
+    }
+
+    const result = await args.operation(client);
+    return { result };
+  } finally {
+    await transport.close().catch(() => undefined);
+    await client.close().catch(() => undefined);
+  }
+}
+
+export async function listMcpTools(args: {
+  endpointUrl: string;
+  token?: string;
+  timeoutMs?: number;
+  fetchImplementation?: typeof fetch;
+}) {
+  return await withMcpClient({
+    ...args,
+    operation: async (client) => await client.listTools(undefined, { timeout: args.timeoutMs }),
+  });
+}
+
+export async function callMcpTool(args: {
+  endpointUrl: string;
+  token?: string;
+  name: string;
+  toolArguments?: Record<string, unknown>;
+  timeoutMs?: number;
+  fetchImplementation?: typeof fetch;
+}) {
+  return await withMcpClient({
+    ...args,
+    operation: async (client) =>
+      await client.callTool({ name: args.name, arguments: args.toolArguments ?? {} }, undefined, {
+        timeout: args.timeoutMs,
+      }),
+  });
+}

--- a/packages/mcp-fragment/src/mcp-types.ts
+++ b/packages/mcp-fragment/src/mcp-types.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+export interface McpFragmentConfig {
+  /** Public URL where this fragment is mounted; used to build OAuth redirects. */
+  publicBaseUrl: string;
+  /** Optional URL allow-list. If omitted, only http(s) URL syntax is checked. */
+  allowedEndpointUrls?: (url: URL) => boolean;
+  /** Optional fetch implementation for tests/custom runtimes. */
+  fetch?: typeof fetch;
+}
+
+export const authConfigSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("none") }),
+  z.object({ type: z.literal("bearer"), token: z.string().min(1) }),
+  z.object({
+    type: z.literal("client_credentials"),
+    clientId: z.string().min(1),
+    clientSecret: z.string().min(1),
+    scopes: z.array(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal("oauth"),
+    clientId: z.string().optional(),
+    clientSecret: z.string().optional(),
+    scopes: z.array(z.string()).optional(),
+  }),
+]);
+
+export const createServerInputSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9][a-z0-9-]*$/),
+  name: z.string().optional(),
+  endpointUrl: z.string().url(),
+  auth: authConfigSchema.default({ type: "none" }),
+});
+
+export const toolCallInputSchema = z.object({
+  name: z.string().min(1),
+  arguments: z.record(z.string(), z.unknown()).optional(),
+  timeoutMs: z.number().int().positive().max(120_000).optional(),
+});
+
+export const tokenAuthInputSchema = z.object({
+  token: z.string().min(1),
+});
+
+export const oauthStartInputSchema = z.object({
+  scope: z.string().optional(),
+  clientId: z.string().min(1).optional(),
+  clientSecret: z.string().min(1).optional(),
+});
+
+export type AuthConfig = z.infer<typeof authConfigSchema>;
+export type CreateServerInput = z.infer<typeof createServerInputSchema>;
+export type ToolCallInput = z.infer<typeof toolCallInputSchema>;
+
+export interface McpJsonRpcResponse {
+  jsonrpc: "2.0";
+  id?: string | number;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface McpTool {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+}

--- a/packages/mcp-fragment/src/oauth-provider.ts
+++ b/packages/mcp-fragment/src/oauth-provider.ts
@@ -1,0 +1,172 @@
+import type {
+  OAuthClientProvider,
+  OAuthDiscoveryState,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+
+export interface OAuthProviderSnapshot {
+  serverId: string;
+  endpointUrl: string;
+  redirectUrl?: string;
+  scope?: string;
+  stateId?: string;
+  clientId?: string;
+  clientSecret?: string;
+  clientName?: string;
+  clientInformation?: OAuthClientInformationMixed;
+  tokens?: OAuthTokens;
+  discoveryState?: OAuthDiscoveryState;
+  flow?: "authorization_code" | "client_credentials";
+  oauthState?: {
+    id: string;
+    codeVerifier: string;
+    redirectUri: string;
+    scope?: string;
+    expiresAt: Date;
+    consumedAt?: Date | null;
+  };
+}
+
+export interface OAuthProviderChanges {
+  authorizationUrl?: URL;
+  clientInformation?: OAuthClientInformationMixed;
+  tokens?: OAuthTokens;
+  discoveryState?: OAuthDiscoveryState;
+  oauthState?: {
+    id: string;
+    codeVerifier: string;
+    redirectUri: string;
+    scope?: string;
+    expiresAt: Date;
+  };
+  consumeStateId?: string;
+  invalidate?: "all" | "client" | "tokens" | "verifier" | "discovery";
+}
+
+export class BufferedOAuthClientProvider implements OAuthClientProvider {
+  readonly changes: OAuthProviderChanges = {};
+
+  constructor(private readonly snapshot: OAuthProviderSnapshot) {}
+
+  get redirectUrl() {
+    return this.snapshot.redirectUrl;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    if (this.snapshot.flow === "client_credentials") {
+      return {
+        redirect_uris: [],
+        token_endpoint_auth_method: "client_secret_basic",
+        grant_types: ["client_credentials"],
+        client_name: this.snapshot.clientName ?? "Fragno MCP Fragment",
+        scope: this.snapshot.scope,
+      };
+    }
+    return {
+      redirect_uris: this.snapshot.redirectUrl ? [this.snapshot.redirectUrl] : [],
+      token_endpoint_auth_method: this.snapshot.clientSecret ? "client_secret_basic" : "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      client_name: this.snapshot.clientName ?? "Fragno MCP Fragment",
+      scope: this.snapshot.scope,
+    };
+  }
+
+  state() {
+    if (!this.snapshot.stateId) {
+      throw new Error("OAuth state is required to start authorization");
+    }
+    return this.snapshot.stateId;
+  }
+
+  clientInformation() {
+    if (this.snapshot.clientId) {
+      const clientInformation = {
+        client_id: this.snapshot.clientId,
+        client_secret: this.snapshot.clientSecret,
+      };
+      this.changes.clientInformation ??= clientInformation;
+      return clientInformation;
+    }
+    return this.changes.clientInformation ?? this.snapshot.clientInformation;
+  }
+
+  saveClientInformation(clientInformation: OAuthClientInformationMixed) {
+    this.changes.clientInformation = clientInformation;
+  }
+
+  tokens() {
+    return this.changes.tokens ?? this.snapshot.tokens;
+  }
+
+  saveTokens(tokens: OAuthTokens) {
+    this.changes.tokens = tokens;
+  }
+
+  redirectToAuthorization(authorizationUrl: URL) {
+    this.changes.authorizationUrl = authorizationUrl;
+  }
+
+  saveCodeVerifier(codeVerifier: string) {
+    if (this.snapshot.flow === "client_credentials") {
+      return;
+    }
+    if (!this.snapshot.stateId || !this.snapshot.redirectUrl) {
+      throw new Error("OAuth state and redirect URL are required");
+    }
+    this.changes.oauthState = {
+      id: this.snapshot.stateId,
+      codeVerifier,
+      redirectUri: this.snapshot.redirectUrl,
+      scope: this.snapshot.scope,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    };
+  }
+
+  codeVerifier() {
+    if (this.snapshot.flow === "client_credentials") {
+      throw new Error("codeVerifier is not used for client_credentials flow");
+    }
+    const state = this.snapshot.oauthState;
+    if (!state || state.consumedAt) {
+      throw new Error("Invalid OAuth state");
+    }
+    if (state.expiresAt.getTime() < Date.now()) {
+      throw new Error("OAuth state expired");
+    }
+    return state.codeVerifier;
+  }
+
+  saveDiscoveryState(state: OAuthDiscoveryState) {
+    this.changes.discoveryState = state;
+  }
+
+  discoveryState() {
+    return this.changes.discoveryState ?? this.snapshot.discoveryState;
+  }
+
+  invalidateCredentials(scope: "all" | "client" | "tokens" | "verifier" | "discovery") {
+    this.changes.invalidate = scope;
+  }
+
+  prepareTokenRequest(scope?: string) {
+    if (this.snapshot.flow !== "client_credentials") {
+      return undefined;
+    }
+    const params = new URLSearchParams({ grant_type: "client_credentials" });
+    if (scope) {
+      params.set("scope", scope);
+    }
+    return params;
+  }
+
+  consumeState() {
+    if (this.snapshot.stateId) {
+      this.changes.consumeStateId = this.snapshot.stateId;
+    }
+  }
+}

--- a/packages/mcp-fragment/src/routes.ts
+++ b/packages/mcp-fragment/src/routes.ts
@@ -1,0 +1,452 @@
+import { z } from "zod";
+
+import { defineRoutes } from "@fragno-dev/core";
+
+import { mcpFragmentDefinition } from "./definition";
+import {
+  assertAllowedEndpoint,
+  callMcpTool,
+  parseSecretPayload,
+  stringifySecretPayload,
+  listMcpTools,
+} from "./mcp-api";
+import {
+  createServerInputSchema,
+  oauthStartInputSchema,
+  tokenAuthInputSchema,
+  toolCallInputSchema,
+  type AuthConfig,
+} from "./mcp-types";
+import { mcpSchema } from "./schema";
+
+const serverOutputSchema = z.object({
+  slug: z.string(),
+  name: z.string().nullable().optional(),
+  endpointUrl: z.string(),
+  authMode: z.string(),
+});
+
+const serversOutputSchema = z.object({ servers: z.array(serverOutputSchema) });
+const authStatusSchema = z.object({ authenticated: z.boolean(), mode: z.string() });
+const oauthStartOutputSchema = z.object({ authorizationUrl: z.string(), state: z.string() });
+const oauthCallbackOutputSchema = z.object({ authenticated: z.boolean(), mode: z.string() });
+const toolListSchema = z.object({ tools: z.array(z.unknown()) });
+const toolResultSchema = z.record(z.string(), z.unknown());
+
+function publicServer(server: {
+  id: { toString(): string } | string;
+  name?: string | null;
+  endpointUrl: string;
+  authMode: string;
+}) {
+  return {
+    slug: server.id.toString(),
+    name: server.name,
+    endpointUrl: server.endpointUrl,
+    authMode: server.authMode,
+  };
+}
+
+function authMode(auth: AuthConfig) {
+  return auth.type;
+}
+
+export const mcpRoutesFactory = defineRoutes(mcpFragmentDefinition).create(
+  ({ services, defineRoute, config }) => {
+    return [
+      defineRoute({
+        method: "POST",
+        path: "/servers",
+        inputSchema: createServerInputSchema,
+        outputSchema: serverOutputSchema,
+        errorCodes: ["SERVER_EXISTS", "ENDPOINT_NOT_ALLOWED"],
+        handler: async function ({ input }, { json, error }) {
+          const body = await input.valid();
+          try {
+            assertAllowedEndpoint(body.endpointUrl, config);
+          } catch (err) {
+            return error({ code: "ENDPOINT_NOT_ALLOWED", message: (err as Error).message }, 400);
+          }
+
+          const payload = body.auth.type === "none" ? undefined : stringifySecretPayload(body.auth);
+
+          const result = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(mcpSchema).findFirst("server_configuration", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", body.slug)),
+              ),
+            )
+            .mutate(({ forSchema, retrieveResult: [existing] }) => {
+              if (existing) {
+                return { exists: true as const };
+              }
+
+              const uow = forSchema(mcpSchema);
+              uow.create("server_configuration", {
+                id: body.slug,
+                name: body.name ?? null,
+                endpointUrl: body.endpointUrl,
+                authMode: authMode(body.auth),
+              });
+              if (payload) {
+                uow.create("secret", {
+                  id: `${body.slug}:auth`,
+                  serverId: body.slug,
+                  kind: "auth",
+                  payload,
+                  expiresAt: null,
+                });
+              }
+              return { exists: false as const };
+            })
+            .execute();
+
+          if (result.exists) {
+            return error({ code: "SERVER_EXISTS", message: "MCP server already exists" }, 409);
+          }
+
+          return json(publicServer({ ...body, id: body.slug, authMode: authMode(body.auth) }), 201);
+        },
+      }),
+
+      defineRoute({
+        method: "GET",
+        path: "/servers",
+        outputSchema: serversOutputSchema,
+        handler: async function (_, { json }) {
+          const [servers] = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(mcpSchema).find("server_configuration", (b) => b.whereIndex("primary")),
+            )
+            .execute();
+          return json({ servers: servers.map(publicServer) });
+        },
+      }),
+
+      defineRoute({
+        method: "GET",
+        path: "/servers/:slug",
+        outputSchema: serverOutputSchema,
+        errorCodes: ["SERVER_NOT_FOUND"],
+        handler: async function ({ pathParams }, { json, error }) {
+          const [server] = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(mcpSchema).findFirst("server_configuration", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", pathParams.slug)),
+              ),
+            )
+            .execute();
+          if (!server) {
+            return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+          }
+          return json(publicServer(server));
+        },
+      }),
+
+      defineRoute({
+        method: "DELETE",
+        path: "/servers/:slug",
+        errorCodes: ["SERVER_NOT_FOUND"],
+        handler: async function ({ pathParams }, { empty, error }) {
+          const result = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(mcpSchema)
+                .findFirst("server_configuration", (b) =>
+                  b.whereIndex("primary", (eb) => eb("id", "=", pathParams.slug)),
+                )
+                .find("secret", (b) =>
+                  b.whereIndex("idx_secret_server_kind", (eb) =>
+                    eb("serverId", "=", pathParams.slug),
+                  ),
+                )
+                .find("oauthState", (b) =>
+                  b.whereIndex("idx_oauth_state_server", (eb) =>
+                    eb("serverId", "=", pathParams.slug),
+                  ),
+                ),
+            )
+            .mutate(({ forSchema, retrieveResult: [server, secrets, oauthStates] }) => {
+              if (!server) {
+                return { deleted: false as const };
+              }
+              const uow = forSchema(mcpSchema);
+              for (const secret of secrets) {
+                uow.delete("secret", secret.id);
+              }
+              for (const oauthState of oauthStates) {
+                uow.delete("oauthState", oauthState.id);
+              }
+              uow.delete("server_configuration", server.id);
+              return { deleted: true as const };
+            })
+            .execute();
+          if (!result.deleted) {
+            return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+          }
+          return empty(204);
+        },
+      }),
+
+      defineRoute({
+        method: "GET",
+        path: "/servers/:slug/auth/status",
+        outputSchema: authStatusSchema,
+        errorCodes: ["SERVER_NOT_FOUND"],
+        handler: async function ({ pathParams }, { json, error }) {
+          const [server, secret] = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(mcpSchema)
+                .findFirst("server_configuration", (b) =>
+                  b.whereIndex("primary", (eb) => eb("id", "=", pathParams.slug)),
+                )
+                .findFirst("secret", (b) =>
+                  b.whereIndex("idx_secret_server_kind", (eb) =>
+                    eb.and(eb("serverId", "=", pathParams.slug), eb("kind", "=", "auth")),
+                  ),
+                ),
+            )
+            .execute();
+          if (!server) {
+            return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+          }
+          const auth = secret
+            ? parseSecretPayload<{
+                type: string;
+                token?: string;
+                tokens?: { access_token: string };
+              }>(secret.payload)
+            : undefined;
+          return json({
+            authenticated:
+              server.authMode === "none" ||
+              Boolean(auth?.token) ||
+              Boolean(auth?.tokens?.access_token),
+            mode: server.authMode,
+          });
+        },
+      }),
+
+      defineRoute({
+        method: "POST",
+        path: "/servers/:slug/auth/token",
+        inputSchema: tokenAuthInputSchema,
+        outputSchema: authStatusSchema,
+        errorCodes: ["SERVER_NOT_FOUND"],
+        handler: async function ({ input, pathParams }, { json, error }) {
+          const { token } = await input.valid();
+          const payload = stringifySecretPayload({ type: "bearer", token });
+          const result = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(mcpSchema)
+                .findFirst("server_configuration", (b) =>
+                  b.whereIndex("primary", (eb) => eb("id", "=", pathParams.slug)),
+                )
+                .findFirst("secret", (b) =>
+                  b.whereIndex("idx_secret_server_kind", (eb) =>
+                    eb.and(eb("serverId", "=", pathParams.slug), eb("kind", "=", "auth")),
+                  ),
+                ),
+            )
+            .mutate(({ forSchema, retrieveResult: [server, secret] }) => {
+              if (!server) {
+                return { found: false as const };
+              }
+              const uow = forSchema(mcpSchema);
+              uow.update("server_configuration", server.id, (b) =>
+                b.set({ authMode: "bearer", updatedAt: b.now() }).check(),
+              );
+              if (secret) {
+                uow.update("secret", secret.id, (b) =>
+                  b.set({ payload, expiresAt: null, updatedAt: b.now() }).check(),
+                );
+              } else {
+                uow.create("secret", {
+                  id: `${pathParams.slug}:auth`,
+                  serverId: pathParams.slug,
+                  kind: "auth",
+                  payload,
+                  expiresAt: null,
+                });
+              }
+              return { found: true as const };
+            })
+            .execute();
+          if (!result.found) {
+            return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+          }
+          return json({ authenticated: true, mode: "bearer" });
+        },
+      }),
+
+      defineRoute({
+        method: "POST",
+        path: "/servers/:slug/auth/start",
+        inputSchema: oauthStartInputSchema,
+        outputSchema: oauthStartOutputSchema,
+        errorCodes: ["SERVER_NOT_FOUND", "OAUTH_ERROR"],
+        handler: async function ({ input, pathParams }, { json, error }) {
+          const body = await input.valid();
+          const state = `${pathParams.slug}:${crypto.randomUUID()}`;
+          try {
+            const [result] = await this.handlerTx()
+              .withServiceCalls(
+                () =>
+                  [
+                    services.startOAuth({
+                      serverId: pathParams.slug,
+                      stateId: state,
+                      scope: body.scope,
+                      clientId: body.clientId,
+                      clientSecret: body.clientSecret,
+                    }),
+                  ] as const,
+              )
+              .execute();
+            if (!result.found) {
+              return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+            }
+            return json({ authorizationUrl: result.authorizationUrl, state });
+          } catch (err) {
+            return error({ code: "OAUTH_ERROR", message: (err as Error).message }, 502);
+          }
+        },
+      }),
+
+      defineRoute({
+        method: "GET",
+        path: "/oauth/callback",
+        outputSchema: oauthCallbackOutputSchema,
+        errorCodes: ["SERVER_NOT_FOUND", "OAUTH_ERROR", "INVALID_OAUTH_STATE"],
+        handler: async function ({ query }, { json, error }) {
+          const code = query.get("code");
+          const stateId = query.get("state");
+          if (!code || !stateId) {
+            return error(
+              { code: "INVALID_OAUTH_STATE", message: "Missing OAuth code or state" },
+              400,
+            );
+          }
+          try {
+            const [result] = await this.handlerTx()
+              .withServiceCalls(() => [services.completeOAuthCallback({ stateId, code })] as const)
+              .execute();
+            if (!result.found) {
+              if (result.reason === "server_not_found") {
+                return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+              }
+              return error({ code: "INVALID_OAUTH_STATE", message: "Invalid OAuth state" }, 400);
+            }
+            return json({ authenticated: true, mode: "oauth" });
+          } catch (err) {
+            return error({ code: "OAUTH_ERROR", message: (err as Error).message }, 502);
+          }
+        },
+      }),
+
+      defineRoute({
+        method: "DELETE",
+        path: "/servers/:slug/auth",
+        errorCodes: ["SERVER_NOT_FOUND"],
+        handler: async function ({ pathParams }, { json, error }) {
+          const result = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(mcpSchema)
+                .findFirst("server_configuration", (b) =>
+                  b.whereIndex("primary", (eb) => eb("id", "=", pathParams.slug)),
+                )
+                .find("secret", (b) =>
+                  b.whereIndex("idx_secret_server_kind", (eb) =>
+                    eb("serverId", "=", pathParams.slug),
+                  ),
+                )
+                .find("oauthState", (b) =>
+                  b.whereIndex("idx_oauth_state_server", (eb) =>
+                    eb("serverId", "=", pathParams.slug),
+                  ),
+                ),
+            )
+            .mutate(({ forSchema, retrieveResult: [server, secrets, oauthStates] }) => {
+              if (!server) {
+                return { found: false as const };
+              }
+              const uow = forSchema(mcpSchema);
+              for (const secret of secrets) {
+                uow.delete("secret", secret.id);
+              }
+              for (const oauthState of oauthStates) {
+                uow.delete("oauthState", oauthState.id);
+              }
+              uow.update("server_configuration", server.id, (b) =>
+                b.set({ authMode: "none", updatedAt: b.now() }).check(),
+              );
+              return { found: true as const };
+            })
+            .execute();
+          if (!result.found) {
+            return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+          }
+          return json({ authenticated: true, mode: "none" });
+        },
+      }),
+
+      defineRoute({
+        method: "GET",
+        path: "/servers/:slug/tools",
+        outputSchema: toolListSchema,
+        errorCodes: ["SERVER_NOT_FOUND", "MCP_ERROR"],
+        handler: async function ({ pathParams }, { json, error }) {
+          try {
+            const [result] = await this.handlerTx()
+              .withServiceCalls(
+                () => [services.prepareMcpOperation({ serverId: pathParams.slug })] as const,
+              )
+              .execute();
+            if (!result.found) {
+              return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+            }
+            const { result: toolsResult } = await listMcpTools({
+              endpointUrl: result.endpointUrl,
+              token: result.token,
+              fetchImplementation: config.fetch,
+            });
+            return json({ tools: Array.isArray(toolsResult.tools) ? toolsResult.tools : [] });
+          } catch (err) {
+            return error({ code: "MCP_ERROR", message: (err as Error).message }, 502);
+          }
+        },
+      }),
+
+      defineRoute({
+        method: "POST",
+        path: "/servers/:slug/tool",
+        inputSchema: toolCallInputSchema,
+        outputSchema: toolResultSchema,
+        errorCodes: ["SERVER_NOT_FOUND", "MCP_ERROR"],
+        handler: async function ({ input, pathParams }, { json, error }) {
+          const body = await input.valid();
+          try {
+            const [result] = await this.handlerTx()
+              .withServiceCalls(
+                () => [services.prepareMcpOperation({ serverId: pathParams.slug })] as const,
+              )
+              .execute();
+            if (!result.found) {
+              return error({ code: "SERVER_NOT_FOUND", message: "MCP server not found" }, 404);
+            }
+            const { result: toolResult } = await callMcpTool({
+              endpointUrl: result.endpointUrl,
+              token: result.token,
+              name: body.name,
+              toolArguments: body.arguments,
+              timeoutMs: body.timeoutMs,
+              fetchImplementation: config.fetch,
+            });
+            return json(toolResult);
+          } catch (err) {
+            return error({ code: "MCP_ERROR", message: (err as Error).message }, 502);
+          }
+        },
+      }),
+    ];
+  },
+);

--- a/packages/mcp-fragment/src/schema.ts
+++ b/packages/mcp-fragment/src/schema.ts
@@ -1,0 +1,44 @@
+import { column, idColumn, referenceColumn, schema } from "@fragno-dev/db/schema";
+
+export const mcpSchema = schema("mcp-fragment", (s) => {
+  return s
+    .addTable("server_configuration", (t) =>
+      t
+        .addColumn("id", idColumn())
+        .addColumn("name", column("string").nullable())
+        .addColumn("endpointUrl", column("string"))
+        .addColumn("authMode", column("string"))
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .addColumn(
+          "updatedAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        ),
+    )
+    .addTable("secret", (t) =>
+      t
+        .addColumn("id", idColumn())
+        .addColumn("serverId", referenceColumn({ table: "server_configuration" }))
+        .addColumn("kind", column("string"))
+        .addColumn("payload", column("text"))
+        .addColumn("expiresAt", column("timestamp").nullable())
+        .addColumn(
+          "updatedAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .createIndex("idx_secret_server_kind", ["serverId", "kind"], { unique: true }),
+    )
+    .addTable("oauthState", (t) =>
+      t
+        .addColumn("id", idColumn())
+        .addColumn("serverId", referenceColumn({ table: "server_configuration" }))
+        .addColumn("codeVerifier", column("text"))
+        .addColumn("redirectUri", column("string"))
+        .addColumn("scope", column("string").nullable())
+        .addColumn("expiresAt", column("timestamp"))
+        .addColumn("consumedAt", column("timestamp").nullable())
+        .createIndex("idx_oauth_state_server", ["serverId"]),
+    );
+});

--- a/packages/mcp-fragment/src/services.ts
+++ b/packages/mcp-fragment/src/services.ts
@@ -1,0 +1,256 @@
+import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+import { parseSecretPayload, stringifySecretPayload } from "./mcp-api";
+import type { McpFragmentConfig } from "./mcp-types";
+import {
+  BufferedOAuthClientProvider,
+  type OAuthProviderChanges,
+  type OAuthProviderSnapshot,
+} from "./oauth-provider";
+
+export async function prepareOAuthChanges(changes: OAuthProviderChanges) {
+  return {
+    ...changes,
+    clientInformationPayload: changes.clientInformation
+      ? stringifySecretPayload(changes.clientInformation)
+      : undefined,
+    discoveryStatePayload: changes.discoveryState
+      ? stringifySecretPayload(changes.discoveryState)
+      : undefined,
+    tokensPayload: changes.tokens
+      ? stringifySecretPayload({ type: "oauth", tokens: changes.tokens })
+      : undefined,
+  };
+}
+
+export function tokenExpiry(tokens: NonNullable<OAuthProviderChanges["tokens"]>): Date | null {
+  return typeof tokens.expires_in === "number"
+    ? new Date(Date.now() + tokens.expires_in * 1000)
+    : null;
+}
+
+export type AuthPersistenceChanges = Awaited<ReturnType<typeof prepareOAuthChanges>> & {
+  authPayload?: string;
+  authExpiresAt?: Date | null;
+};
+
+export type SecretRecord = {
+  id: { toString(): string } | string;
+  kind: string;
+  payload: string;
+  expiresAt?: Date | string | null;
+};
+
+type StoredAuthPayload =
+  | { type: "bearer"; token: string }
+  | { type: "oauth"; tokens?: OAuthTokens; redirectUri?: string }
+  | {
+      type: "client_credentials";
+      clientId: string;
+      clientSecret: string;
+      scopes?: string[];
+      tokens?: NonNullable<OAuthProviderChanges["tokens"]>;
+    };
+
+function secretByKind<TSecret extends { kind: string }>(secrets: TSecret[], kind: string) {
+  return secrets.find((secret) => secret.kind === kind);
+}
+
+function secretExpiresInFuture(secret: Pick<SecretRecord, "expiresAt"> | undefined) {
+  if (!secret?.expiresAt) {
+    return false;
+  }
+  return new Date(secret.expiresAt).getTime() > Date.now() + 30_000;
+}
+
+function secretIsUnexpired(secret: Pick<SecretRecord, "expiresAt"> | undefined) {
+  return !secret?.expiresAt || secretExpiresInFuture(secret);
+}
+
+async function parseSecretKind<T>(
+  secrets: Pick<SecretRecord, "kind" | "payload">[],
+  kind: string,
+): Promise<T | undefined> {
+  const secret = secretByKind(secrets, kind);
+  return secret ? parseSecretPayload<T>(secret.payload) : undefined;
+}
+
+export function defaultOAuthRedirectUri(config: McpFragmentConfig) {
+  return `${config.publicBaseUrl.replace(/\/$/, "")}/oauth/callback`;
+}
+
+export async function createOAuthStartSnapshot(args: {
+  config: McpFragmentConfig;
+  server: { id: { toString(): string } | string; endpointUrl: string };
+  secrets: Pick<SecretRecord, "kind" | "payload">[];
+  stateId: string;
+  redirectUri: string;
+  scope?: string;
+  clientId?: string;
+  clientSecret?: string;
+}): Promise<{
+  authorizationUrl: URL;
+  changes: Awaited<ReturnType<typeof prepareOAuthChanges>>;
+}> {
+  const snapshot: OAuthProviderSnapshot = {
+    serverId: args.server.id.toString(),
+    endpointUrl: args.server.endpointUrl,
+    redirectUrl: args.redirectUri,
+    scope: args.scope,
+    stateId: args.stateId,
+    clientId: args.clientId,
+    clientSecret: args.clientSecret,
+    clientInformation: await parseSecretKind(args.secrets, "oauth-client"),
+    discoveryState: await parseSecretKind(args.secrets, "oauth-discovery"),
+  };
+  const provider = new BufferedOAuthClientProvider(snapshot);
+  await auth(provider, {
+    serverUrl: snapshot.endpointUrl,
+    scope: args.scope,
+    fetchFn: args.config.fetch,
+  });
+  const authorizationUrl = provider.changes.authorizationUrl;
+  if (!authorizationUrl) {
+    throw new Error("OAuth authorization did not produce a redirect URL");
+  }
+  return { authorizationUrl, changes: await prepareOAuthChanges(provider.changes) };
+}
+
+export async function createOAuthCallbackSnapshot(args: {
+  config: McpFragmentConfig;
+  stateId: string;
+  code: string;
+  state: {
+    id: { toString(): string } | string;
+    codeVerifier: string;
+    redirectUri: string;
+    scope?: string | null;
+    expiresAt: Date | string;
+    consumedAt?: Date | string | null;
+  };
+  server: { id: { toString(): string } | string; endpointUrl: string };
+  secrets: Pick<SecretRecord, "kind" | "payload">[];
+}): Promise<Awaited<ReturnType<typeof prepareOAuthChanges>>> {
+  const authPayload = await parseSecretKind<{ type: string; tokens?: OAuthTokens }>(
+    args.secrets,
+    "auth",
+  );
+  const snapshot: OAuthProviderSnapshot = {
+    serverId: args.server.id.toString(),
+    endpointUrl: args.server.endpointUrl,
+    redirectUrl: args.state.redirectUri,
+    scope: args.state.scope ?? undefined,
+    stateId: args.stateId,
+    clientInformation: await parseSecretKind(args.secrets, "oauth-client"),
+    tokens: authPayload?.tokens,
+    discoveryState: await parseSecretKind(args.secrets, "oauth-discovery"),
+    oauthState: {
+      id: args.state.id.toString(),
+      codeVerifier: args.state.codeVerifier,
+      redirectUri: args.state.redirectUri,
+      scope: args.state.scope ?? undefined,
+      expiresAt: new Date(args.state.expiresAt),
+      consumedAt: args.state.consumedAt ? new Date(args.state.consumedAt) : null,
+    },
+  };
+  const provider = new BufferedOAuthClientProvider(snapshot);
+  await auth(provider, {
+    serverUrl: snapshot.endpointUrl,
+    authorizationCode: args.code,
+    scope: snapshot.scope,
+    fetchFn: args.config.fetch,
+  });
+  provider.consumeState();
+  return prepareOAuthChanges(provider.changes);
+}
+
+export async function resolveMcpOperationAuth(args: {
+  config: McpFragmentConfig;
+  server: { id: { toString(): string } | string; endpointUrl: string };
+  secrets: SecretRecord[];
+}): Promise<{
+  token?: string;
+  authChanges?: AuthPersistenceChanges;
+}> {
+  const authSecret = secretByKind(args.secrets, "auth");
+  const authPayload = authSecret
+    ? parseSecretPayload<StoredAuthPayload>(authSecret.payload)
+    : undefined;
+  if (!authPayload || authPayload.type === "bearer") {
+    return { token: authPayload?.token };
+  }
+  if (authPayload.type === "oauth") {
+    if (!authPayload.tokens?.access_token) {
+      return {};
+    }
+    if (secretIsUnexpired(authSecret)) {
+      return { token: authPayload.tokens.access_token };
+    }
+    if (!authPayload.tokens.refresh_token) {
+      throw new Error("OAuth access token expired and no refresh token is available");
+    }
+
+    const clientSecret = secretByKind(args.secrets, "oauth-client");
+    const discoverySecret = secretByKind(args.secrets, "oauth-discovery");
+    const provider = new BufferedOAuthClientProvider({
+      serverId: args.server.id.toString(),
+      endpointUrl: args.server.endpointUrl,
+      redirectUrl: authPayload.redirectUri ?? defaultOAuthRedirectUri(args.config),
+      scope: authPayload.tokens.scope,
+      clientInformation: clientSecret ? parseSecretPayload(clientSecret.payload) : undefined,
+      tokens: authPayload.tokens,
+      discoveryState: discoverySecret ? parseSecretPayload(discoverySecret.payload) : undefined,
+    });
+    await auth(provider, {
+      serverUrl: args.server.endpointUrl,
+      scope: authPayload.tokens.scope,
+      fetchFn: args.config.fetch,
+    });
+    const tokens = provider.changes.tokens ?? authPayload.tokens;
+    if (!tokens.access_token) {
+      throw new Error("OAuth refresh did not return an access token");
+    }
+    return {
+      token: tokens.access_token,
+      authChanges: {
+        ...(await prepareOAuthChanges(provider.changes)),
+        authPayload: stringifySecretPayload({ ...authPayload, tokens }),
+        authExpiresAt: tokenExpiry(tokens),
+      },
+    };
+  }
+
+  if (authPayload.tokens?.access_token && secretExpiresInFuture(authSecret)) {
+    return { token: authPayload.tokens.access_token };
+  }
+
+  const discoverySecret = secretByKind(args.secrets, "oauth-discovery");
+  const provider = new BufferedOAuthClientProvider({
+    serverId: args.server.id.toString(),
+    endpointUrl: args.server.endpointUrl,
+    scope: authPayload.scopes?.join(" "),
+    clientId: authPayload.clientId,
+    clientSecret: authPayload.clientSecret,
+    tokens: authPayload.tokens,
+    discoveryState: discoverySecret ? parseSecretPayload(discoverySecret.payload) : undefined,
+    flow: "client_credentials",
+  });
+  await auth(provider, {
+    serverUrl: args.server.endpointUrl,
+    scope: authPayload.scopes?.join(" "),
+    fetchFn: args.config.fetch,
+  });
+  const tokens = provider.changes.tokens ?? authPayload.tokens;
+  if (!tokens?.access_token) {
+    throw new Error("Client credentials flow did not return an access token");
+  }
+  return {
+    token: tokens.access_token,
+    authChanges: {
+      ...(await prepareOAuthChanges(provider.changes)),
+      authPayload: stringifySecretPayload({ ...authPayload, tokens }),
+      authExpiresAt: tokenExpiry(tokens),
+    },
+  };
+}

--- a/packages/mcp-fragment/src/testing/streamable-http-mcp-server.ts
+++ b/packages/mcp-fragment/src/testing/streamable-http-mcp-server.ts
@@ -1,0 +1,302 @@
+/// <reference types="node" />
+
+import { createServer, type IncomingMessage, type Server } from "node:http";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import * as z from "zod/v4";
+
+export interface TestMcpServerHandle {
+  endpointUrl: string;
+  getTokenRequestCount: () => number;
+  close: () => Promise<void>;
+}
+
+export interface StartTestMcpServerOptions {
+  requiredBearerToken?: string;
+  enableJsonResponse?: boolean;
+  registerEchoTool?: boolean;
+  oauth?: boolean;
+  disableDynamicRegistration?: boolean;
+  requiredClientId?: string;
+  requiredClientSecret?: string;
+}
+
+interface McpSession {
+  server: McpServer;
+  transport: StreamableHTTPServerTransport;
+}
+
+function rejectUnauthorized(request: IncomingMessage, requiredBearerToken: string | undefined) {
+  if (!requiredBearerToken) {
+    return false;
+  }
+  return request.headers["authorization"] !== `Bearer ${requiredBearerToken}`;
+}
+
+function hasExpectedClientAuth(
+  request: IncomingMessage,
+  form: URLSearchParams,
+  options: StartTestMcpServerOptions,
+) {
+  if (!options.requiredClientId) {
+    return true;
+  }
+  const authorization = request.headers.authorization;
+  if (authorization?.startsWith("Basic ")) {
+    const decoded = Buffer.from(authorization.slice("Basic ".length), "base64").toString("utf8");
+    return decoded === `${options.requiredClientId}:${options.requiredClientSecret ?? ""}`;
+  }
+  return (
+    form.get("client_id") === options.requiredClientId &&
+    form.get("client_secret") === (options.requiredClientSecret ?? "")
+  );
+}
+
+function createConfiguredMcpServer(options: StartTestMcpServerOptions) {
+  const mcpServer = new McpServer({ name: "fragno-test-mcp-server", version: "1.0.0" });
+
+  if (options.registerEchoTool ?? true) {
+    mcpServer.registerTool(
+      "echo",
+      {
+        title: "Echo",
+        description: "Echo a message",
+        inputSchema: z.object({ text: z.string() }),
+        outputSchema: z.object({ echoed: z.string() }),
+      },
+      async ({ text }) => {
+        const output = { echoed: text };
+        return {
+          content: [{ type: "text" as const, text }],
+          structuredContent: output,
+        };
+      },
+    );
+  }
+
+  return mcpServer;
+}
+
+export async function startStreamableHttpTestMcpServer(
+  options: StartTestMcpServerOptions = {},
+): Promise<TestMcpServerHandle> {
+  const sessions = new Map<string, McpSession>();
+  let tokenRequestCount = 0;
+
+  async function createSession() {
+    const server = createConfiguredMcpServer(options);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      onsessioninitialized: (sessionId) => {
+        sessions.set(sessionId, { server, transport });
+      },
+      enableJsonResponse: options.enableJsonResponse ?? false,
+    });
+    await server.connect(transport);
+    return { server, transport };
+  }
+
+  const httpServer = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "127.0.0.1"}`);
+    const baseUrl = `http://127.0.0.1:${(httpServer.address() as { port: number } | null)?.port ?? 0}`;
+
+    if (options.oauth && url.pathname.includes("/.well-known/oauth-protected-resource")) {
+      response.writeHead(200, { "Content-Type": "application/json" }).end(
+        JSON.stringify({
+          resource: `${baseUrl}/mcp`,
+          authorization_servers: [baseUrl],
+          scopes_supported: ["tools"],
+        }),
+      );
+      return;
+    }
+    if (options.oauth && url.pathname === "/.well-known/oauth-authorization-server") {
+      response.writeHead(200, { "Content-Type": "application/json" }).end(
+        JSON.stringify({
+          issuer: baseUrl,
+          authorization_endpoint: `${baseUrl}/authorize`,
+          token_endpoint: `${baseUrl}/token`,
+          ...(options.disableDynamicRegistration
+            ? {}
+            : { registration_endpoint: `${baseUrl}/register` }),
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token", "client_credentials"],
+          token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+          code_challenge_methods_supported: ["S256"],
+        }),
+      );
+      return;
+    }
+    if (
+      options.oauth &&
+      !options.disableDynamicRegistration &&
+      url.pathname === "/register" &&
+      request.method === "POST"
+    ) {
+      let rawBody = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        rawBody += chunk;
+      });
+      request.on("end", () => {
+        const metadata = rawBody ? (JSON.parse(rawBody) as Record<string, unknown>) : {};
+        response.writeHead(200, { "Content-Type": "application/json" }).end(
+          JSON.stringify({
+            ...metadata,
+            client_id: "test-client",
+            client_secret: "test-secret",
+          }),
+        );
+      });
+      return;
+    }
+    if (options.oauth && url.pathname === "/authorize") {
+      const redirectUri = url.searchParams.get("redirect_uri");
+      const state = url.searchParams.get("state");
+      if (!redirectUri) {
+        response.writeHead(400).end("Missing redirect_uri");
+        return;
+      }
+      const redirect = new URL(redirectUri);
+      redirect.searchParams.set("code", "valid-code");
+      if (state) {
+        redirect.searchParams.set("state", state);
+      }
+      response.writeHead(302, { Location: redirect.toString() }).end();
+      return;
+    }
+    if (options.oauth && url.pathname === "/token" && request.method === "POST") {
+      let rawBody = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        rawBody += chunk;
+      });
+      request.on("end", () => {
+        tokenRequestCount += 1;
+        const form = new URLSearchParams(rawBody);
+        if (!hasExpectedClientAuth(request, form, options)) {
+          response
+            .writeHead(401, { "Content-Type": "application/json" })
+            .end(JSON.stringify({ error: "invalid_client" }));
+          return;
+        }
+        if (form.get("grant_type") === "client_credentials") {
+          response.writeHead(200, { "Content-Type": "application/json" }).end(
+            JSON.stringify({
+              access_token: options.requiredBearerToken ?? "client-credentials-access-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+              scope: form.get("scope") ?? "tools",
+            }),
+          );
+          return;
+        }
+        if (form.get("grant_type") === "refresh_token") {
+          if (form.get("refresh_token") !== "oauth-refresh-token") {
+            response
+              .writeHead(400, { "Content-Type": "application/json" })
+              .end(JSON.stringify({ error: "invalid_grant" }));
+            return;
+          }
+          response.writeHead(200, { "Content-Type": "application/json" }).end(
+            JSON.stringify({
+              access_token: options.requiredBearerToken ?? "oauth-access-token",
+              refresh_token: "oauth-refresh-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+              scope: "tools",
+            }),
+          );
+          return;
+        }
+        if (form.get("grant_type") !== "authorization_code" || form.get("code") !== "valid-code") {
+          response
+            .writeHead(400, { "Content-Type": "application/json" })
+            .end(JSON.stringify({ error: "invalid_grant" }));
+          return;
+        }
+        if (!form.get("code_verifier")) {
+          response
+            .writeHead(400, { "Content-Type": "application/json" })
+            .end(JSON.stringify({ error: "invalid_request" }));
+          return;
+        }
+        response.writeHead(200, { "Content-Type": "application/json" }).end(
+          JSON.stringify({
+            access_token: options.requiredBearerToken ?? "oauth-access-token",
+            refresh_token: "oauth-refresh-token",
+            token_type: "Bearer",
+            expires_in: 3600,
+            scope: "tools",
+          }),
+        );
+      });
+      return;
+    }
+
+    if (url.pathname !== "/mcp") {
+      response.writeHead(404).end("Not found");
+      return;
+    }
+    if (rejectUnauthorized(request, options.requiredBearerToken)) {
+      if (options.oauth) {
+        response
+          .writeHead(401, {
+            "WWW-Authenticate": `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource/mcp"`,
+          })
+          .end("Unauthorized");
+      } else {
+        response.writeHead(401).end("Unauthorized");
+      }
+      return;
+    }
+
+    void (async () => {
+      const sessionId = request.headers["mcp-session-id"];
+      const existingSession = typeof sessionId === "string" ? sessions.get(sessionId) : undefined;
+      const session = existingSession ?? (await createSession());
+      await session.transport.handleRequest(request, response);
+    })().catch((error: unknown) => {
+      if (!response.headersSent) {
+        response.writeHead(500).end(error instanceof Error ? error.message : "MCP transport error");
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, "127.0.0.1", resolve);
+  });
+
+  return {
+    endpointUrl: endpointUrl(httpServer),
+    getTokenRequestCount: () => tokenRequestCount,
+    close: async () => {
+      for (const session of sessions.values()) {
+        await session.server.close();
+        await session.transport.close();
+      }
+      await closeHttpServer(httpServer);
+    },
+  };
+}
+
+function endpointUrl(httpServer: Server) {
+  const address = httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Test MCP server did not bind to a TCP port");
+  }
+  return `http://127.0.0.1:${address.port}/mcp`;
+}
+
+async function closeHttpServer(httpServer: Server) {
+  await new Promise<void>((resolve, reject) => {
+    httpServer.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/packages/mcp-fragment/tsconfig.base.json
+++ b/packages/mcp-fragment/tsconfig.base.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    // Enable latest features
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": false,
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    // Project reference specific settings
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rewriteRelativeImportExtensions": true,
+    "emitDeclarationOnly": false,
+    "isolatedDeclarations": false,
+    "isolatedModules": true,
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    // Some stricter flags
+    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": true,
+    // Misc
+    "esModuleInterop": true,
+    "noErrorTruncation": true
+  }
+}

--- a/packages/mcp-fragment/tsconfig.json
+++ b/packages/mcp-fragment/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp-fragment/tsdown.config.ts
+++ b/packages/mcp-fragment/tsdown.config.ts
@@ -1,0 +1,51 @@
+import unpluginFragno from "@fragno-dev/unplugin-fragno/rollup";
+import { defineConfig } from "tsdown";
+
+export default defineConfig([
+  {
+    ignoreWatch: ["./dist"],
+    entry: [
+      "./src/index.ts",
+      "./src/client/react.ts",
+      "./src/client/svelte.ts",
+      "./src/client/solid.ts",
+      "./src/client/vanilla.ts",
+      "./src/client/vue.ts",
+    ],
+    dts: true,
+    failOnWarn: true,
+    platform: "browser",
+    outDir: "./dist/browser",
+    plugins: [unpluginFragno({ platform: "browser" })],
+    noExternal: [/^@fragno-dev\/core\//],
+    inlineOnly: [/^@fragno-dev\/core/, /^nanostores$/, /^@nanostores\//, /^nanoevents$/],
+  },
+  {
+    ignoreWatch: ["./dist"],
+    entry: [
+      "./src/index.ts",
+      "./src/definition.ts",
+      "./src/routes.ts",
+      "./src/schema.ts",
+      "./src/mcp-types.ts",
+    ],
+    dts: true,
+    failOnWarn: true,
+    platform: "node",
+    outDir: "./dist/node",
+    fixedExtension: false,
+    plugins: [unpluginFragno({ platform: "node" })],
+    unbundle: true,
+    inlineOnly: false,
+  },
+  {
+    ignoreWatch: ["./dist"],
+    entry: "./src/cli/cli.ts",
+    dts: true,
+    failOnWarn: true,
+    platform: "node",
+    outDir: "./dist/cli",
+    fixedExtension: false,
+    unbundle: true,
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,19 +105,19 @@ importers:
         version: 4.1.1
       '@cloudflare/codemode':
         specifier: ^0.3.8
-        version: 0.3.8(zod@4.3.5)
+        version: 0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(zod@4.3.5)
       '@cloudflare/sandbox':
         specifier: ^0.7.12
         version: 0.7.21
       '@cloudflare/shell':
         specifier: ^0.3.8
-        version: 0.3.8(zod@4.3.5)
+        version: 0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(zod@4.3.5)
       '@earendil-works/pi-agent-core':
         specifier: ^0.75.4
-        version: 0.75.4(ws@8.20.0)(zod@4.3.5)
+        version: 0.75.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(ws@8.20.0)(zod@4.3.5)
       '@earendil-works/pi-ai':
         specifier: ^0.75.4
-        version: 0.75.4(patch_hash=f60f0b72fe619f0fcb96686efc80a0d239e1a7b36d4915e722b60eca03cfecd4)(ws@8.20.0)(zod@4.3.5)
+        version: 0.75.4(patch_hash=f60f0b72fe619f0fcb96686efc80a0d239e1a7b36d4915e722b60eca03cfecd4)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(ws@8.20.0)(zod@4.3.5)
       '@fragno-dev/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -576,7 +576,7 @@ importers:
         version: link:../../packages/fragment-workflows
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       gunshi:
         specifier: ^0.26.3
         version: 0.26.3
@@ -656,7 +656,7 @@ importers:
         version: link:../../example-fragments/fragno-db-library
       '@prisma/client':
         specifier: ^6.16.1
-        version: 6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3)
+        version: 6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3)
       better-sqlite3:
         specifier: ^12.5.0
         version: 12.5.0
@@ -687,7 +687,7 @@ importers:
         version: 4.1.0(vitest@4.1.6)
       prisma:
         specifier: ^6.16.1
-        version: 6.19.2(magicast@0.5.1)(typescript@5.9.3)
+        version: 6.19.2(magicast@0.5.2)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.6(@types/node@22.19.1)(@vitest/coverage-istanbul@4.1.0)(happy-dom@20.3.4)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -739,7 +739,7 @@ importers:
         version: link:../../example-fragments/example-fragment
       nuxt:
         specifier: ^4.2.2
-        version: 4.2.2(04bbb6a2e6a204b8765c2f19c5e95cf8)
+        version: 4.2.2(3e221778ab8971782bc0f7a4ca093ddf)
       vue:
         specifier: ^3.5.27
         version: 3.5.27(typescript@5.9.3)
@@ -868,7 +868,7 @@ importers:
         version: 0.15.4(solid-js@1.9.10)
       '@solidjs/start':
         specifier: ^1.2.1
-        version: 1.2.1(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vinxi@0.5.11(e5c271d02af7b7e0e06403adc8ddba12))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.2.1(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vinxi@0.5.11(be48bc04fc2d16aa44300f8e21182c16))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -880,7 +880,7 @@ importers:
         version: 4.1.18
       vinxi:
         specifier: ^0.5.10
-        version: 0.5.11(e5c271d02af7b7e0e06403adc8ddba12)
+        version: 0.5.11(be48bc04fc2d16aa44300f8e21182c16)
 
   example-apps/stripe-webshop:
     dependencies:
@@ -967,7 +967,7 @@ importers:
         version: 0.31.8
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       kysely-pglite:
         specifier: ^0.6.1
         version: 0.6.1(@electric-sql/pglite@0.3.15)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)
@@ -1223,7 +1223,7 @@ importers:
         version: 7.9.6(react-router@7.9.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       drizzle-orm:
         specifier: ^0.44.6
-        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       isbot:
         specifier: ^5
         version: 5.1.32
@@ -1598,7 +1598,7 @@ importers:
         version: 22.19.7
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       kysely:
         specifier: ^0.28.10
         version: 0.28.10
@@ -2026,7 +2026,7 @@ importers:
         version: 0.31.8
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       kysely-pglite:
         specifier: ^0.6.1
         version: 0.6.1(@electric-sql/pglite@0.3.15)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)
@@ -2118,7 +2118,7 @@ importers:
         version: 0.31.8
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       kysely-pglite:
         specifier: ^0.6.1
         version: 0.6.1(@electric-sql/pglite@0.3.15)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)
@@ -2206,7 +2206,7 @@ importers:
         version: 0.31.8
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       kysely-pglite:
         specifier: ^0.6.1
         version: 0.6.1(@electric-sql/pglite@0.3.15)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)
@@ -2303,14 +2303,81 @@ importers:
         specifier: 'catalog:'
         version: 4.1.6(@types/node@22.19.7)(@vitest/coverage-istanbul@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.3.4)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/mcp-fragment:
+    dependencies:
+      '@fragno-dev/core':
+        specifier: workspace:*
+        version: link:../fragno
+      '@fragno-dev/db':
+        specifier: workspace:*
+        version: link:../fragno-db
+      '@fragno-dev/node':
+        specifier: workspace:*
+        version: link:../fragno-node
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5)
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.1.0
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260414.1
+      better-sqlite3:
+        specifier: ^12.5.0
+        version: 12.6.2
+      react:
+        specifier: '>=18.0.0'
+        version: 19.2.5
+      solid-js:
+        specifier: '>=1.0.0'
+        version: 1.9.10
+      svelte:
+        specifier: '>=4.0.0'
+        version: 5.47.1
+      vue:
+        specifier: '>=3.0.0'
+        version: 3.5.27(typescript@5.9.3)
+      zod:
+        specifier: 4.3.5
+        version: 4.3.5
+    devDependencies:
+      '@fragno-dev/cli':
+        specifier: workspace:*
+        version: link:../../apps/fragno-cli
+      '@fragno-dev/test':
+        specifier: workspace:*
+        version: link:../fragno-test
+      '@fragno-dev/unplugin-fragno':
+        specifier: workspace:*
+        version: link:../unplugin-fragno
+      '@fragno-private/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages-private/typescript-config
+      '@fragno-private/vitest-config':
+        specifier: workspace:*
+        version: link:../../packages-private/vitest-config
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.3.0
+      '@vitest/coverage-istanbul':
+        specifier: ^4.1.0
+        version: 4.1.0(vitest@4.1.6)
+      tsdown:
+        specifier: ^0.20.3
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260414.1)(typescript@5.9.3)(vue-tsc@3.2.2(typescript@5.9.3))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@types/node@25.3.0)(@vitest/coverage-istanbul@4.1.0)(happy-dom@20.3.4)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/pi-fragment:
     dependencies:
       '@earendil-works/pi-agent-core':
         specifier: ^0.75.4
-        version: 0.75.4(ws@8.20.0)(zod@4.3.5)
+        version: 0.75.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(ws@8.20.0)(zod@4.3.5)
       '@earendil-works/pi-ai':
         specifier: ^0.75.4
-        version: 0.75.4(patch_hash=f60f0b72fe619f0fcb96686efc80a0d239e1a7b36d4915e722b60eca03cfecd4)(ws@8.20.0)(zod@4.3.5)
+        version: 0.75.4(patch_hash=f60f0b72fe619f0fcb96686efc80a0d239e1a7b36d4915e722b60eca03cfecd4)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(ws@8.20.0)(zod@4.3.5)
       '@fragno-dev/core':
         specifier: workspace:*
         version: link:../fragno
@@ -2368,7 +2435,7 @@ importers:
         version: 0.31.8
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+        version: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260414.1)(typescript@5.9.3)(vue-tsc@3.2.2(typescript@5.9.3))
@@ -4604,6 +4671,12 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -4966,6 +5039,16 @@ packages:
 
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: 4.3.5
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/zstd@7.0.0':
     resolution: {integrity: sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==}
@@ -9213,6 +9296,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
@@ -10011,6 +10102,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -10855,6 +10950,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -10878,6 +10981,12 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -11592,6 +11701,10 @@ packages:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
 
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -11787,6 +11900,10 @@ packages:
   ioredis@5.8.2:
     resolution: {integrity: sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -12083,6 +12200,9 @@ packages:
   jose@6.1.2:
     resolution: {integrity: sha512-MpcPtHLE5EmztuFIqB0vzHAWJPpmN1E6L4oo+kze56LIs3MyXIj9ZHMDxqOvkP38gBR7K1v3jqd4WU2+nrfONQ==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -12154,6 +12274,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -13715,6 +13838,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -17218,7 +17345,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -17283,19 +17410,6 @@ snapshots:
       browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
-
-  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.6)':
-    dependencies:
-      '@babel/core': 7.28.6
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.6)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.29.0)':
     dependencies:
@@ -17374,7 +17488,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17412,15 +17526,6 @@ snapshots:
   '@babel/helper-plugin-utils@7.27.1': {}
 
   '@babel/helper-plugin-utils@7.28.6': {}
-
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.6)':
-    dependencies:
-      '@babel/core': 7.28.6
-      '@babel/helper-member-expression-to-functions': 7.28.5
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -17478,7 +17583,7 @@ snapshots:
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/helpers@7.28.6':
     dependencies:
@@ -17505,28 +17610,28 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0-rc.1
 
-  '@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.28.6)':
+  '@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.6
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.6)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.6)':
+  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.6)':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.6)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5)':
@@ -17537,6 +17642,11 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.28.5)':
@@ -17600,17 +17710,6 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.28.6)':
-    dependencies:
-      '@babel/core': 7.28.6
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.6)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -17699,9 +17798,9 @@ snapshots:
 
   '@babel/template@7.27.2':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.28.6
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
 
   '@babel/template@7.28.6':
     dependencies:
@@ -18019,11 +18118,12 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@cloudflare/codemode@0.3.8(zod@4.3.5)':
+  '@cloudflare/codemode@0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
       '@types/json-schema': 7.0.15
       acorn: 8.16.0
     optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5)
       zod: 4.3.5
 
   '@cloudflare/containers@0.1.1': {}
@@ -18037,9 +18137,9 @@ snapshots:
       '@cloudflare/containers': 0.1.1
       aws4fetch: 1.0.20
 
-  '@cloudflare/shell@0.3.8(zod@4.3.5)':
+  '@cloudflare/shell@0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(zod@4.3.5)':
     dependencies:
-      '@cloudflare/codemode': 0.3.8(zod@4.3.5)
+      '@cloudflare/codemode': 0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(zod@4.3.5)
       isomorphic-git: 1.38.3
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -18186,10 +18286,10 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@dxup/nuxt@0.2.2(magicast@0.5.1)':
+  '@dxup/nuxt@0.2.2(magicast@0.5.2)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.2.2(magicast@0.5.1)
+      '@nuxt/kit': 4.2.2(magicast@0.5.2)
       chokidar: 4.0.3
       pathe: 2.0.3
       tinyglobby: 0.2.16
@@ -18198,9 +18298,9 @@ snapshots:
 
   '@dxup/unimport@0.1.2': {}
 
-  '@earendil-works/pi-agent-core@0.75.4(ws@8.20.0)(zod@4.3.5)':
+  '@earendil-works/pi-agent-core@0.75.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(ws@8.20.0)(zod@4.3.5)':
     dependencies:
-      '@earendil-works/pi-ai': 0.75.4(patch_hash=f60f0b72fe619f0fcb96686efc80a0d239e1a7b36d4915e722b60eca03cfecd4)(ws@8.20.0)(zod@4.3.5)
+      '@earendil-works/pi-ai': 0.75.4(patch_hash=f60f0b72fe619f0fcb96686efc80a0d239e1a7b36d4915e722b60eca03cfecd4)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(ws@8.20.0)(zod@4.3.5)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -18212,11 +18312,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.75.4(patch_hash=f60f0b72fe619f0fcb96686efc80a0d239e1a7b36d4915e722b60eca03cfecd4)(ws@8.20.0)(zod@4.3.5)':
+  '@earendil-works/pi-ai@0.75.4(patch_hash=f60f0b72fe619f0fcb96686efc80a0d239e1a7b36d4915e722b60eca03cfecd4)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(ws@8.20.0)(zod@4.3.5)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.3.5)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))
       '@mistralai/mistralai': 2.2.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -18893,16 +18993,22 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.1.18
 
-  '@google/genai@1.52.0':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))':
     dependencies:
       google-auth-library: 10.6.1
       p-retry: 4.6.2
       protobufjs: 7.5.5
       ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@hono/node-server@1.19.14(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
 
   '@humanfs/core@0.19.1': {}
 
@@ -19279,6 +19385,30 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.23)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.23
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.5
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@mongodb-js/zstd@7.0.0':
     dependencies:
       node-addon-api: 8.6.0
@@ -19384,11 +19514,11 @@ snapshots:
     dependencies:
       which: 3.0.1
 
-  '@nuxt/cli@3.32.0(cac@6.7.14)(magicast@0.5.1)':
+  '@nuxt/cli@3.32.0(cac@6.7.14)(magicast@0.5.2)':
     dependencies:
       '@bomb.sh/tab': 0.0.11(cac@6.7.14)(citty@0.1.6)
       '@clack/prompts': 1.0.0-alpha.9
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.5.2)
       citty: 0.1.6
       confbox: 0.2.2
       consola: 3.4.2
@@ -19421,9 +19551,9 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.1.1(magicast@0.5.1)(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@3.1.1(magicast@0.5.2)(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@nuxt/kit': 4.2.2(magicast@0.5.1)
+      '@nuxt/kit': 4.2.2(magicast@0.5.2)
       execa: 8.0.1
       vite: 8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -19434,7 +19564,7 @@ snapshots:
       consola: 3.4.2
       diff: 8.0.3
       execa: 8.0.1
-      magicast: 0.5.1
+      magicast: 0.5.2
       pathe: 2.0.3
       pkg-types: 2.3.0
       prompts: 2.4.2
@@ -19442,9 +19572,9 @@ snapshots:
 
   '@nuxt/devtools@3.1.1(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.27(typescript@5.9.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.2)(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.1.1
-      '@nuxt/kit': 4.2.2(magicast@0.5.1)
+      '@nuxt/kit': 4.2.2(magicast@0.5.2)
       '@vue/devtools-core': 8.0.5(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.27(typescript@5.9.3))
       '@vue/devtools-kit': 8.0.5
       birpc: 2.9.0
@@ -19459,7 +19589,7 @@ snapshots:
       is-installed-globally: 1.0.0
       launch-editor: 2.12.0
       local-pkg: 1.1.2
-      magicast: 0.5.1
+      magicast: 0.5.2
       nypm: 0.6.2
       ohash: 2.0.11
       pathe: 2.0.3
@@ -19471,7 +19601,7 @@ snapshots:
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.16
       vite: 8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.2.2(magicast@0.5.1))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.2.2(magicast@0.5.2))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.1.3(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.27(typescript@5.9.3))
       which: 5.0.0
       ws: 8.18.3
@@ -19481,9 +19611,9 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/kit@3.20.1(magicast@0.5.1)':
+  '@nuxt/kit@3.20.1(magicast@0.5.2)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -19501,31 +19631,6 @@ snapshots:
       scule: 1.3.0
       semver: 7.7.4
       tinyglobby: 0.2.16
-      ufo: 1.6.1
-      unctx: 2.4.1
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
-  '@nuxt/kit@4.2.2(magicast@0.5.1)':
-    dependencies:
-      c12: 3.3.3(magicast@0.5.1)
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.0.8
-      ignore: 7.0.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      mlly: 1.8.0
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rc9: 2.1.2
-      scule: 1.3.0
-      semver: 7.7.3
-      tinyglobby: 0.2.15
       ufo: 1.6.1
       unctx: 2.4.1
       untyped: 2.0.0
@@ -19557,10 +19662,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.2.2(fd4cf95c01bb8f8cd9d115c1f2757e90)':
+  '@nuxt/nitro-server@4.2.2(eaa5243872e9c901d1fbc4c0a6799b9e)':
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.2.2(magicast@0.5.1)
+      '@nuxt/kit': 4.2.2(magicast@0.5.2)
       '@unhead/vue': 2.0.19(vue@3.5.27(typescript@5.9.3))
       '@vue/shared': 3.5.29
       consola: 3.4.2
@@ -19574,15 +19679,15 @@ snapshots:
       impound: 1.0.0
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.12.9(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)(rolldown@1.0.0-rc.9)
-      nuxt: 4.2.2(04bbb6a2e6a204b8765c2f19c5e95cf8)
+      nitropack: 2.12.9(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)(rolldown@1.0.0-rc.9)
+      nuxt: 4.2.2(3e221778ab8971782bc0f7a4ca093ddf)
       pathe: 2.0.3
       pkg-types: 2.3.0
       radix3: 1.1.2
       std-env: 3.10.0
       ufo: 1.6.1
       unctx: 2.4.1
-      unstorage: 1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2)
+      unstorage: 1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2)
       vue: 3.5.27(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -19629,9 +19734,9 @@ snapshots:
       pkg-types: 2.3.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.6.6(magicast@0.5.1)':
+  '@nuxt/telemetry@2.6.6(magicast@0.5.2)':
     dependencies:
-      '@nuxt/kit': 3.20.1(magicast@0.5.1)
+      '@nuxt/kit': 3.20.1(magicast@0.5.2)
       citty: 0.1.6
       consola: 3.4.2
       destr: 2.0.5
@@ -19646,9 +19751,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@4.2.2(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.1)(nuxt@4.2.2(04bbb6a2e6a204b8765c2f19c5e95cf8))(optionator@0.9.4)(oxlint@1.60.0)(rolldown@1.0.0-rc.9)(rollup@4.60.2)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.2(typescript@5.9.3))(vue@3.5.27(typescript@5.9.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.2.2(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.2.2(3e221778ab8971782bc0f7a4ca093ddf))(optionator@0.9.4)(oxlint@1.60.0)(rolldown@1.0.0-rc.9)(rollup@4.60.2)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.2(typescript@5.9.3))(vue@3.5.27(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
-      '@nuxt/kit': 4.2.2(magicast@0.5.1)
+      '@nuxt/kit': 4.2.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.2(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.27(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.2(vite@7.3.2(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.27(typescript@5.9.3))
@@ -19666,7 +19771,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.0
       mocked-exports: 0.1.1
-      nuxt: 4.2.2(04bbb6a2e6a204b8765c2f19c5e95cf8)
+      nuxt: 4.2.2(3e221778ab8971782bc0f7a4ca093ddf)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.6
@@ -20259,14 +20364,14 @@ snapshots:
 
   '@poppinss/exception@1.2.2': {}
 
-  '@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
-      prisma: 6.19.2(magicast@0.5.1)(typescript@5.9.3)
+      prisma: 6.19.2(magicast@0.5.2)(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@prisma/config@6.19.2(magicast@0.5.1)':
+  '@prisma/config@6.19.2(magicast@0.5.2)':
     dependencies:
-      c12: 3.1.0(magicast@0.5.1)
+      c12: 3.1.0(magicast@0.5.2)
       deepmerge-ts: 7.1.5
       effect: 3.18.4
       empathic: 2.0.0
@@ -22261,11 +22366,11 @@ snapshots:
     dependencies:
       solid-js: 1.9.10
 
-  '@solidjs/start@1.2.1(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vinxi@0.5.11(e5c271d02af7b7e0e06403adc8ddba12))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@solidjs/start@1.2.1(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vinxi@0.5.11(be48bc04fc2d16aa44300f8e21182c16))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.21(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(e5c271d02af7b7e0e06403adc8ddba12))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(e5c271d02af7b7e0e06403adc8ddba12))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(be48bc04fc2d16aa44300f8e21182c16))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(be48bc04fc2d16aa44300f8e21182c16))
       cookie-es: 2.0.0
       defu: 6.1.4
       error-stack-parser: 2.1.4
@@ -22277,7 +22382,7 @@ snapshots:
       source-map-js: 1.2.1
       terracotta: 1.0.6(solid-js@1.9.10)
       tinyglobby: 0.2.15
-      vinxi: 0.5.11(e5c271d02af7b7e0e06403adc8ddba12)
+      vinxi: 0.5.11(be48bc04fc2d16aa44300f8e21182c16)
       vite-plugin-solid: 2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
@@ -22510,8 +22615,8 @@ snapshots:
   '@tanstack/directive-functions-plugin@1.121.21(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/core': 7.28.6
-      '@babel/traverse': 7.28.6
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@tanstack/router-utils': 1.143.11
       babel-dead-code-elimination: 1.0.12
@@ -22666,12 +22771,12 @@ snapshots:
 
   '@tanstack/router-plugin@1.153.2(@tanstack/react-router@1.153.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.7))':
     dependencies:
-      '@babel/core': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.6)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.6)
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       '@tanstack/router-core': 1.153.2
       '@tanstack/router-generator': 1.153.2
       '@tanstack/router-utils': 1.143.11
@@ -22695,7 +22800,7 @@ snapshots:
 
   '@tanstack/router-utils@1.143.11':
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/generator': 7.28.6
       '@babel/parser': 7.29.0
       ansis: 4.2.0
@@ -22708,9 +22813,9 @@ snapshots:
   '@tanstack/server-functions-plugin@1.121.21(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/core': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.6)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.6)
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
       '@babel/template': 7.28.6
       '@babel/traverse': 7.28.6
       '@babel/types': 7.29.0
@@ -22735,7 +22840,7 @@ snapshots:
   '@tanstack/start-plugin-core@1.154.0(@tanstack/react-router@1.153.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.7))':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/types': 7.28.6
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.153.2
@@ -23156,7 +23261,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.2
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(e5c271d02af7b7e0e06403adc8ddba12))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(be48bc04fc2d16aa44300f8e21182c16))':
     dependencies:
       '@babel/parser': 7.29.0
       acorn: 8.16.0
@@ -23167,18 +23272,18 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.11(e5c271d02af7b7e0e06403adc8ddba12)
+      vinxi: 0.5.11(be48bc04fc2d16aa44300f8e21182c16)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.11(e5c271d02af7b7e0e06403adc8ddba12))':
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(be48bc04fc2d16aa44300f8e21182c16))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(e5c271d02af7b7e0e06403adc8ddba12))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(be48bc04fc2d16aa44300f8e21182c16))
       acorn: 8.16.0
       acorn-loose: 8.5.2
       acorn-typescript: 1.4.13(acorn@8.16.0)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.11(e5c271d02af7b7e0e06403adc8ddba12)
+      vinxi: 0.5.11(be48bc04fc2d16aa44300f8e21182c16)
 
   '@vitejs/plugin-basic-ssl@2.2.0(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -23416,19 +23521,19 @@ snapshots:
 
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
-  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.28.6)':
+  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@vue/babel-helper-vue-transform-on': 1.5.0
-      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.28.6)
+      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.29.0)
       '@vue/shared': 3.5.29
     optionalDependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23448,10 +23553,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.28.6)':
+  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/parser': 7.29.3
@@ -23472,7 +23577,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.25':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@vue/shared': 3.5.25
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -23480,7 +23585,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.27':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@vue/shared': 3.5.27
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -23812,6 +23917,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
       ajv: 8.18.0
@@ -23940,7 +24049,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       pathe: 2.0.3
 
   ast-kit@3.0.0-beta.1:
@@ -24094,7 +24203,7 @@ snapshots:
 
   babel-dead-code-elimination@1.0.10:
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/parser': 7.28.6
       '@babel/traverse': 7.28.6
       '@babel/types': 7.28.6
@@ -24110,19 +24219,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-jsx-dom-expressions@0.40.3(@babel/core@7.28.6):
+  babel-plugin-jsx-dom-expressions@0.40.3(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/types': 7.29.0
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-preset-solid@1.9.10(@babel/core@7.28.6)(solid-js@1.9.10):
+  babel-preset-solid@1.9.10(@babel/core@7.29.0)(solid-js@1.9.10):
     dependencies:
-      '@babel/core': 7.28.6
-      babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.28.6)
+      '@babel/core': 7.29.0
+      babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.29.0)
     optionalDependencies:
       solid-js: 1.9.10
 
@@ -24163,7 +24272,7 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.5
     optionalDependencies:
-      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3)
       '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.47.1)(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.47.1)(typescript@5.9.3)(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-start': 1.154.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite-plugin-solid@2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.7))
       better-sqlite3: 12.6.2
@@ -24172,7 +24281,7 @@ snapshots:
       mysql2: 3.16.1
       next: 16.1.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       pg: 8.18.0
-      prisma: 6.19.2(magicast@0.5.1)(typescript@5.9.3)
+      prisma: 6.19.2(magicast@0.5.2)(typescript@5.9.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       solid-js: 1.9.10
@@ -24338,7 +24447,7 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c12@3.1.0(magicast@0.5.1):
+  c12@3.1.0(magicast@0.5.2):
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.4
@@ -24353,24 +24462,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 2.1.2
     optionalDependencies:
-      magicast: 0.5.1
-
-  c12@3.3.3(magicast@0.5.1):
-    dependencies:
-      chokidar: 5.0.0
-      confbox: 0.2.2
-      defu: 6.1.4
-      dotenv: 17.2.3
-      exsolve: 1.0.8
-      giget: 2.0.0
-      jiti: 2.6.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.0.0
-      pkg-types: 2.3.0
-      rc9: 2.1.2
-    optionalDependencies:
-      magicast: 0.5.1
+      magicast: 0.5.2
 
   c12@3.3.3(magicast@0.5.2):
     dependencies:
@@ -24734,6 +24826,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   crc-32@1.2.2: {}
 
   crc32-stream@6.0.0:
@@ -24868,12 +24965,12 @@ snapshots:
       '@deno/shim-deno': 0.19.2
       undici-types: 5.28.4
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.15.15
       better-sqlite3: 12.6.2
-      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1)
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1)
       mysql2: 3.16.1
 
   db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1):
@@ -25118,29 +25215,29 @@ snapshots:
       '@cloudflare/workers-types': 4.20260313.1
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.15.15
-      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3)
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.16.0
       better-sqlite3: 12.6.2
       kysely: 0.28.10
       mysql2: 3.16.1
       pg: 8.18.0
-      prisma: 6.19.2(magicast@0.5.1)(typescript@5.9.3)
+      prisma: 6.19.2(magicast@0.5.2)(typescript@5.9.3)
       sql.js: 1.14.1
 
-  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1):
+  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260504.1
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.15.15
-      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3)
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.16.0
       better-sqlite3: 12.6.2
       kysely: 0.28.10
       mysql2: 3.16.1
       pg: 8.18.0
-      prisma: 6.19.2(magicast@0.5.1)(typescript@5.9.3)
+      prisma: 6.19.2(magicast@0.5.2)(typescript@5.9.3)
       sql.js: 1.14.1
 
   drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(typescript@5.9.3))(sql.js@1.14.1):
@@ -25148,14 +25245,14 @@ snapshots:
       '@cloudflare/workers-types': 4.20260504.1
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.15.15
-      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3)
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.16.0
       better-sqlite3: 12.6.2
       kysely: 0.28.10
       mysql2: 3.16.1
       pg: 8.18.0
-      prisma: 6.19.2(magicast@0.5.1)(typescript@5.9.3)
+      prisma: 6.19.2(magicast@0.5.2)(typescript@5.9.3)
       sql.js: 1.14.1
     optional: true
 
@@ -25679,6 +25776,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -25720,6 +25823,11 @@ snapshots:
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
 
   express@4.21.2:
     dependencies:
@@ -25920,10 +26028,6 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -26643,6 +26747,8 @@ snapshots:
 
   hex-rgb@4.3.0: {}
 
+  hono@4.12.23: {}
+
   hookable@5.5.3: {}
 
   hookable@6.0.1: {}
@@ -26850,6 +26956,8 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -27066,11 +27174,11 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@babel/parser': 7.28.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -27131,6 +27239,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.1.2: {}
+
+  jose@6.2.3: {}
 
   js-base64@3.7.8: {}
 
@@ -27209,6 +27319,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -27699,7 +27811,7 @@ snapshots:
 
   magicast@0.2.11:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       recast: 0.23.11
 
@@ -27711,7 +27823,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -28439,7 +28551,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.12.9(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)(rolldown@1.0.0-rc.9):
+  nitropack@2.12.9(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)(rolldown@1.0.0-rc.9):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 5.1.1(rollup@4.55.2)
@@ -28451,7 +28563,7 @@ snapshots:
       '@rollup/plugin-terser': 0.4.4(rollup@4.55.2)
       '@vercel/nft': 0.30.4(rollup@4.55.2)
       archiver: 7.0.1
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 4.0.3
       citty: 0.1.6
       compatx: 0.2.0
@@ -28460,7 +28572,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -28479,7 +28591,7 @@ snapshots:
       knitwork: 1.3.0
       listhen: 1.9.0
       magic-string: 0.30.21
-      magicast: 0.5.1
+      magicast: 0.5.2
       mime: 4.1.0
       mlly: 1.8.0
       node-fetch-native: 1.6.7
@@ -28506,7 +28618,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.5.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2)
+      unstorage: 1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2)
       untyped: 2.0.0
       unwasm: 0.3.11
       youch: 4.1.0-beta.13
@@ -28675,19 +28787,19 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.2.2(04bbb6a2e6a204b8765c2f19c5e95cf8):
+  nuxt@4.2.2(3e221778ab8971782bc0f7a4ca093ddf):
     dependencies:
-      '@dxup/nuxt': 0.2.2(magicast@0.5.1)
-      '@nuxt/cli': 3.32.0(cac@6.7.14)(magicast@0.5.1)
+      '@dxup/nuxt': 0.2.2(magicast@0.5.2)
+      '@nuxt/cli': 3.32.0(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.1.1(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.27(typescript@5.9.3))
-      '@nuxt/kit': 4.2.2(magicast@0.5.1)
-      '@nuxt/nitro-server': 4.2.2(fd4cf95c01bb8f8cd9d115c1f2757e90)
+      '@nuxt/kit': 4.2.2(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.2.2(eaa5243872e9c901d1fbc4c0a6799b9e)
       '@nuxt/schema': 4.2.2
-      '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
-      '@nuxt/vite-builder': 4.2.2(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.1)(nuxt@4.2.2(04bbb6a2e6a204b8765c2f19c5e95cf8))(optionator@0.9.4)(oxlint@1.60.0)(rolldown@1.0.0-rc.9)(rollup@4.60.2)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.2(typescript@5.9.3))(vue@3.5.27(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/telemetry': 2.6.6(magicast@0.5.2)
+      '@nuxt/vite-builder': 4.2.2(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.2.2(3e221778ab8971782bc0f7a4ca093ddf))(optionator@0.9.4)(oxlint@1.60.0)(rolldown@1.0.0-rc.9)(rollup@4.60.2)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.2(typescript@5.9.3))(vue@3.5.27(typescript@5.9.3))(yaml@2.9.0)
       '@unhead/vue': 2.0.19(vue@3.5.27(typescript@5.9.3))
       '@vue/shared': 3.5.29
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 5.0.0
       compatx: 0.2.0
       consola: 3.4.2
@@ -29294,6 +29406,8 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pkce-challenge@5.0.1: {}
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -29592,9 +29706,9 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3):
+  prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3):
     dependencies:
-      '@prisma/config': 6.19.2(magicast@0.5.1)
+      '@prisma/config': 6.19.2(magicast@0.5.2)
       '@prisma/engines': 6.19.2
     optionalDependencies:
       typescript: 5.9.3
@@ -29783,7 +29897,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.7.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc9@2.1.2:
@@ -31319,8 +31433,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
@@ -31469,12 +31583,12 @@ snapshots:
       hookable: 6.0.1
       import-without-cache: 0.2.5
       obug: 2.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       rolldown: 1.0.0-rc.3
       rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260414.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)(vue-tsc@3.2.2(typescript@5.9.3))
       semver: 7.7.4
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
       tree-kill: 1.2.2
       unconfig-core: 7.4.2
       unrun: 0.2.27
@@ -31791,7 +31905,7 @@ snapshots:
     dependencies:
       rolldown: 1.0.0-rc.3
 
-  unstorage@1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2):
+  unstorage@1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -31803,7 +31917,7 @@ snapshots:
       ufo: 1.6.1
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)
       ioredis: 5.8.2
 
   unstorage@1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2):
@@ -31925,7 +32039,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.11(e5c271d02af7b7e0e06403adc8ddba12):
+  vinxi@0.5.11(be48bc04fc2d16aa44300f8e21182c16):
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.6)
@@ -31946,7 +32060,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1(debug@4.4.3)
       micromatch: 4.0.8
-      nitropack: 2.12.9(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)(rolldown@1.0.0-rc.9)
+      nitropack: 2.12.9(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1)(rolldown@1.0.0-rc.9)
       node-fetch-native: 1.6.7
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -31958,7 +32072,7 @@ snapshots:
       ufo: 1.6.1
       unctx: 2.4.1
       unenv: 1.10.0
-      unstorage: 1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.1)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2)
+      unstorage: 1.17.3(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260504.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.10)(mysql2@3.16.1)(pg@8.18.0)(prisma@6.19.2(magicast@0.5.2)(typescript@5.9.3))(sql.js@1.14.1))(mysql2@3.16.1))(ioredis@5.8.2)
       vite: 6.4.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       zod: 4.3.5
     transitivePeerDependencies:
@@ -32137,7 +32251,7 @@ snapshots:
 
   vite-plugin-checker@0.12.0(eslint@9.39.2(jiti@2.6.1))(optionator@0.9.4)(oxlint@1.60.0)(typescript@5.9.3)(vite@7.3.2(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.2(typescript@5.9.3)):
     dependencies:
-      '@babel/code-frame': 7.28.6
+      '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1
@@ -32173,7 +32287,7 @@ snapshots:
       uuid: 11.1.0
       vite: 8.0.0(@types/node@24.10.9)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.2.2(magicast@0.5.1))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.2.2(magicast@0.5.2))(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -32186,7 +32300,7 @@ snapshots:
       vite: 8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
       vite-dev-rpc: 1.1.0(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
-      '@nuxt/kit': 4.2.2(magicast@0.5.1)
+      '@nuxt/kit': 4.2.2(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -32207,9 +32321,9 @@ snapshots:
 
   vite-plugin-solid@2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.10(@babel/core@7.28.6)(solid-js@1.9.10)
+      babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@1.9.10)
       merge-anything: 5.1.7
       solid-js: 1.9.10
       solid-refresh: 0.6.3(solid-js@1.9.10)
@@ -32223,9 +32337,9 @@ snapshots:
 
   vite-plugin-solid@2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vite@8.0.0(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.10(@babel/core@7.28.6)(solid-js@1.9.10)
+      babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@1.9.10)
       merge-anything: 5.1.7
       solid-js: 1.9.10
       solid-refresh: 0.6.3(solid-js@1.9.10)
@@ -32252,12 +32366,12 @@ snapshots:
 
   vite-plugin-vue-inspector@5.3.2(vite@8.0.0(@types/node@22.19.7)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@babel/core': 7.28.6
-      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.6)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.6)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.6)
-      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.6)
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.6)
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
       '@vue/compiler-dom': 3.5.29
       kolorist: 1.8.0
       magic-string: 0.30.21


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ESLint rule to simplify JSON-response assertions in tests
  * New MCP fragment: DB-backed server management, CLI, OAuth flows, tool calling, and framework clients (React/Vue/Svelte/Solid/Vanilla)
  * Async-capable client/server helpers and test MCP server for integration testing

* **Bug Fixes**
  * Ensure async transform/retrieve hooks are awaited before subsequent mutation logic

* **Documentation**
  * Initial README and changelog for the MCP fragment

* **Tests**
  * Expanded unit and end-to-end Vitest suites for DB and MCP flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->