### PR TITLE
fix(unplugin): emit stable declaration entrypoints

### DIFF
--- a/packages/unplugin-fragno/tsdown.config.ts
+++ b/packages/unplugin-fragno/tsdown.config.ts
@@ -2,4 +2,5 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   entry: ["src/index.ts", "src/macros.ts", "src/types.ts", "src/integrations/*.ts"],
+  unbundle: true,
 });


### PR DESCRIPTION
## Summary

- enable unbundled output for `@fragno-dev/unplugin-fragno` so each exported entrypoint emits a stable declaration file
- fixes package export targets such as `./vite` pointing at `dist/integrations/vite.d.ts` while the build only produced hashed declaration chunks

## Problem

The published package exports subpaths like `@fragno-dev/unplugin-fragno/vite` with declaration targets such as `./dist/integrations/vite.d.ts`, but the current bundled declaration build emits hashed files like `dist/integrations/vite-e7zsXYyd.d.ts`. In a clean TypeScript project, importing the Vite integration reports that no declaration file can be found for the subpath.

Using `unbundle: true` keeps the JavaScript and declaration entry filenames aligned, so the package export map points at files that are actually shipped.

## Validation

- `corepack pnpm --filter @fragno-dev/unplugin-fragno build`
- `corepack pnpm --filter @fragno-dev/unplugin-fragno types:check`
- `corepack pnpm --filter @fragno-dev/unplugin-fragno test`
- packed the package and installed it in a clean temp project; `import('@fragno-dev/unplugin-fragno/vite')` works and `tsc --noEmit` resolves the subpath declaration with `skipLibCheck` enabled for optional peer declarations
- verified every `package.json` export target exists after build
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the unplugin-fragno package to enable unbundling during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->