### PR TITLE
feat(api-fragment): add webhook receiver endpoints

### DIFF
--- a/.changeset/webhook-receiver-endpoints.md
+++ b/.changeset/webhook-receiver-endpoints.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/api-fragment": patch
+"@fragno-dev/core": patch
+---
+
+feat: add API fragment webhook receiver endpoints.

--- a/apps/backoffice/app/files/content/backoffice-capability-files.test.ts
+++ b/apps/backoffice/app/files/content/backoffice-capability-files.test.ts
@@ -23,45 +23,40 @@ const readSkillName = (skill: string) => {
 };
 
 describe("Backoffice capability system skills", () => {
-  test("capabilities with files contribute one spec-shaped static skill", () => {
+  test("capability skills are spec-shaped static skills", () => {
     for (const capability of backofficeCapabilities) {
       const skillPaths = Object.keys(capability.files ?? {}).filter(
         (path) => path.startsWith("skills/") && path.endsWith("/SKILL.md"),
       );
 
-      if (!capability.files) {
-        expect(skillPaths).toEqual([]);
-        continue;
+      expect(skillPaths).toHaveLength(Object.keys(capability.files ?? {}).length);
+
+      for (const skillPath of skillPaths) {
+        const skill = readSystemText(skillPath);
+        const skillName = readSkillName(skill);
+
+        expect(skillName).toMatch(skillNamePattern);
+        expect(skillPath).toBe(`skills/${skillName}/SKILL.md`);
+        expect(capability.files?.[skillPath]).toBe(skill);
+        expect(skill).toContain("description:");
+        expect(skill).toContain("#");
+        expect(SYSTEM_CONTENT[`skills/${skillName}/references/configuration.md`]).toBeUndefined();
+        expect(SYSTEM_CONTENT[`skills/${skillName}/references/events.md`]).toBeUndefined();
+        expect(SYSTEM_CONTENT[`skills/${skillName}/references/tools.md`]).toBeUndefined();
       }
-
-      expect(skillPaths).toHaveLength(1);
-      const skillPath = skillPaths[0]!;
-      const skill = readSystemText(skillPath);
-      const skillName = readSkillName(skill);
-
-      expect(skillName).toMatch(skillNamePattern);
-      expect(skillPath).toBe(`skills/${skillName}/SKILL.md`);
-      expect(capability.files[skillPath]).toBe(skill);
-      expect(skill).toContain("description:");
-      expect(skill).toContain("#");
-      expect(SYSTEM_CONTENT[`skills/${skillName}/references/configuration.md`]).toBeUndefined();
-      expect(SYSTEM_CONTENT[`skills/${skillName}/references/events.md`]).toBeUndefined();
-      expect(SYSTEM_CONTENT[`skills/${skillName}/references/tools.md`]).toBeUndefined();
     }
   });
 
-  test("skips skills that are covered by system guidance or do not add capability-specific detail", () => {
-    const capabilityIdsWithoutSkills = backofficeCapabilities
-      .filter((capability) => !capability.files)
-      .map((capability) => capability.id);
+  test("some capabilities intentionally rely on general system guidance instead of specific skills", () => {
+    const capabilityIdsWithoutSkills = new Set(
+      backofficeCapabilities
+        .filter((capability) => !capability.files)
+        .map((capability) => capability.id),
+    );
 
-    expect(capabilityIdsWithoutSkills).toEqual([
-      "sandbox",
-      "automations",
-      "github",
-      "cloudflare",
-      "auth",
-    ]);
+    expect(capabilityIdsWithoutSkills).toEqual(
+      new Set(["sandbox", "automations", "github", "cloudflare", "auth"]),
+    );
   });
 
   test("Telegram skill documents its primary event and tools", () => {

--- a/apps/backoffice/app/fragno/api.ts
+++ b/apps/backoffice/app/fragno/api.ts
@@ -11,6 +11,7 @@ export type ApiConfig = Pick<
   | "onConnectionChanged"
   | "onConnectionDeleted"
   | "onConnectionAvailable"
+  | "onWebhookReceived"
 >;
 
 export const resolveApiPublicBaseUrl = ({ baseUrl, orgId }: { baseUrl: string; orgId: string }) => {
@@ -36,6 +37,7 @@ export function createApiServer(
       onConnectionChanged: config.onConnectionChanged,
       onConnectionDeleted: config.onConnectionDeleted,
       onConnectionAvailable: config.onConnectionAvailable,
+      onWebhookReceived: config.onWebhookReceived,
     },
     {
       databaseAdapter: runtime.adapters.createAdapter({

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api-files.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api-files.ts
@@ -124,8 +124,7 @@ Cataloged automation events:
 - \`source\`: \`api\`, \`eventType\`: \`connection.changed\` — fires when an API connection is created or its configuration changes.
 - \`source\`: \`api\`, \`eventType\`: \`connection.deleted\` — fires when an API connection is deleted.
 - \`source\`: \`api\`, \`eventType\`: \`connection.available\` — fires when auth becomes usable after bearer setup, OAuth callback, or client-credentials token acquisition.
-
-Hook payloads include \`connectionId\` and a connection snapshot with \`slug\`, \`name\`, \`baseUrl\`, \`authMode\`, and \`status\`.
+Connection hook payloads include \`connectionId\` and a connection snapshot with \`slug\`, \`name\`, \`baseUrl\`, \`authMode\`, and \`status\`.
 `,
     tools: `# API tools
 
@@ -153,6 +152,7 @@ await api.request({
   headers: { Accept: "application/json" },
   timeoutMs: 30_000,
 });
+
 \`\`\`
 
 Bash runtime commands include \`api.connections.list\`, \`api.connections.create\`, \`api.connections.delete\`, \`api.auth.status\`, \`api.auth.token\`, \`api.oauth.start\`, \`api.auth.delete\`, and \`api.request\`.

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api-webhooks-files.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api-webhooks-files.ts
@@ -1,0 +1,190 @@
+import { skillFiles } from "@/fragno/backoffice-capabilities/backoffice-capabilities";
+
+export const createApiWebhooksCapabilityFiles = () =>
+  skillFiles({
+    name: "api-webhooks",
+    title: "API Webhooks",
+    description:
+      "Configure inbound webhooks received by Backoffice API endpoints. Use when the user wants to receive provider webhooks, asks for a webhook/callback endpoint URL, gives a webhook secret or sample payload, configures webhook authentication/signatures, or wires webhook.received events into automations.",
+    overview:
+      "Use this skill for scope-aware inbound HTTP webhook endpoints, provider delivery IDs, webhook authentication, public webhook URLs, and webhook-triggered automations.",
+    configuration: `# API webhook configuration
+
+Configuration fields:
+
+Initialize the API capability first; webhook endpoints share the same API capability storage and public base URL.
+
+Typical setup flow:
+
+1. Initialize the shared API capability and create a draft endpoint. Assume the user needs a webhook URL before auth, payload, or header details are known. Deduce a good stable lowercase \`endpointId\` from the user's request; this is usually the name of the service you are configuring webhooks for:
+
+\`\`\`js
+const apiCapability = await connections.configure({ id: "api", payload: {} });
+const draft = await api.createWebhookEndpoint({
+  endpointId: "example-provider",
+  name: "Example Provider",
+  status: "draft",
+  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
+  auth: { type: "none" },
+});
+
+return { publicBaseUrl: apiCapability.config?.publicBaseUrl, webhookUrl: draft.publicUrl };
+\`\`\`
+
+Draft endpoints reserve a stable URL and reject deliveries with "not configured yet" until you update them to \`status: "active"\`.
+
+2. Collect the remaining inputs before activating the draft endpoint:
+   - webhook auth type: \`none\`, \`bearer\`, \`apiKey\`, \`basic\`, or \`hmac\`. Typical case is HMAC.
+   - if auth is \`hmac\`: algorithm, signature header/query name, signature encoding, optional prefix, and whether the provider signs the raw body or a timestamped body;
+   - example JSON payload;
+   - relevant delivery/signature headers.
+3. If any auth, signature, payload, header, or delivery identity detail is unknown, keep the endpoint in \`draft\` and ask the user for the missing details. Do not activate the endpoint yet.
+4. Choose \`deliveryIdentity\` from the example payload or headers. Prefer provider delivery ids such as \`webhookId\`, \`event.id\`, \`id\`, or a provider delivery-id header.
+5. Update the draft endpoint with the correct auth configuration, delivery identity, and \`status: "active"\`. Return the exact \`webhook.publicUrl\` from the tool result:
+
+\`\`\`js
+const webhook = await api.updateWebhookEndpoint({
+  endpointId: "example-provider",
+  status: "active",
+  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
+  auth: {
+    type: "hmac",
+    secret: "whs_secret_123",
+    algorithm: "sha256",
+    signature: {
+      location: "header",
+      name: "x-provider-signature",
+      encoding: "hex",
+    },
+    signedPayload: { type: "rawBody" },
+  },
+});
+
+return webhook.publicUrl;
+\`\`\`
+
+6. Tell the user you are standing by to check for deliveries. Once the provider sends a test delivery, verify recent API durable hooks:
+
+\`\`\`js
+await hooks.list({ fragment: "api", pageSize: 10 });
+\`\`\`
+
+Notes:
+- Public receive URLs look like \`/api/http/:orgId/webhooks/endpoints/:endpointId/events\`.
+- Return the exact \`webhook.publicUrl\` after creating or updating an endpoint; do not manually assemble the final URL unless you are only explaining the URL shape before creation.
+
+
+Rules:
+
+- ALWAYS start by immediately setting up a draft endpoint with a good endpointId AND informing the user of the FULL receiving webhook URL. ALWAYS DO THIS.
+- Do not talk about setting up the API connection (i.e. \`connections.get({ id: 'api' })\`) unless something is wrong.
+- Do NOT mention the public base URL. This could confuse the user. Only mention the fully qualified url including the filled in endpointId and orgId. 
+- Do not call \`connections.setup({ id: "api-webhooks" })\`; webhook endpoints use the shared \`api\` capability.
+- Do not guess webhook auth from the word "secret" or "key". If the user says "webhook secret", "signing secret", or gives a secret-shaped webhook key, treat it as likely \`hmac\` and ask for the signature header/encoding/payload details if missing. Use \`bearer\` only when the provider explicitly sends an \`Authorization: Bearer ...\` header.
+- Do not guess the delivery identity when the provider payload/header shape is unknown. 
+- ALWAYS ask the user for an example webhook payload and relevant headers, then choose a stable id that is unique per provider delivery.
+- If auth scheme, signature header, signature encoding, signed payload, or delivery identity is unknown, ask for the missing information before activating the endpoint. Create a draft endpoint first if the user needs the URL.
+- DO NOT GUESS ANYTHING but the endpointId. Ask for all other details before activating the endpoint.
+
+HMAC decision guide:
+
+- \`algorithm\`: ask whether the provider uses \`sha1\`, \`sha256\`, or \`sha512\`.
+- \`signature.location\`: ask whether the signature is in a \`header\` or \`query\` parameter.
+- \`signature.name\`: ask for the exact header or query parameter name.
+- \`signature.encoding\`: ask whether the signature value is \`hex\`, \`base64\`, or \`base64url\`.
+- \`signature.prefix\`: include this only when the provider prefixes the signature value, for example \`sha256=\` or \`v1=\`.
+- \`signedPayload\`: use \`rawBody\` only when the provider signs the raw request body. Use \`timestampBody\` when the provider signs a timestamp joined with the body.
+
+Basic setup example:
+
+\`\`\`js
+const webhook = await api.createWebhookEndpoint({
+  endpointId: "example-provider",
+  name: "Example Provider",
+  status: "active",
+  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
+  auth: { type: "none" },
+});
+
+return webhook.publicUrl;
+\`\`\`
+
+HMAC setup example:
+
+\`\`\`js
+const webhook = await api.createWebhookEndpoint({
+  endpointId: "example-provider",
+  name: "Example Provider",
+  status: "active",
+  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
+  auth: {
+    type: "hmac",
+    secret: "whs_secret_123",
+    algorithm: "sha256",
+    signature: {
+      location: "header",
+      name: "x-provider-signature",
+      encoding: "hex",
+    },
+    signedPayload: { type: "rawBody" },
+  },
+});
+
+return webhook.publicUrl;
+\`\`\`
+`,
+    events: `# API webhook events
+
+Cataloged automation events:
+
+- \`source\`: \`api\`, \`eventType\`: \`webhook.received\` — fires after a configured webhook endpoint accepts and authenticates a delivery.
+
+Webhook payloads include:
+
+- \`endpointId\`
+- \`deliveryId\`
+- \`hookId\`
+- \`receivedAt\`
+- redacted \`headers\`
+- redacted \`query\`
+- parsed JSON \`body\`
+- \`contentType\`
+
+Use \`hookId\` or the automation event id for idempotency. Duplicate provider deliveries with the same endpoint and delivery id produce the same hook id.
+`,
+    tools: `# API webhook tools
+
+API webhook tools can:
+
+- list configured webhook endpoints;
+- inspect a webhook endpoint;
+- create or replace a webhook endpoint;
+- update a webhook endpoint;
+- delete a webhook endpoint.
+
+Use codemode first. The \`api\` provider methods are \`listWebhookEndpoints\`, \`getWebhookEndpoint\`, \`createWebhookEndpoint\`, \`updateWebhookEndpoint\`, and \`deleteWebhookEndpoint\`.
+
+Examples:
+
+\`\`\`js
+await api.listWebhookEndpoints();
+
+const draft = await api.createWebhookEndpoint({
+  endpointId: "example-provider",
+  name: "Example Provider",
+  status: "draft",
+  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
+  auth: { type: "none" },
+});
+
+const webhook = await api.updateWebhookEndpoint({
+  endpointId: draft.id,
+  status: "active",
+  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
+  auth: { type: "none" },
+});
+
+return webhook.publicUrl;
+\`\`\`
+`,
+  });

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api.ts
@@ -6,6 +6,7 @@ import type {
   ConnectionStatus,
 } from "@/fragno/backoffice-capabilities/backoffice-capabilities";
 import { createApiCapabilityFiles } from "@/fragno/backoffice-capabilities/capabilities/api-files";
+import { createApiWebhooksCapabilityFiles } from "@/fragno/backoffice-capabilities/capabilities/api-webhooks-files";
 
 import type { ApiAdminConfigResponse } from "../../../../workers/api.do";
 
@@ -15,6 +16,7 @@ const AUTOMATION_SOURCE = "api" as const;
 const AUTOMATION_EVENT_CONNECTION_CHANGED = "connection.changed" as const;
 const AUTOMATION_EVENT_CONNECTION_DELETED = "connection.deleted" as const;
 const AUTOMATION_EVENT_CONNECTION_AVAILABLE = "connection.available" as const;
+const AUTOMATION_EVENT_WEBHOOK_RECEIVED = "webhook.received" as const;
 
 const apiConnectionSnapshotSchema = z.object({
   slug: z.string().min(1),
@@ -45,6 +47,23 @@ const apiConnectionSubjectSchema = z.object({
   connectionId: z.string().min(1),
 });
 
+const apiWebhookReceivedPayloadSchema = z.object({
+  endpointId: z.string().min(1),
+  deliveryId: z.string().min(1),
+  hookId: z.string().min(1),
+  receivedAt: z.string().min(1),
+  headers: z.record(z.string(), z.string()),
+  query: z.record(z.string(), z.string()),
+  body: z.record(z.string(), z.unknown()),
+  contentType: z.string().nullable(),
+});
+
+const apiWebhookSubjectSchema = z.object({
+  orgId: z.string().min(1),
+  endpointId: z.string().min(1),
+  deliveryId: z.string().min(1),
+});
+
 const capability = { id: "api", label: "API", kind: "connection" } as const;
 const getApiDo = (objects: BackofficeObjectRegistry, orgId: string) => objects.api.forOrg(orgId);
 
@@ -69,7 +88,10 @@ export const apiCapability: BackofficeConfigurableConnectionCapability = {
   ...capability,
   runtimeToolNamespaces: ["api"],
   get files() {
-    return createApiCapabilityFiles();
+    return {
+      ...createApiCapabilityFiles(),
+      ...createApiWebhooksCapabilityFiles(),
+    };
   },
   connection: {
     configurable: true,
@@ -131,6 +153,24 @@ export const apiCapability: BackofficeConfigurableConnectionCapability = {
           authMode: "bearer",
           status: "active",
         },
+      },
+    },
+    {
+      source: AUTOMATION_SOURCE,
+      eventType: AUTOMATION_EVENT_WEBHOOK_RECEIVED,
+      label: "API webhook received",
+      description: "Fires when an API webhook endpoint receives and authenticates a delivery.",
+      payloadSchema: apiWebhookReceivedPayloadSchema,
+      subjectSchema: apiWebhookSubjectSchema,
+      example: {
+        endpointId: "stripe",
+        deliveryId: "evt_123",
+        hookId: "webhook_abc123",
+        receivedAt: "2026-06-23T12:00:00.000Z",
+        headers: { "content-type": "application/json" },
+        query: {},
+        body: { type: "payment_intent.succeeded" },
+        contentType: "application/json",
       },
     },
     {

--- a/apps/backoffice/app/fragno/runtime-tools/families/api-runtime.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/api-runtime.ts
@@ -1,4 +1,10 @@
-import type { ApiConnectionInput, ApiRequestInput } from "@fragno-dev/api-fragment/types";
+import type {
+  ApiConnectionInput,
+  ApiRequestInput,
+  UpdateWebhookEndpointInput,
+  WebhookEndpoint,
+  WebhookEndpointInput,
+} from "@fragno-dev/api-fragment/types";
 import { createRouteCaller } from "@fragno-dev/core/api";
 
 import type { ApiObject } from "@/backoffice-runtime/object-registry";
@@ -17,6 +23,10 @@ import type {
   ApiOAuthStartOutput,
   ApiRequestOutput,
   ApiSetTokenInput,
+  ApiWebhookEndpoint,
+  ApiWebhookEndpointInput,
+  ApiWebhookEndpointsOutput,
+  ApiWebhookEndpointUpdateInput,
 } from "./api";
 
 export type ApiRuntime = {
@@ -28,6 +38,15 @@ export type ApiRuntime = {
   startOAuth: (input: { slug: string } & ApiOAuthStartInput) => Promise<ApiOAuthStartOutput>;
   deleteAuth: (input: { slug: string }) => Promise<{ ok: true }>;
   request: (input: { slug: string } & ApiRequestInput) => Promise<ApiRequestOutput>;
+  listWebhookEndpoints: () => Promise<ApiWebhookEndpointsOutput>;
+  getWebhookEndpoint: (input: { endpointId: string }) => Promise<ApiWebhookEndpoint>;
+  createWebhookEndpoint: (
+    input: { endpointId: string } & ApiWebhookEndpointInput,
+  ) => Promise<ApiWebhookEndpoint>;
+  updateWebhookEndpoint: (
+    input: { endpointId: string } & ApiWebhookEndpointUpdateInput,
+  ) => Promise<ApiWebhookEndpoint>;
+  deleteWebhookEndpoint: (input: { endpointId: string }) => Promise<{ ok: true }>;
 };
 
 export type RegisteredApiCommandContext = {
@@ -50,6 +69,16 @@ const createApiRouteCaller = (options: CreateRouteBackedApiRuntimeOptions) =>
     fetch: options.fetch,
   });
 
+const appendWebhookPublicUrl = (
+  endpoint: WebhookEndpoint,
+  publicBaseUrl: string | null,
+): ApiWebhookEndpoint => ({
+  ...endpoint,
+  publicUrl: publicBaseUrl
+    ? `${publicBaseUrl}/webhooks/endpoints/${encodeURIComponent(endpoint.id)}/events`
+    : null,
+});
+
 const normalizeSlug = (slug: string, label = "API connection slug") => {
   const normalized = slug.trim();
   if (!normalized) {
@@ -68,13 +97,16 @@ const throwOnApiRuntimeError = (
     notConfiguredMessage: API_NOT_CONFIGURED,
   });
 
-const createRouteBackedApiRuntime = (options: CreateRouteBackedApiRuntimeOptions): ApiRuntime => {
+export const createRouteBackedApiRuntime = (
+  options: CreateRouteBackedApiRuntimeOptions & { getPublicBaseUrl?: () => Promise<string | null> },
+): ApiRuntime => {
   const baseUrl = options.baseUrl.trim();
   if (!baseUrl) {
     throw new Error("API runtime requires a base URL");
   }
 
   const callRoute = createApiRouteCaller({ ...options, baseUrl });
+  const getPublicBaseUrl = options.getPublicBaseUrl ?? (async () => null);
 
   return {
     listConnections: async () => {
@@ -154,6 +186,57 @@ const createRouteBackedApiRuntime = (options: CreateRouteBackedApiRuntimeOptions
       }
       return throwOnApiRuntimeError(response, "api.request");
     },
+    listWebhookEndpoints: async () => {
+      const response = await callRoute("GET", "/webhooks/endpoints");
+      if (response.type === "json" && isSuccessStatus(response.status)) {
+        const publicBaseUrl = await getPublicBaseUrl();
+        const data = response.data as { endpoints: WebhookEndpoint[] };
+        return {
+          endpoints: data.endpoints.map((endpoint) =>
+            appendWebhookPublicUrl(endpoint, publicBaseUrl),
+          ),
+        };
+      }
+      return throwOnApiRuntimeError(response, "api.webhooks.list");
+    },
+    getWebhookEndpoint: async ({ endpointId }) => {
+      const response = await callRoute("GET", "/webhooks/endpoints/:endpointId", {
+        pathParams: { endpointId: normalizeSlug(endpointId, "Webhook endpoint id") },
+      });
+      if (response.type === "json" && isSuccessStatus(response.status)) {
+        return appendWebhookPublicUrl(response.data as WebhookEndpoint, await getPublicBaseUrl());
+      }
+      return throwOnApiRuntimeError(response, "api.webhooks.get");
+    },
+    createWebhookEndpoint: async ({ endpointId, ...body }) => {
+      const response = await callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+        pathParams: { endpointId: normalizeSlug(endpointId, "Webhook endpoint id") },
+        body: body satisfies WebhookEndpointInput,
+      });
+      if (response.type === "json" && isSuccessStatus(response.status)) {
+        return appendWebhookPublicUrl(response.data as WebhookEndpoint, await getPublicBaseUrl());
+      }
+      return throwOnApiRuntimeError(response, "api.webhooks.create");
+    },
+    updateWebhookEndpoint: async ({ endpointId, ...body }) => {
+      const response = await callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+        pathParams: { endpointId: normalizeSlug(endpointId, "Webhook endpoint id") },
+        body: body satisfies UpdateWebhookEndpointInput,
+      });
+      if (response.type === "json" && isSuccessStatus(response.status)) {
+        return appendWebhookPublicUrl(response.data as WebhookEndpoint, await getPublicBaseUrl());
+      }
+      return throwOnApiRuntimeError(response, "api.webhooks.update");
+    },
+    deleteWebhookEndpoint: async ({ endpointId }) => {
+      const response = await callRoute("DELETE", "/webhooks/endpoints/:endpointId", {
+        pathParams: { endpointId: normalizeSlug(endpointId, "Webhook endpoint id") },
+      });
+      if (isSuccessStatus(response.status)) {
+        return { ok: true };
+      }
+      return throwOnApiRuntimeError(response, "api.webhooks.delete");
+    },
   };
 };
 
@@ -161,6 +244,10 @@ export const createApiRuntime = (object: ApiObject) =>
   createRouteBackedApiRuntime({
     baseUrl: "https://api.do",
     fetch: async (outboundRequest) => object.fetch(outboundRequest),
+    getPublicBaseUrl: async () => {
+      const config = await object.getAdminConfig();
+      return config.configured ? (config.config?.publicBaseUrl ?? null) : null;
+    },
   });
 
 export const createUnavailableApiRuntime = (message = API_NOT_CONFIGURED): ApiRuntime => ({
@@ -186,6 +273,21 @@ export const createUnavailableApiRuntime = (message = API_NOT_CONFIGURED): ApiRu
     throw new Error(message);
   },
   request: async () => {
+    throw new Error(message);
+  },
+  listWebhookEndpoints: async () => {
+    throw new Error(message);
+  },
+  getWebhookEndpoint: async () => {
+    throw new Error(message);
+  },
+  createWebhookEndpoint: async () => {
+    throw new Error(message);
+  },
+  updateWebhookEndpoint: async () => {
+    throw new Error(message);
+  },
+  deleteWebhookEndpoint: async () => {
     throw new Error(message);
   },
 });

--- a/apps/backoffice/app/fragno/runtime-tools/families/api.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/api.ts
@@ -1,3 +1,8 @@
+import {
+  createWebhookEndpointInputSchema as apiFragmentCreateWebhookEndpointInputSchema,
+  updateWebhookEndpointInputSchema as apiFragmentUpdateWebhookEndpointInputSchema,
+  webhookEndpointOutputSchema,
+} from "@fragno-dev/api-fragment/types";
 import { z } from "zod";
 
 import {
@@ -91,6 +96,18 @@ const requestOutputSchema = z.object({
   body: z.unknown().nullable(),
 });
 
+const webhookEndpointSchema = webhookEndpointOutputSchema.extend({
+  publicUrl: z.string().url().nullable(),
+});
+const webhookEndpointsOutputSchema = z.object({ endpoints: z.array(webhookEndpointSchema) });
+const webhookEndpointCreateInputSchema = apiFragmentCreateWebhookEndpointInputSchema.extend({
+  endpointId: z.string().trim().min(1),
+});
+const webhookEndpointUpdateInputSchema = apiFragmentUpdateWebhookEndpointInputSchema.extend({
+  endpointId: z.string().trim().min(1),
+});
+const endpointInputSchema = z.object({ endpointId: z.string().trim().min(1) });
+
 export type ApiConnection = z.infer<typeof connectionSchema>;
 export type ApiListConnectionsOutput = z.infer<typeof connectionsOutputSchema>;
 export type ApiAuthStatus = z.infer<typeof authStatusSchema>;
@@ -98,6 +115,16 @@ export type ApiSetTokenInput = Omit<z.infer<typeof setTokenInputSchema>, "slug">
 export type ApiOAuthStartInput = Omit<z.infer<typeof oauthStartInputSchema>, "slug">;
 export type ApiOAuthStartOutput = z.infer<typeof oauthStartOutputSchema>;
 export type ApiRequestOutput = z.infer<typeof requestOutputSchema>;
+export type ApiWebhookEndpoint = z.infer<typeof webhookEndpointSchema>;
+export type ApiWebhookEndpointsOutput = z.infer<typeof webhookEndpointsOutputSchema>;
+export type ApiWebhookEndpointInput = Omit<
+  z.infer<typeof webhookEndpointCreateInputSchema>,
+  "endpointId"
+>;
+export type ApiWebhookEndpointUpdateInput = Omit<
+  z.infer<typeof webhookEndpointUpdateInputSchema>,
+  "endpointId"
+>;
 export type { ApiRuntime } from "./api-runtime";
 
 type ApiToolContext = BackofficeToolContext<{ api?: ApiRuntime }>;
@@ -172,6 +199,17 @@ const renderRequest = (result: ApiRequestOutput) => {
   const body = typeof result.body === "string" ? result.body : JSON.stringify(result.body, null, 2);
   return [`${result.status} ${result.statusText}`, body].filter(Boolean).join("\n");
 };
+
+const renderWebhookEndpointRows = (endpoints: readonly ApiWebhookEndpoint[]) =>
+  renderTable(
+    ["endpoint", "name", "status", "public URL"],
+    endpoints.map((endpoint) => [endpoint.id, endpoint.name, endpoint.status, endpoint.publicUrl]),
+  );
+
+const renderWebhookEndpoints = (result: ApiWebhookEndpointsOutput) =>
+  result.endpoints.length
+    ? renderWebhookEndpointRows(result.endpoints)
+    : "No API webhook endpoints configured.";
 
 const parseScopes = (value: string | undefined) =>
   value
@@ -261,12 +299,37 @@ const parseRequest = defineCliArgsParser<z.input<typeof requestInputSchema>>("ap
   body: { option: "body" },
   timeoutMs: { option: "timeout-ms", kind: "integer" },
 });
+const parseEndpoint = defineCliArgsParser<{ endpointId: string }>("api.webhooks.endpoint", {
+  endpointId: { required: true, option: "endpoint" },
+});
+const parseWebhookCreate = defineCliArgsParser<z.input<typeof webhookEndpointCreateInputSchema>>(
+  "api.webhooks.create",
+  {
+    endpointId: { required: true, option: "endpoint" },
+    name: { required: true },
+    status: {},
+    deliveryIdentity: { required: true, option: "delivery-identity-json", kind: "json" },
+    auth: { required: true, option: "auth-json", kind: "json" },
+  },
+);
+const parseWebhookUpdate = defineCliArgsParser<z.input<typeof webhookEndpointUpdateInputSchema>>(
+  "api.webhooks.update",
+  {
+    endpointId: { required: true, option: "endpoint" },
+    name: {},
+    status: {},
+    deliveryIdentity: { option: "delivery-identity-json", kind: "json" },
+    auth: { option: "auth-json", kind: "json" },
+  },
+);
 
 const apiPermissions = {
   "connections.read": "Read API connection configuration and auth status.",
   "connections.create": "Create API connections and auth state.",
   "connections.delete": "Delete API connections and auth state.",
   "requests.execute": "Execute HTTP requests through configured API connections.",
+  "webhooks.read": "Read API webhook endpoint configuration.",
+  "webhooks.manage": "Create, update, and delete API webhook endpoints.",
 } as const;
 
 export const apiRuntimeTools = [
@@ -589,6 +652,222 @@ export const apiRuntimeTools = [
         parse: parseSlug,
         outputOptions: defaultOutput,
         format: textOrDataFormat(() => "Deleted API connection auth."),
+      },
+    },
+  }),
+  defineBackofficeRuntimeTool({
+    id: "api.webhooks.list",
+    namespace: "api",
+    name: "listWebhookEndpoints",
+    capabilityId: "api",
+    description: "List API webhook endpoints configured for the current scope.",
+    requiredPermissions: ["webhooks.read"],
+    inputSchema: z.object({}).optional().default({}),
+    outputSchema: webhookEndpointsOutputSchema,
+    execute: async (_input, context: ApiToolContext) =>
+      await getApiRuntime(context.runtimes.api).listWebhookEndpoints(),
+    adapters: {
+      bash: {
+        command: "api.webhooks.list",
+        help: {
+          summary: "api.webhooks.list lists configured API webhook endpoints.",
+          options: [],
+          examples: ["api.webhooks.list"],
+        },
+        parse: defineEmptyArgsParser("api.webhooks.list"),
+        outputOptions: defaultOutput,
+        format: textOrDataFormat(renderWebhookEndpoints),
+      },
+    },
+  }),
+  defineBackofficeRuntimeTool({
+    id: "api.webhooks.get",
+    namespace: "api",
+    name: "getWebhookEndpoint",
+    capabilityId: "api",
+    description: "Read an API webhook endpoint.",
+    requiredPermissions: ["webhooks.read"],
+    getResource: (input) => ({ endpointId: input.endpointId }),
+    inputSchema: endpointInputSchema,
+    outputSchema: webhookEndpointSchema,
+    execute: async (input, context: ApiToolContext) =>
+      await getApiRuntime(context.runtimes.api).getWebhookEndpoint(input),
+    adapters: {
+      bash: {
+        command: "api.webhooks.get",
+        help: {
+          summary: "api.webhooks.get shows an API webhook endpoint.",
+          options: [
+            {
+              name: "endpoint",
+              required: true,
+              valueRequired: true,
+              valueName: "id",
+              description: "Endpoint id",
+            },
+          ],
+          examples: ["api.webhooks.get --endpoint stripe"],
+        },
+        parse: parseEndpoint,
+        outputOptions: defaultOutput,
+        format: textOrDataFormat((endpoint: ApiWebhookEndpoint) =>
+          renderWebhookEndpointRows([endpoint]),
+        ),
+      },
+    },
+  }),
+  defineBackofficeRuntimeTool({
+    id: "api.webhooks.create",
+    namespace: "api",
+    name: "createWebhookEndpoint",
+    capabilityId: "api",
+    description: "Create or replace an API webhook endpoint.",
+    requiredPermissions: ["webhooks.manage"],
+    getResource: (input) => ({ endpointId: input.endpointId }),
+    inputSchema: webhookEndpointCreateInputSchema,
+    outputSchema: webhookEndpointSchema,
+    execute: async (input, context: ApiToolContext) =>
+      await getApiRuntime(context.runtimes.api).createWebhookEndpoint(input),
+    adapters: {
+      bash: {
+        command: "api.webhooks.create",
+        help: {
+          summary: "api.webhooks.create configures an API webhook endpoint.",
+          options: [
+            {
+              name: "endpoint",
+              required: true,
+              valueRequired: true,
+              valueName: "id",
+              description: "Endpoint id",
+            },
+            {
+              name: "name",
+              required: true,
+              valueRequired: true,
+              valueName: "name",
+              description: "Display name",
+            },
+            {
+              name: "status",
+              valueRequired: true,
+              valueName: "draft|active|disabled",
+              description: "Endpoint status",
+            },
+            {
+              name: "delivery-identity-json",
+              required: true,
+              valueRequired: true,
+              valueName: "json",
+              description: "Delivery id extractor",
+            },
+            {
+              name: "auth-json",
+              required: true,
+              valueRequired: true,
+              valueName: "json",
+              description: "Webhook auth config with secret values",
+            },
+          ],
+          examples: [
+            'api.webhooks.create --endpoint stripe --name Stripe --delivery-identity-json \'{"type":"header","name":"stripe-signature"}\' --auth-json \'{"type":"none"}\'',
+          ],
+        },
+        parse: parseWebhookCreate,
+        outputOptions: defaultOutput,
+        format: textOrDataFormat(
+          (endpoint: ApiWebhookEndpoint) =>
+            `Created API webhook endpoint\n\n${renderWebhookEndpointRows([endpoint])}`,
+        ),
+      },
+    },
+  }),
+  defineBackofficeRuntimeTool({
+    id: "api.webhooks.update",
+    namespace: "api",
+    name: "updateWebhookEndpoint",
+    capabilityId: "api",
+    description: "Update an API webhook endpoint.",
+    requiredPermissions: ["webhooks.manage"],
+    getResource: (input) => ({ endpointId: input.endpointId }),
+    inputSchema: webhookEndpointUpdateInputSchema,
+    outputSchema: webhookEndpointSchema,
+    execute: async (input, context: ApiToolContext) =>
+      await getApiRuntime(context.runtimes.api).updateWebhookEndpoint(input),
+    adapters: {
+      bash: {
+        command: "api.webhooks.update",
+        help: {
+          summary: "api.webhooks.update updates an API webhook endpoint.",
+          options: [
+            {
+              name: "endpoint",
+              required: true,
+              valueRequired: true,
+              valueName: "id",
+              description: "Endpoint id",
+            },
+            { name: "name", valueRequired: true, valueName: "name", description: "Display name" },
+            {
+              name: "status",
+              valueRequired: true,
+              valueName: "draft|active|disabled",
+              description: "Endpoint status",
+            },
+            {
+              name: "delivery-identity-json",
+              valueRequired: true,
+              valueName: "json",
+              description: "Delivery id extractor",
+            },
+            {
+              name: "auth-json",
+              valueRequired: true,
+              valueName: "json",
+              description: "Webhook auth config with secret values",
+            },
+          ],
+          examples: ["api.webhooks.update --endpoint stripe --status disabled"],
+        },
+        parse: parseWebhookUpdate,
+        outputOptions: defaultOutput,
+        format: textOrDataFormat((endpoint: ApiWebhookEndpoint) =>
+          renderWebhookEndpointRows([endpoint]),
+        ),
+      },
+    },
+  }),
+  defineBackofficeRuntimeTool({
+    id: "api.webhooks.delete",
+    namespace: "api",
+    name: "deleteWebhookEndpoint",
+    capabilityId: "api",
+    description: "Delete an API webhook endpoint.",
+    requiredPermissions: ["webhooks.manage"],
+    getResource: (input) => ({ endpointId: input.endpointId }),
+    inputSchema: endpointInputSchema,
+    outputSchema: deleteOutputSchema,
+    execute: async (input, context: ApiToolContext) =>
+      await getApiRuntime(context.runtimes.api).deleteWebhookEndpoint(input),
+    adapters: {
+      bash: {
+        command: "api.webhooks.delete",
+        help: {
+          summary: "api.webhooks.delete removes an API webhook endpoint.",
+          options: [
+            {
+              name: "endpoint",
+              required: true,
+              valueRequired: true,
+              valueName: "id",
+              description: "Endpoint id",
+            },
+          ],
+          examples: ["api.webhooks.delete --endpoint stripe"],
+        },
+        parse: parseEndpoint,
+        outputOptions: defaultOutput,
+        format: textOrDataFormat(() => "Deleted API webhook endpoint."),
       },
     },
   }),

--- a/apps/backoffice/app/routes/api/api.ts
+++ b/apps/backoffice/app/routes/api/api.ts
@@ -12,6 +12,19 @@ type RouteContext = Route.LoaderArgs["context"];
 const API_INTERNAL_PREFIX = "/api/api";
 const API_PUBLIC_PREFIX = "/api/http";
 
+const isPublicWebhookReceiveRequest = (request: Request, orgId: string) => {
+  if (request.method !== "POST") {
+    return false;
+  }
+  const url = new URL(request.url);
+  const prefix = `${API_PUBLIC_PREFIX}/${orgId}/webhooks/endpoints/`;
+  if (!url.pathname.startsWith(prefix)) {
+    return false;
+  }
+  const [endpointId, tail, ...rest] = url.pathname.slice(prefix.length).split("/");
+  return Boolean(endpointId) && tail === "events" && rest.length === 0;
+};
+
 const forwardToApi = async (request: Request, context: RouteContext, orgId: string | undefined) => {
   if (!orgId) {
     return new Response("Missing organisation id", { status: 400 });
@@ -21,7 +34,10 @@ const forwardToApi = async (request: Request, context: RouteContext, orgId: stri
     return handleBackofficeApiOAuthCallback(request, context, orgId);
   }
 
-  const auth = await authorizeAccessTokenForOrganization(request, context, orgId);
+  const isPublicWebhookReceive = isPublicWebhookReceiveRequest(request, orgId);
+  const auth = isPublicWebhookReceive
+    ? { ok: true as const, headers: [] }
+    : await authorizeAccessTokenForOrganization(request, context, orgId);
   if (!auth.ok) {
     return auth.response;
   }

--- a/apps/backoffice/app/routes/backoffice/internals/durable-hooks-organisation-redirect.tsx
+++ b/apps/backoffice/app/routes/backoffice/internals/durable-hooks-organisation-redirect.tsx
@@ -6,7 +6,7 @@ import {
   isDurableHookOrgFragment,
 } from "./durable-hooks-organisation-state";
 
-const DEFAULT_FRAGMENT: DurableHooksOrgFragment = "pi";
+const DEFAULT_FRAGMENT: DurableHooksOrgFragment = "api";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   if (!params.orgId) {

--- a/apps/backoffice/app/routes/backoffice/internals/durable-hooks-organisation-state.ts
+++ b/apps/backoffice/app/routes/backoffice/internals/durable-hooks-organisation-state.ts
@@ -1,4 +1,5 @@
 export type DurableHooksOrgFragment =
+  | "api"
   | "cloudflare"
   | "telegram"
   | "mcp"
@@ -11,6 +12,7 @@ export type DurableHooksOrgFragment =
   | "pi-workflows";
 
 export const DURABLE_HOOK_ORG_FRAGMENTS = [
+  "api",
   "cloudflare",
   "telegram",
   "mcp",
@@ -24,6 +26,7 @@ export const DURABLE_HOOK_ORG_FRAGMENTS = [
 ] as const satisfies DurableHooksOrgFragment[];
 
 export const FRAGMENT_LABELS: Record<DurableHooksOrgFragment, string> = {
+  api: "API",
   cloudflare: "Cloudflare Workers",
   telegram: "Telegram",
   mcp: "MCP",
@@ -43,6 +46,10 @@ export const FRAGMENT_CONFIGURE_META: Record<
     label: string;
   }
 > = {
+  api: {
+    path: () => "/backoffice/connections",
+    label: "Configure API",
+  },
   cloudflare: {
     path: () => "/backoffice/environments/workers",
     label: "Open Workers control plane",

--- a/apps/backoffice/app/routes/backoffice/internals/durable-hooks-organisation.tsx
+++ b/apps/backoffice/app/routes/backoffice/internals/durable-hooks-organisation.tsx
@@ -6,6 +6,7 @@ import { BackofficePageHeader } from "@/components/backoffice";
 import { getAuthMe } from "@/fragno/auth/auth-server";
 import type { DurableHookQueueEntry, DurableHookQueueResponse } from "@/fragno/durable-hooks";
 import {
+  getApiDurableObject,
   getCloudflareWorkersDurableObject,
   getAutomationsDurableObject,
   getGitHubDurableObject,
@@ -91,6 +92,13 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   try {
     const queueData = await (async (): Promise<DurableHookQueueResponse> => {
       switch (fragment) {
+        case "api": {
+          const repository = await getApiDurableObject(
+            context,
+            params.orgId,
+          ).getDurableHookRepository();
+          return await repository.getHookQueue({ cursor, pageSize });
+        }
         case "cloudflare": {
           const repository = await getCloudflareWorkersDurableObject(
             context,

--- a/apps/backoffice/app/routes/backoffice/internals/durable-hooks.tsx
+++ b/apps/backoffice/app/routes/backoffice/internals/durable-hooks.tsx
@@ -4,6 +4,8 @@ import { Link, useNavigate, useOutletContext } from "react-router";
 import { BackofficePageHeader } from "@/components/backoffice";
 import type { BackofficeLayoutContext } from "@/layouts/backoffice-layout";
 
+import { DURABLE_HOOK_ORG_FRAGMENTS, FRAGMENT_LABELS } from "./durable-hooks-organisation-state";
+
 export function meta() {
   return [
     { title: "Backoffice Durable Hooks" },
@@ -83,15 +85,11 @@ export default function BackofficeDurableHooksLanding() {
           ) : (
             organizations.map(({ organization }) => {
               const organizationPath = `/backoffice/internals/durable-hooks/${organization.id}`;
-              const cloudflarePath = `${organizationPath}/cloudflare`;
-              const telegramPath = `${organizationPath}/telegram`;
-              const mcpPath = `${organizationPath}/mcp`;
-              const resendPath = `${organizationPath}/resend`;
-              const githubPath = `${organizationPath}/github`;
-              const uploadPath = `${organizationPath}/upload`;
-              const piPath = `${organizationPath}/pi`;
-              const piWorkflowsPath = `${organizationPath}/pi-workflows`;
-              const automationsPath = `${organizationPath}/automations`;
+              const fragmentLinks = DURABLE_HOOK_ORG_FRAGMENTS.map((fragment) => ({
+                id: fragment,
+                label: FRAGMENT_LABELS[fragment],
+                to: `${organizationPath}/${fragment}`,
+              }));
               const handleOrgClick = () => {
                 void navigate(organizationPath);
               };
@@ -123,69 +121,16 @@ export default function BackofficeDurableHooksLanding() {
                   </div>
 
                   <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
-                    <Link
-                      to={cloudflarePath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      Workers
-                    </Link>
-                    <Link
-                      to={telegramPath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      Telegram
-                    </Link>
-                    <Link
-                      to={mcpPath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      MCP
-                    </Link>
-                    <Link
-                      to={resendPath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      Resend
-                    </Link>
-                    <Link
-                      to={githubPath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      GitHub
-                    </Link>
-                    <Link
-                      to={uploadPath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      Upload
-                    </Link>
-                    <Link
-                      to={piPath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      Pi
-                    </Link>
-                    <Link
-                      to={piWorkflowsPath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      Pi workflows
-                    </Link>
-                    <Link
-                      to={automationsPath}
-                      onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
-                      className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-                    >
-                      Automations
-                    </Link>
+                    {fragmentLinks.map((fragment) => (
+                      <Link
+                        key={fragment.id}
+                        to={fragment.to}
+                        onClick={(event: MouseEvent<HTMLAnchorElement>) => event.stopPropagation()}
+                        className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
+                      >
+                        {fragment.label}
+                      </Link>
+                    ))}
                   </div>
                 </div>
               );

--- a/apps/backoffice/workers/api.do.ts
+++ b/apps/backoffice/workers/api.do.ts
@@ -74,6 +74,12 @@ const buildConnectionAvailableEventId = (input: {
   idempotencyKey: string;
 }) => `api:connection.available:${input.orgId}:${input.connectionId}:${input.idempotencyKey}`;
 
+const buildWebhookReceivedEventId = (input: {
+  orgId: string;
+  endpointId: string;
+  hookId: string;
+}) => `api:webhook.received:${input.orgId}:${input.endpointId}:${input.hookId}`;
+
 function buildConfigResponse(
   env: ApiObjectEnv,
   config: StoredApiConfig | null,
@@ -173,6 +179,27 @@ export class InMemoryApiObject implements ApiObject {
             subject: {
               orgId: stored.orgId,
               connectionId: payload.connectionId,
+            },
+          });
+        },
+        onWebhookReceived: async (payload) => {
+          await this.#runtimeServices.objects.automations.forOrg(stored.orgId).ingestEvent({
+            id: buildWebhookReceivedEventId({
+              orgId: stored.orgId,
+              endpointId: payload.endpointId,
+              hookId: payload.hookId,
+            }),
+            scope: { kind: "org", orgId: stored.orgId },
+            source: "api",
+            eventType: "webhook.received",
+            occurredAt: payload.receivedAt,
+            payload: { ...payload },
+            actor: AUTOMATION_SYSTEM_ACTOR,
+            actors: [AUTOMATION_SYSTEM_ACTOR],
+            subject: {
+              orgId: stored.orgId,
+              endpointId: payload.endpointId,
+              deliveryId: payload.deliveryId,
             },
           });
         },

--- a/packages/api-fragment/package.json
+++ b/packages/api-fragment/package.json
@@ -60,6 +60,11 @@
       "types": "./dist/node/api-types.d.ts",
       "default": "./dist/node/api-types.js"
     },
+    "./webhooks/auth": {
+      "development": "./src/webhooks/auth.ts",
+      "types": "./dist/node/webhooks/auth.d.ts",
+      "default": "./dist/node/webhooks/auth.js"
+    },
     "./dist/node/api-types.js": {
       "types": "./dist/node/api-types.d.ts",
       "default": "./dist/node/api-types.js"

--- a/packages/api-fragment/src/api-types.ts
+++ b/packages/api-fragment/src/api-types.ts
@@ -126,10 +126,12 @@ export const webhookEndpointAuthInputSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
+export const webhookEndpointStatusSchema = z.enum(["draft", "active", "disabled"]);
+
 export const webhookEndpointOutputSchema = z.object({
   id: z.string(),
   name: z.string(),
-  status: z.enum(["active", "disabled"]),
+  status: webhookEndpointStatusSchema,
   authConfig: webhookAuthConfigSchema,
   deliveryIdentity: webhookDeliveryIdentitySchema,
   secretRefs: z.array(z.string()),
@@ -139,14 +141,14 @@ export const webhookEndpointOutputSchema = z.object({
 
 export const createWebhookEndpointInputSchema = z.object({
   name: z.string().min(1),
-  status: z.enum(["active", "disabled"]).default("active"),
+  status: webhookEndpointStatusSchema.default("active"),
   deliveryIdentity: webhookDeliveryIdentitySchema,
   auth: webhookEndpointAuthInputSchema,
 });
 
 export const updateWebhookEndpointInputSchema = z.object({
   name: z.string().min(1).optional(),
-  status: z.enum(["active", "disabled"]).optional(),
+  status: webhookEndpointStatusSchema.optional(),
   deliveryIdentity: webhookDeliveryIdentitySchema.optional(),
   auth: webhookEndpointAuthInputSchema.optional(),
 });

--- a/packages/api-fragment/src/api-types.ts
+++ b/packages/api-fragment/src/api-types.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { webhookAuthConfigSchema } from "./webhooks/auth";
+
 export interface ApiFragmentConfig {
   /** Public URL where this fragment is mounted; used to build OAuth redirects. */
   publicBaseUrl: string;
@@ -76,7 +78,85 @@ export const apiRequestInputSchema = z
     path: ["body"],
   });
 
+const webhookSecretRefSchema = z.string().trim().min(1);
+const webhookRequestValueNameSchema = z.string().trim().min(1);
+
+export const webhookDeliveryIdentitySchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("header"), name: webhookRequestValueNameSchema }),
+  z.object({ type: z.literal("query"), name: webhookRequestValueNameSchema }),
+  z.object({
+    type: z.literal("jsonBodyPath"),
+    path: z.array(z.string().trim().min(1)).min(1),
+  }),
+]);
+
+export const webhookEndpointAuthInputSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("none") }),
+  z.object({ type: z.literal("bearer"), token: webhookSecretRefSchema }),
+  z.object({
+    type: z.literal("apiKey"),
+    location: z.enum(["header", "query"]),
+    name: webhookRequestValueNameSchema,
+    secret: webhookSecretRefSchema,
+  }),
+  z.object({
+    type: z.literal("basic"),
+    username: webhookSecretRefSchema,
+    password: webhookSecretRefSchema,
+  }),
+  z.object({
+    type: z.literal("hmac"),
+    secret: webhookSecretRefSchema,
+    algorithm: z.enum(["sha1", "sha256", "sha512"]),
+    signature: z.object({
+      location: z.enum(["header", "query"]),
+      name: webhookRequestValueNameSchema,
+      encoding: z.enum(["hex", "base64", "base64url"]),
+      prefix: z.string().optional(),
+    }),
+    signedPayload: z.discriminatedUnion("type", [
+      z.object({ type: z.literal("rawBody") }),
+      z.object({
+        type: z.literal("timestampBody"),
+        timestampHeader: webhookRequestValueNameSchema,
+        delimiter: z.string(),
+        toleranceSeconds: z.number().int().positive(),
+      }),
+    ]),
+  }),
+]);
+
+export const webhookEndpointOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(["active", "disabled"]),
+  authConfig: webhookAuthConfigSchema,
+  deliveryIdentity: webhookDeliveryIdentitySchema,
+  secretRefs: z.array(z.string()),
+  createdAt: z.union([z.string(), z.date()]).optional(),
+  updatedAt: z.union([z.string(), z.date()]).optional(),
+});
+
+export const createWebhookEndpointInputSchema = z.object({
+  name: z.string().min(1),
+  status: z.enum(["active", "disabled"]).default("active"),
+  deliveryIdentity: webhookDeliveryIdentitySchema,
+  auth: webhookEndpointAuthInputSchema,
+});
+
+export const updateWebhookEndpointInputSchema = z.object({
+  name: z.string().min(1).optional(),
+  status: z.enum(["active", "disabled"]).optional(),
+  deliveryIdentity: webhookDeliveryIdentitySchema.optional(),
+  auth: webhookEndpointAuthInputSchema.optional(),
+});
+
 export type AuthConfig = z.infer<typeof authConfigSchema>;
 export type ApiConnectionInput = z.infer<typeof createApiConnectionInputSchema>;
 export type ApiConnection = z.infer<typeof apiConnectionOutputSchema>;
 export type ApiRequestInput = z.infer<typeof apiRequestInputSchema>;
+export type WebhookDeliveryIdentity = z.infer<typeof webhookDeliveryIdentitySchema>;
+export type WebhookEndpointAuthInput = z.infer<typeof webhookEndpointAuthInputSchema>;
+export type WebhookEndpointInput = z.infer<typeof createWebhookEndpointInputSchema>;
+export type UpdateWebhookEndpointInput = z.infer<typeof updateWebhookEndpointInputSchema>;
+export type WebhookEndpoint = z.infer<typeof webhookEndpointOutputSchema>;

--- a/packages/api-fragment/src/crypto.ts
+++ b/packages/api-fragment/src/crypto.ts
@@ -1,0 +1,177 @@
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export type HmacAlgorithm = "sha1" | "sha256" | "sha512";
+
+const hmacHashName = (algorithm: HmacAlgorithm) =>
+  ({
+    sha1: "SHA-1",
+    sha256: "SHA-256",
+    sha512: "SHA-512",
+  })[algorithm];
+
+export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+export function utf8Bytes(value: string) {
+  return textEncoder.encode(value);
+}
+
+export function assertAscii(value: string, label: string) {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value.charCodeAt(index) > 0x7f) {
+      throw new Error(`${label} must contain ASCII characters only`);
+    }
+  }
+}
+
+export function asciiToBase64(value: string, label: string) {
+  assertAscii(value, label);
+  return btoa(value);
+}
+
+export function bytesToBase64(bytes: Uint8Array) {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export function bytesToBase64Url(bytes: Uint8Array) {
+  return bytesToBase64(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function bytesToHex(bytes: Uint8Array) {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function decodeHex(value: string) {
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length % 2 !== 0 || /[^0-9a-f]/i.test(normalized)) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(normalized.length / 2);
+  for (let index = 0; index < normalized.length; index += 2) {
+    bytes[index / 2] = Number.parseInt(normalized.slice(index, index + 2), 16);
+  }
+  return bytes;
+}
+
+export function decodeBase64(value: string, encoding: "base64" | "base64url") {
+  const normalized = normalizeBase64(value, encoding);
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    const binary = atob(normalized);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+export function decodeBase64ToText(value: string, encoding: "base64" | "base64url") {
+  const bytes = decodeBase64(value, encoding);
+  if (!bytes) {
+    return null;
+  }
+
+  return textDecoder.decode(bytes);
+}
+
+export function normalizeBase64(value: string, encoding: "base64" | "base64url") {
+  let normalized = value.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  if (encoding === "base64url") {
+    normalized = normalized.replace(/-/g, "+").replace(/_/g, "/");
+  }
+
+  const paddingLength = (4 - (normalized.length % 4)) % 4;
+  return `${normalized}${"=".repeat(paddingLength)}`;
+}
+
+export function randomBase64Url(bytes = 32) {
+  const data = new Uint8Array(bytes);
+  crypto.getRandomValues(data);
+  return bytesToBase64Url(data);
+}
+
+export async function sha256Bytes(bytes: Uint8Array) {
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", toArrayBuffer(bytes)));
+}
+
+export async function sha256Base64Url(value: string) {
+  return bytesToBase64Url(await sha256Bytes(utf8Bytes(value)));
+}
+
+export async function importHmacKey(input: { algorithm: HmacAlgorithm; secret: string }) {
+  return await crypto.subtle.importKey(
+    "raw",
+    toArrayBuffer(utf8Bytes(input.secret)),
+    { name: "HMAC", hash: hmacHashName(input.algorithm) },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+export async function signHmacBytes(input: {
+  algorithm: HmacAlgorithm;
+  secret: string;
+  payload: Uint8Array;
+}) {
+  const key = await importHmacKey(input);
+  return new Uint8Array(await crypto.subtle.sign("HMAC", key, toArrayBuffer(input.payload)));
+}
+
+export async function verifyHmacSignature(input: {
+  algorithm: HmacAlgorithm;
+  secret: string;
+  payload: Uint8Array;
+  signature: Uint8Array;
+}) {
+  const key = await importHmacKey(input);
+  return await crypto.subtle.verify(
+    "HMAC",
+    key,
+    toArrayBuffer(input.signature),
+    toArrayBuffer(input.payload),
+  );
+}
+
+export async function digestEqual(first: Uint8Array, second: Uint8Array) {
+  const [firstDigest, secondDigest] = await Promise.all([sha256Bytes(first), sha256Bytes(second)]);
+  return equalLengthBytes(firstDigest, secondDigest);
+}
+
+function equalLengthBytes(first: Uint8Array, second: Uint8Array) {
+  if (first.length !== second.length) {
+    return false;
+  }
+
+  let diff = 0;
+  for (let index = 0; index < first.length; index += 1) {
+    diff |= first[index]! ^ second[index]!;
+  }
+  return diff === 0;
+}
+
+export async function timingSafeEqualText(first: string, second: string) {
+  return await digestEqual(utf8Bytes(first), utf8Bytes(second));
+}
+
+export async function timingSafeEqualBytes(first: Uint8Array, second: Uint8Array) {
+  return await digestEqual(first, second);
+}

--- a/packages/api-fragment/src/definition.ts
+++ b/packages/api-fragment/src/definition.ts
@@ -37,6 +37,29 @@ export interface ApiConnectionAvailablePayload {
   authMode: string;
 }
 
+interface InternalWebhookReceivedPayload {
+  endpointId: string;
+  deliveryId: string;
+  hookId: string;
+  receivedAt: string;
+  headers: Record<string, string>;
+  query: Record<string, string>;
+  rawBody: string;
+  body: Record<string, unknown>;
+  contentType: string | null;
+}
+
+export interface WebhookReceivedPayload {
+  endpointId: string;
+  deliveryId: string;
+  hookId: string;
+  receivedAt: string;
+  headers: Record<string, string>;
+  query: Record<string, string>;
+  body: Record<string, unknown>;
+  contentType: string | null;
+}
+
 export interface ApiFragmentHooksConfig {
   onConnectionChanged?: (
     payload: ApiConnectionChangedPayload,
@@ -50,6 +73,7 @@ export interface ApiFragmentHooksConfig {
     payload: ApiConnectionAvailablePayload,
     idempotencyKey: string,
   ) => Promise<void> | void;
+  onWebhookReceived?: (payload: WebhookReceivedPayload) => Promise<void> | void;
 }
 
 export type ApiFragmentConfig = BaseApiFragmentConfig & ApiFragmentHooksConfig;
@@ -58,6 +82,7 @@ export type ApiHooksMap = {
   onConnectionChanged: HookFn<ApiConnectionChangedPayload>;
   onConnectionDeleted: HookFn<ApiConnectionDeletedPayload>;
   onConnectionAvailable: HookFn<ApiConnectionAvailablePayload>;
+  onWebhookReceived: HookFn<InternalWebhookReceivedPayload>;
 };
 
 function connectionHookSnapshot(connection: {
@@ -87,6 +112,18 @@ export const apiFragmentDefinition = defineFragment<ApiFragmentConfig>("api-frag
     }),
     onConnectionAvailable: defineHook(async function (payload) {
       await config.onConnectionAvailable?.(payload, this.idempotencyKey);
+    }),
+    onWebhookReceived: defineHook(async function (payload) {
+      await config.onWebhookReceived?.({
+        endpointId: payload.endpointId,
+        deliveryId: payload.deliveryId,
+        hookId: payload.hookId,
+        receivedAt: payload.receivedAt,
+        headers: payload.headers,
+        query: payload.query,
+        body: payload.body,
+        contentType: payload.contentType,
+      });
     }),
   }))
   .providesBaseService(({ defineService, config }) =>

--- a/packages/api-fragment/src/index.ts
+++ b/packages/api-fragment/src/index.ts
@@ -32,11 +32,26 @@ export function createApiFragmentClients(fragnoConfig: FragnoPublicClientConfig 
     startOAuth: builder.createMutator("POST", "/connections/:slug/auth/oauth/start"),
     deleteAuth: builder.createMutator("DELETE", "/connections/:slug/auth"),
     request: builder.createMutator("POST", "/connections/:slug/request"),
+    useWebhookEndpoints: builder.createHook("/webhooks/endpoints"),
+    useWebhookEndpoint: builder.createHook("/webhooks/endpoints/:endpointId"),
+    createWebhookEndpoint: builder.createMutator("PUT", "/webhooks/endpoints/:endpointId"),
+    updateWebhookEndpoint: builder.createMutator("PATCH", "/webhooks/endpoints/:endpointId"),
+    deleteWebhookEndpoint: builder.createMutator("DELETE", "/webhooks/endpoints/:endpointId"),
   };
 }
 
 export { apiFragmentDefinition } from "./definition";
 export { apiRoutesFactory } from "./routes";
 export { apiSchema } from "./schema";
-export type { ApiFragmentConfig } from "./definition";
-export type { ApiConnection, ApiConnectionInput, ApiRequestInput, AuthConfig } from "./api-types";
+export type { ApiFragmentConfig, WebhookReceivedPayload } from "./definition";
+export type {
+  ApiConnection,
+  ApiConnectionInput,
+  ApiRequestInput,
+  AuthConfig,
+  UpdateWebhookEndpointInput,
+  WebhookDeliveryIdentity,
+  WebhookEndpoint,
+  WebhookEndpointAuthInput,
+  WebhookEndpointInput,
+} from "./api-types";

--- a/packages/api-fragment/src/oauth.ts
+++ b/packages/api-fragment/src/oauth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { AuthConfig } from "./api-types";
+import { asciiToBase64, sha256Base64Url } from "./crypto";
 
 export interface OAuthTokens {
   tokenType?: string;
@@ -33,40 +34,10 @@ const oauthTokenResponseSchema = z
   })
   .passthrough();
 
-function assertAscii(value: string, label: string) {
-  for (let index = 0; index < value.length; index += 1) {
-    if (value.charCodeAt(index) > 0x7f) {
-      throw new Error(`${label} must contain ASCII characters only`);
-    }
-  }
-}
-
-function asciiToBase64(value: string, label: string) {
-  assertAscii(value, label);
-  return btoa(value);
-}
-
-function bytesToBase64(bytes: Uint8Array) {
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary);
-}
-
-export function bytesToBase64Url(bytes: Uint8Array) {
-  return bytesToBase64(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-export function randomBase64Url(bytes = 32) {
-  const data = new Uint8Array(bytes);
-  crypto.getRandomValues(data);
-  return bytesToBase64Url(data);
-}
+export { bytesToBase64Url, randomBase64Url } from "./crypto";
 
 export async function createCodeChallenge(codeVerifier: string) {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(codeVerifier));
-  return bytesToBase64Url(new Uint8Array(digest));
+  return await sha256Base64Url(codeVerifier);
 }
 
 export function createAuthorizationUrl(args: {

--- a/packages/api-fragment/src/routes.ts
+++ b/packages/api-fragment/src/routes.ts
@@ -1,19 +1,35 @@
 import { z } from "zod";
 
 import { defineRoutes } from "@fragno-dev/core";
+import { isUniqueConstraintError } from "@fragno-dev/db";
 
 import {
   apiConnectionOutputSchema,
   apiRequestInputSchema,
   createApiConnectionInputSchema,
+  createWebhookEndpointInputSchema,
   oauthStartInputSchema,
   tokenAuthInputSchema,
+  updateWebhookEndpointInputSchema,
+  webhookEndpointOutputSchema,
+  type WebhookDeliveryIdentity,
+  type WebhookEndpoint,
+  type WebhookEndpointAuthInput,
 } from "./api-types";
+import { sha256Base64Url } from "./crypto";
 import { apiFragmentDefinition } from "./definition";
 import { apiSchema } from "./schema";
 import { assertAllowedBaseUrl, storedAuthPayloadSchema } from "./services";
+import {
+  getSensitiveWebhookAuthValues,
+  getWebhookAuthSecretRefs,
+  verifyWebhookAuth,
+  type WebhookAuthConfig,
+} from "./webhooks/auth";
 
 const connectionsOutputSchema = z.object({ connections: z.array(apiConnectionOutputSchema) });
+const webhookEndpointsOutputSchema = z.object({ endpoints: z.array(webhookEndpointOutputSchema) });
+const webhookReceivedOutputSchema = z.object({ accepted: z.boolean() });
 const authStatusSchema = z.object({
   authenticated: z.boolean(),
   mode: z.string(),
@@ -70,8 +86,569 @@ function connectionHookSnapshot(connection: {
   };
 }
 
+type WebhookSecretDraft = { ref: string; payload: string };
+
+function webhookSecretId(endpointId: string, ref: string) {
+  return `${endpointId}:${ref}`;
+}
+
+function webhookEndpointAuthStorage(auth: WebhookEndpointAuthInput): {
+  authConfig: WebhookAuthConfig;
+  secrets: WebhookSecretDraft[];
+} {
+  if (auth.type === "none") {
+    return { authConfig: { type: "none" }, secrets: [] };
+  }
+  if (auth.type === "bearer") {
+    return {
+      authConfig: { type: "bearer", tokenRef: "token" },
+      secrets: [{ ref: "token", payload: auth.token }],
+    };
+  }
+  if (auth.type === "apiKey") {
+    return {
+      authConfig: {
+        type: "apiKey",
+        location: auth.location,
+        name: auth.name,
+        secretRef: "secret",
+      },
+      secrets: [{ ref: "secret", payload: auth.secret }],
+    };
+  }
+  if (auth.type === "basic") {
+    return {
+      authConfig: { type: "basic", usernameRef: "username", passwordRef: "password" },
+      secrets: [
+        { ref: "username", payload: auth.username },
+        { ref: "password", payload: auth.password },
+      ],
+    };
+  }
+
+  return {
+    authConfig: {
+      type: "hmac",
+      secretRef: "secret",
+      algorithm: auth.algorithm,
+      signature: auth.signature,
+      signedPayload: auth.signedPayload,
+    },
+    secrets: [{ ref: "secret", payload: auth.secret }],
+  };
+}
+
+function parseWebhookEndpointStatus(status: string): "active" | "disabled" {
+  if (status === "active" || status === "disabled") {
+    return status;
+  }
+  throw new Error(`Unexpected webhook endpoint status: ${status}`);
+}
+
+function recordFromSearchParams(
+  query: URLSearchParams,
+  sensitiveQueryNames: ReadonlySet<string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [name, value] of query.entries()) {
+    result[name] = sensitiveQueryNames.has(name) ? "[redacted]" : value;
+  }
+  return result;
+}
+
+function recordFromHeaders(
+  headers: Headers,
+  sensitiveHeaderNames: ReadonlySet<string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [name, value] of headers.entries()) {
+    result[name] = sensitiveHeaderNames.has(name.toLowerCase()) ? "[redacted]" : value;
+  }
+  return result;
+}
+
+type WebhookJsonBodyResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; reason: "invalid_json" | "invalid_value" };
+
+type WebhookDeliveryIdentityResult =
+  | { ok: true; deliveryId: string }
+  | { ok: false; reason: "missing" | "invalid_value" };
+
+function parseWebhookJsonBody(rawBody: string | undefined): WebhookJsonBodyResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(rawBody ?? "");
+  } catch {
+    return { ok: false, reason: "invalid_json" };
+  }
+  if (!isJsonObject(value)) {
+    return { ok: false, reason: "invalid_value" };
+  }
+  return { ok: true, body: value };
+}
+
+function extractWebhookDeliveryId(input: {
+  identity: WebhookDeliveryIdentity;
+  headers: Headers;
+  query: URLSearchParams;
+  body: Record<string, unknown>;
+}): WebhookDeliveryIdentityResult {
+  if (input.identity.type === "header") {
+    return normalizeWebhookDeliveryId(input.headers.get(input.identity.name));
+  }
+  if (input.identity.type === "query") {
+    return normalizeWebhookDeliveryId(input.query.get(input.identity.name));
+  }
+
+  let value: unknown = input.body;
+  for (const segment of input.identity.path) {
+    if (!isJsonObject(value) || !(segment in value)) {
+      return { ok: false, reason: "missing" };
+    }
+    value = value[segment];
+  }
+  return normalizeWebhookDeliveryId(value);
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeWebhookDeliveryId(value: unknown): WebhookDeliveryIdentityResult {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return value == null
+      ? { ok: false, reason: "missing" }
+      : { ok: false, reason: "invalid_value" };
+  }
+  const deliveryId = `${value}`.trim();
+  if (!deliveryId) {
+    return { ok: false, reason: "missing" };
+  }
+  return { ok: true, deliveryId };
+}
+
+async function webhookHookId(endpointId: string, deliveryId: string) {
+  return `webhook_${await sha256Base64Url(`${endpointId}\0${deliveryId}`)}`;
+}
+
+function publicWebhookEndpoint(endpoint: {
+  id: { toString(): string } | string;
+  name: string;
+  status: string;
+  authConfig: WebhookAuthConfig;
+  deliveryIdentity: WebhookDeliveryIdentity;
+  createdAt?: Date;
+  updatedAt?: Date;
+}): WebhookEndpoint {
+  return {
+    id: endpoint.id.toString(),
+    name: endpoint.name,
+    status: parseWebhookEndpointStatus(endpoint.status),
+    authConfig: endpoint.authConfig,
+    deliveryIdentity: endpoint.deliveryIdentity,
+    secretRefs: [...getWebhookAuthSecretRefs(endpoint.authConfig)],
+    createdAt: endpoint.createdAt,
+    updatedAt: endpoint.updatedAt,
+  };
+}
+
 export const apiRoutesFactory = defineRoutes(apiFragmentDefinition).create(
   ({ services, defineRoute, config }) => [
+    defineRoute({
+      method: "PUT",
+      path: "/webhooks/endpoints/:endpointId",
+      inputSchema: createWebhookEndpointInputSchema,
+      outputSchema: webhookEndpointOutputSchema,
+      handler: async function ({ input, pathParams }, { json }) {
+        const body = await input.valid();
+        const authStorage = webhookEndpointAuthStorage(body.auth);
+        const result = await this.handlerTx()
+          .retrieve(({ forSchema }) =>
+            forSchema(apiSchema)
+              .findFirst("webhookEndpoint", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", pathParams.endpointId)),
+              )
+              .find("webhookSecret", (b) =>
+                b.whereIndex("idx_webhook_secret_endpoint_ref", (eb) =>
+                  eb("endpointId", "=", pathParams.endpointId),
+                ),
+              ),
+          )
+          .mutate(({ forSchema, retrieveResult: [existing, existingSecrets] }) => {
+            const uow = forSchema(apiSchema);
+            if (existing) {
+              uow.update("webhookEndpoint", existing.id, (b) =>
+                b
+                  .set({
+                    name: body.name,
+                    status: body.status,
+                    authConfig: authStorage.authConfig,
+                    deliveryIdentity: body.deliveryIdentity,
+                    updatedAt: b.now(),
+                  })
+                  .check(),
+              );
+            } else {
+              uow.create("webhookEndpoint", {
+                id: pathParams.endpointId,
+                name: body.name,
+                status: body.status,
+                authConfig: authStorage.authConfig,
+                deliveryIdentity: body.deliveryIdentity,
+              });
+            }
+
+            const nextSecretRefs = new Set(authStorage.secrets.map((secret) => secret.ref));
+            for (const secret of existingSecrets) {
+              if (!nextSecretRefs.has(secret.ref)) {
+                uow.delete("webhookSecret", secret.id);
+              }
+            }
+            for (const secret of authStorage.secrets) {
+              const existingSecret = existingSecrets.find(
+                (candidate) => candidate.ref === secret.ref,
+              );
+              if (existingSecret) {
+                uow.update("webhookSecret", existingSecret.id, (b) =>
+                  b.set({ payload: secret.payload, updatedAt: b.now() }).check(),
+                );
+              } else {
+                uow.create("webhookSecret", {
+                  id: webhookSecretId(pathParams.endpointId, secret.ref),
+                  endpointId: pathParams.endpointId,
+                  ref: secret.ref,
+                  payload: secret.payload,
+                });
+              }
+            }
+
+            return {
+              created: !existing,
+              endpoint: {
+                id: pathParams.endpointId,
+                name: body.name,
+                status: body.status,
+                authConfig: authStorage.authConfig,
+                deliveryIdentity: body.deliveryIdentity,
+                createdAt: existing?.createdAt,
+              },
+            };
+          })
+          .execute();
+
+        return json(publicWebhookEndpoint(result.endpoint), result.created ? 201 : 200);
+      },
+    }),
+
+    defineRoute({
+      method: "GET",
+      path: "/webhooks/endpoints",
+      outputSchema: webhookEndpointsOutputSchema,
+      handler: async function (_, { json }) {
+        const [endpoints] = await this.handlerTx()
+          .retrieve(({ forSchema }) =>
+            forSchema(apiSchema).find("webhookEndpoint", (b) => b.whereIndex("primary")),
+          )
+          .execute();
+        return json({ endpoints: endpoints.map(publicWebhookEndpoint) });
+      },
+    }),
+
+    defineRoute({
+      method: "GET",
+      path: "/webhooks/endpoints/:endpointId",
+      outputSchema: webhookEndpointOutputSchema,
+      errorCodes: ["WEBHOOK_ENDPOINT_NOT_FOUND"],
+      handler: async function ({ pathParams }, { json, error }) {
+        const [endpoint] = await this.handlerTx()
+          .retrieve(({ forSchema }) =>
+            forSchema(apiSchema).findFirst("webhookEndpoint", (b) =>
+              b.whereIndex("primary", (eb) => eb("id", "=", pathParams.endpointId)),
+            ),
+          )
+          .execute();
+        if (!endpoint) {
+          return error(
+            { code: "WEBHOOK_ENDPOINT_NOT_FOUND", message: "Webhook endpoint not found" },
+            404,
+          );
+        }
+        return json(publicWebhookEndpoint(endpoint));
+      },
+    }),
+
+    defineRoute({
+      method: "POST",
+      path: "/webhooks/endpoints/:endpointId/events",
+      errorCodes: [
+        "WEBHOOK_ENDPOINT_NOT_FOUND",
+        "WEBHOOK_ENDPOINT_DISABLED",
+        "WEBHOOK_AUTH_FAILED",
+        "WEBHOOK_BODY_INVALID",
+        "WEBHOOK_DELIVERY_ID_MISSING",
+        "WEBHOOK_DELIVERY_ID_INVALID",
+      ],
+      outputSchema: webhookReceivedOutputSchema,
+      handler: async function ({ pathParams, headers, query, rawBody, request }, { json, error }) {
+        let result:
+          | {
+              ok: true;
+            }
+          | {
+              ok: false;
+              code:
+                | "WEBHOOK_ENDPOINT_NOT_FOUND"
+                | "WEBHOOK_ENDPOINT_DISABLED"
+                | "WEBHOOK_AUTH_FAILED"
+                | "WEBHOOK_BODY_INVALID"
+                | "WEBHOOK_DELIVERY_ID_MISSING"
+                | "WEBHOOK_DELIVERY_ID_INVALID";
+              reason?: string;
+            };
+        try {
+          result = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(apiSchema)
+                .findFirst("webhookEndpoint", (b) =>
+                  b.whereIndex("primary", (eb) => eb("id", "=", pathParams.endpointId)),
+                )
+                .find("webhookSecret", (b) =>
+                  b.whereIndex("idx_webhook_secret_endpoint_ref", (eb) =>
+                    eb("endpointId", "=", pathParams.endpointId),
+                  ),
+                ),
+            )
+            .transformRetrieve(async ([endpoint, secrets]) => {
+              if (!endpoint) {
+                return { ok: false as const, code: "WEBHOOK_ENDPOINT_NOT_FOUND" as const };
+              }
+              if (endpoint.status !== "active") {
+                return { ok: false as const, code: "WEBHOOK_ENDPOINT_DISABLED" as const };
+              }
+
+              const authConfig = endpoint.authConfig;
+              const secretValues = new Map(secrets.map((secret) => [secret.ref, secret.payload]));
+              if (!request) {
+                throw new Error("Webhook receive route requires a web-standard Request");
+              }
+              const auth = await verifyWebhookAuth({
+                config: authConfig,
+                request,
+                secrets: { get: async (ref) => secretValues.get(ref) },
+              });
+              if (!auth.ok) {
+                return {
+                  ok: false as const,
+                  code: "WEBHOOK_AUTH_FAILED" as const,
+                  reason: auth.reason,
+                };
+              }
+
+              const body = parseWebhookJsonBody(rawBody);
+              if (!body.ok) {
+                return { ok: false as const, code: "WEBHOOK_BODY_INVALID" as const };
+              }
+
+              const deliveryIdentity = endpoint.deliveryIdentity;
+              const deliveryId = extractWebhookDeliveryId({
+                identity: deliveryIdentity,
+                headers,
+                query,
+                body: body.body,
+              });
+              if (!deliveryId.ok) {
+                return {
+                  ok: false as const,
+                  code:
+                    deliveryId.reason === "missing"
+                      ? ("WEBHOOK_DELIVERY_ID_MISSING" as const)
+                      : ("WEBHOOK_DELIVERY_ID_INVALID" as const),
+                };
+              }
+
+              return {
+                ok: true as const,
+                authConfig,
+                deliveryId: deliveryId.deliveryId,
+                hookId: await webhookHookId(pathParams.endpointId, deliveryId.deliveryId),
+                body: body.body,
+              };
+            })
+            .mutate(({ forSchema, retrieveResult }) => {
+              if (!retrieveResult.ok) {
+                return retrieveResult;
+              }
+
+              const sensitiveValues = getSensitiveWebhookAuthValues(retrieveResult.authConfig);
+              const sensitiveHeaderNames = new Set(
+                sensitiveValues
+                  .filter((value) => value.location === "header")
+                  .map((value) => value.name.toLowerCase()),
+              );
+              const sensitiveQueryNames = new Set(
+                sensitiveValues
+                  .filter((value) => value.location === "query")
+                  .map((value) => value.name),
+              );
+
+              const uow = forSchema(apiSchema);
+              uow.triggerHook(
+                "onWebhookReceived",
+                {
+                  endpointId: pathParams.endpointId,
+                  deliveryId: retrieveResult.deliveryId,
+                  hookId: retrieveResult.hookId,
+                  receivedAt: new Date().toISOString(),
+                  headers: recordFromHeaders(headers, sensitiveHeaderNames),
+                  query: recordFromSearchParams(query, sensitiveQueryNames),
+                  rawBody: rawBody ?? "",
+                  body: retrieveResult.body,
+                  contentType: headers.get("content-type"),
+                },
+                { id: retrieveResult.hookId },
+              );
+              return { ok: true as const };
+            })
+            .execute();
+        } catch (err) {
+          if (isUniqueConstraintError(err)) {
+            return json({ accepted: true }, 202);
+          }
+          throw err;
+        }
+
+        if (!result.ok) {
+          if (result.code === "WEBHOOK_ENDPOINT_NOT_FOUND") {
+            return error({ code: result.code, message: "Webhook endpoint not found" }, 404);
+          }
+          if (result.code === "WEBHOOK_ENDPOINT_DISABLED") {
+            return error({ code: result.code, message: "Webhook endpoint is disabled" }, 409);
+          }
+          if (result.code === "WEBHOOK_BODY_INVALID") {
+            return error({ code: result.code, message: "Webhook body must be a JSON object" }, 400);
+          }
+          if (result.code === "WEBHOOK_DELIVERY_ID_MISSING") {
+            return error({ code: result.code, message: "Webhook delivery ID is missing" }, 400);
+          }
+          if (result.code === "WEBHOOK_DELIVERY_ID_INVALID") {
+            return error({ code: result.code, message: "Webhook delivery ID is invalid" }, 400);
+          }
+          return error({ code: result.code, message: "Webhook authentication failed" }, 401);
+        }
+
+        return json({ accepted: true }, 202);
+      },
+    }),
+
+    defineRoute({
+      method: "PATCH",
+      path: "/webhooks/endpoints/:endpointId",
+      inputSchema: updateWebhookEndpointInputSchema,
+      outputSchema: webhookEndpointOutputSchema,
+      errorCodes: ["WEBHOOK_ENDPOINT_NOT_FOUND"],
+      handler: async function ({ input, pathParams }, { json, error }) {
+        const body = await input.valid();
+        const authStorage = body.auth ? webhookEndpointAuthStorage(body.auth) : null;
+        const result = await this.handlerTx()
+          .retrieve(({ forSchema }) =>
+            forSchema(apiSchema)
+              .findFirst("webhookEndpoint", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", pathParams.endpointId)),
+              )
+              .find("webhookSecret", (b) =>
+                b.whereIndex("idx_webhook_secret_endpoint_ref", (eb) =>
+                  eb("endpointId", "=", pathParams.endpointId),
+                ),
+              ),
+          )
+          .mutate(({ forSchema, retrieveResult: [endpoint, secrets] }) => {
+            if (!endpoint) {
+              return { found: false as const };
+            }
+            const uow = forSchema(apiSchema);
+            const authConfig = authStorage?.authConfig ?? endpoint.authConfig;
+            const deliveryIdentity = body.deliveryIdentity ?? endpoint.deliveryIdentity;
+            const next = {
+              id: endpoint.id,
+              name: body.name ?? endpoint.name,
+              status: body.status ?? endpoint.status,
+              authConfig,
+              deliveryIdentity,
+              createdAt: endpoint.createdAt,
+            };
+            uow.update("webhookEndpoint", endpoint.id, (b) =>
+              b
+                .set({
+                  name: next.name,
+                  status: next.status,
+                  authConfig,
+                  deliveryIdentity,
+                  updatedAt: b.now(),
+                })
+                .check(),
+            );
+            if (authStorage) {
+              for (const secret of secrets) {
+                uow.delete("webhookSecret", secret.id);
+              }
+              for (const secret of authStorage.secrets) {
+                uow.create("webhookSecret", {
+                  id: webhookSecretId(pathParams.endpointId, secret.ref),
+                  endpointId: pathParams.endpointId,
+                  ref: secret.ref,
+                  payload: secret.payload,
+                });
+              }
+            }
+            return { found: true as const, endpoint: next };
+          })
+          .execute();
+
+        if (!result.found) {
+          return error(
+            { code: "WEBHOOK_ENDPOINT_NOT_FOUND", message: "Webhook endpoint not found" },
+            404,
+          );
+        }
+
+        return json(publicWebhookEndpoint(result.endpoint));
+      },
+    }),
+
+    defineRoute({
+      method: "DELETE",
+      path: "/webhooks/endpoints/:endpointId",
+      handler: async function ({ pathParams }, { empty }) {
+        await this.handlerTx()
+          .retrieve(({ forSchema }) =>
+            forSchema(apiSchema)
+              .findFirst("webhookEndpoint", (b) =>
+                b.whereIndex("primary", (eb) => eb("id", "=", pathParams.endpointId)),
+              )
+              .find("webhookSecret", (b) =>
+                b.whereIndex("idx_webhook_secret_endpoint_ref", (eb) =>
+                  eb("endpointId", "=", pathParams.endpointId),
+                ),
+              ),
+          )
+          .mutate(({ forSchema, retrieveResult: [endpoint, secrets] }) => {
+            if (!endpoint) {
+              return { deleted: false as const };
+            }
+            const uow = forSchema(apiSchema);
+            for (const secret of secrets) {
+              uow.delete("webhookSecret", secret.id);
+            }
+            uow.delete("webhookEndpoint", endpoint.id);
+            return { deleted: true as const };
+          })
+          .execute();
+
+        return empty(204);
+      },
+    }),
+
     defineRoute({
       method: "PUT",
       path: "/connections/:slug",

--- a/packages/api-fragment/src/routes.ts
+++ b/packages/api-fragment/src/routes.ts
@@ -138,8 +138,8 @@ function webhookEndpointAuthStorage(auth: WebhookEndpointAuthInput): {
   };
 }
 
-function parseWebhookEndpointStatus(status: string): "active" | "disabled" {
-  if (status === "active" || status === "disabled") {
+function parseWebhookEndpointStatus(status: string): "draft" | "active" | "disabled" {
+  if (status === "draft" || status === "active" || status === "disabled") {
     return status;
   }
   throw new Error(`Unexpected webhook endpoint status: ${status}`);
@@ -384,6 +384,7 @@ export const apiRoutesFactory = defineRoutes(apiFragmentDefinition).create(
       errorCodes: [
         "WEBHOOK_ENDPOINT_NOT_FOUND",
         "WEBHOOK_ENDPOINT_DISABLED",
+        "WEBHOOK_ENDPOINT_DRAFT",
         "WEBHOOK_AUTH_FAILED",
         "WEBHOOK_BODY_INVALID",
         "WEBHOOK_DELIVERY_ID_MISSING",
@@ -400,6 +401,7 @@ export const apiRoutesFactory = defineRoutes(apiFragmentDefinition).create(
               code:
                 | "WEBHOOK_ENDPOINT_NOT_FOUND"
                 | "WEBHOOK_ENDPOINT_DISABLED"
+                | "WEBHOOK_ENDPOINT_DRAFT"
                 | "WEBHOOK_AUTH_FAILED"
                 | "WEBHOOK_BODY_INVALID"
                 | "WEBHOOK_DELIVERY_ID_MISSING"
@@ -422,6 +424,9 @@ export const apiRoutesFactory = defineRoutes(apiFragmentDefinition).create(
             .transformRetrieve(async ([endpoint, secrets]) => {
               if (!endpoint) {
                 return { ok: false as const, code: "WEBHOOK_ENDPOINT_NOT_FOUND" as const };
+              }
+              if (endpoint.status === "draft") {
+                return { ok: false as const, code: "WEBHOOK_ENDPOINT_DRAFT" as const };
               }
               if (endpoint.status !== "active") {
                 return { ok: false as const, code: "WEBHOOK_ENDPOINT_DISABLED" as const };
@@ -524,6 +529,12 @@ export const apiRoutesFactory = defineRoutes(apiFragmentDefinition).create(
           }
           if (result.code === "WEBHOOK_ENDPOINT_DISABLED") {
             return error({ code: result.code, message: "Webhook endpoint is disabled" }, 409);
+          }
+          if (result.code === "WEBHOOK_ENDPOINT_DRAFT") {
+            return error(
+              { code: result.code, message: "Webhook endpoint is not configured yet" },
+              409,
+            );
           }
           if (result.code === "WEBHOOK_BODY_INVALID") {
             return error({ code: result.code, message: "Webhook body must be a JSON object" }, 400);

--- a/packages/api-fragment/src/schema.ts
+++ b/packages/api-fragment/src/schema.ts
@@ -1,4 +1,13 @@
-import { column, idColumn, referenceColumn, schema } from "@fragno-dev/db/schema";
+import { column, idColumn, referenceColumn, schema, type Column } from "@fragno-dev/db/schema";
+
+import type { WebhookDeliveryIdentity } from "./api-types";
+import type { WebhookAuthConfig } from "./webhooks/auth";
+
+type JsonColumn<T> = Column<"json", T, T>;
+
+function jsonColumn<T>(): JsonColumn<T> {
+  return column("json") as unknown as JsonColumn<T>;
+}
 
 export const apiSchema = schema("api-fragment", (s) => {
   return s
@@ -41,5 +50,35 @@ export const apiSchema = schema("api-fragment", (s) => {
         .addColumn("expiresAt", column("timestamp"))
         .addColumn("consumedAt", column("timestamp").nullable())
         .createIndex("idx_oauth_state_connection", ["connectionId"]),
+    )
+    .addTable("webhookEndpoint", (t) =>
+      t
+        .addColumn("id", idColumn())
+        .addColumn("name", column("string"))
+        .addColumn("status", column("string"))
+        .addColumn("authConfig", jsonColumn<WebhookAuthConfig>())
+        .addColumn("deliveryIdentity", jsonColumn<WebhookDeliveryIdentity>())
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .addColumn(
+          "updatedAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        ),
+    )
+    .addTable("webhookSecret", (t) =>
+      t
+        .addColumn("id", idColumn())
+        .addColumn("endpointId", referenceColumn({ table: "webhookEndpoint" }))
+        .addColumn("ref", column("string"))
+        .addColumn("payload", column("text"))
+        .addColumn(
+          "updatedAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .createIndex("idx_webhook_secret_endpoint_ref", ["endpointId", "ref"], {
+          unique: true,
+        }),
     );
 });

--- a/packages/api-fragment/src/webhooks/auth.test.ts
+++ b/packages/api-fragment/src/webhooks/auth.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+
+import { bytesToBase64Url, bytesToHex, signHmacBytes, utf8Bytes } from "../crypto";
+import {
+  getSensitiveWebhookAuthValues,
+  getWebhookAuthSecretRefs,
+  timingSafeEqualBytes,
+  timingSafeEqualText,
+  verifyWebhookAuth,
+  type WebhookAuthConfig,
+  type WebhookSecretResolver,
+} from "./auth";
+
+const secrets = (values: Record<string, string>): WebhookSecretResolver => ({
+  get: (ref) => values[ref],
+});
+
+const rawBodyHmacConfig = {
+  type: "hmac",
+  secretRef: "webhook-secret",
+  algorithm: "sha256",
+  signature: {
+    location: "header",
+    name: "x-signature",
+    encoding: "hex",
+    prefix: "sha256=",
+  },
+  signedPayload: { type: "rawBody" },
+} satisfies WebhookAuthConfig;
+
+describe("webhook auth", () => {
+  it("accepts unauthenticated webhooks for auth type none", async () => {
+    await expect(
+      verifyWebhookAuth({
+        config: { type: "none" },
+        request: new Request("https://example.test/webhook"),
+        secrets: secrets({}),
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("verifies bearer authorization headers", async () => {
+    const config = { type: "bearer", tokenRef: "token" } satisfies WebhookAuthConfig;
+
+    await expect(
+      verifyWebhookAuth({
+        config,
+        request: new Request("https://example.test/webhook", {
+          headers: { authorization: "Bearer expected-token" },
+        }),
+        secrets: secrets({ token: "expected-token" }),
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      verifyWebhookAuth({
+        config,
+        request: new Request("https://example.test/webhook", {
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+        secrets: secrets({ token: "expected-token" }),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "invalid_credential" });
+  });
+
+  it("returns explicit failure reasons for missing bearer secrets and credentials", async () => {
+    const config = { type: "bearer", tokenRef: "token" } satisfies WebhookAuthConfig;
+
+    await expect(
+      verifyWebhookAuth({
+        config,
+        request: new Request("https://example.test/webhook"),
+        secrets: secrets({}),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "missing_secret" });
+
+    await expect(
+      verifyWebhookAuth({
+        config,
+        request: new Request("https://example.test/webhook"),
+        secrets: secrets({ token: "expected-token" }),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "missing_credential" });
+  });
+
+  it("verifies API keys from headers and query parameters", async () => {
+    await expect(
+      verifyWebhookAuth({
+        config: {
+          type: "apiKey",
+          location: "header",
+          name: "x-api-key",
+          secretRef: "key",
+        },
+        request: new Request("https://example.test/webhook", {
+          headers: { "x-api-key": "header-secret" },
+        }),
+        secrets: secrets({ key: "header-secret" }),
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      verifyWebhookAuth({
+        config: {
+          type: "apiKey",
+          location: "query",
+          name: "token",
+          secretRef: "key",
+        },
+        request: new Request("https://example.test/webhook?token=query-secret"),
+        secrets: secrets({ key: "query-secret" }),
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      verifyWebhookAuth({
+        config: {
+          type: "apiKey",
+          location: "query",
+          name: "token",
+          secretRef: "key",
+        },
+        request: new Request("https://example.test/webhook?token=wrong"),
+        secrets: secrets({ key: "query-secret" }),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "invalid_credential" });
+  });
+
+  it("verifies basic auth without storing the encoded credential", async () => {
+    const config = {
+      type: "basic",
+      usernameRef: "username",
+      passwordRef: "password",
+    } satisfies WebhookAuthConfig;
+
+    await expect(
+      verifyWebhookAuth({
+        config,
+        request: new Request("https://example.test/webhook", {
+          headers: { authorization: `Basic ${btoa("ada:lovelace")}` },
+        }),
+        secrets: secrets({ username: "ada", password: "lovelace" }),
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      verifyWebhookAuth({
+        config,
+        request: new Request("https://example.test/webhook", {
+          headers: { authorization: `Basic ${btoa("ada:wrong")}` },
+        }),
+        secrets: secrets({ username: "ada", password: "lovelace" }),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "invalid_credential" });
+  });
+
+  it("verifies HMAC signatures over the exact raw request body bytes", async () => {
+    const body = JSON.stringify({ hello: "world" });
+    const signature = bytesToHex(
+      await signHmacBytes({
+        algorithm: "sha256",
+        secret: "secret",
+        payload: utf8Bytes(body),
+      }),
+    );
+    const originalRequest = new Request("https://example.test/webhook", {
+      method: "POST",
+      headers: { "x-signature": `sha256=${signature}` },
+      body,
+    });
+
+    await expect(
+      verifyWebhookAuth({
+        config: rawBodyHmacConfig,
+        request: originalRequest,
+        secrets: secrets({ "webhook-secret": "secret" }),
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(originalRequest.text()).resolves.toBe(body);
+  });
+
+  it("rejects invalid HMAC signatures", async () => {
+    await expect(
+      verifyWebhookAuth({
+        config: rawBodyHmacConfig,
+        request: new Request("https://example.test/webhook", {
+          method: "POST",
+          headers: { "x-signature": "sha256=deadbeef" },
+          body: "body",
+        }),
+        secrets: secrets({ "webhook-secret": "secret" }),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "invalid_credential" });
+  });
+
+  it("supports base64url HMAC signatures in query parameters", async () => {
+    const body = "payload";
+    const signature = bytesToBase64Url(
+      await signHmacBytes({
+        algorithm: "sha512",
+        secret: "secret",
+        payload: utf8Bytes(body),
+      }),
+    );
+
+    await expect(
+      verifyWebhookAuth({
+        config: {
+          type: "hmac",
+          secretRef: "secret",
+          algorithm: "sha512",
+          signature: {
+            location: "query",
+            name: "signature",
+            encoding: "base64url",
+          },
+          signedPayload: { type: "rawBody" },
+        },
+        request: new Request(`https://example.test/webhook?signature=${signature}`, {
+          method: "POST",
+          body,
+        }),
+        secrets: secrets({ secret: "secret" }),
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("verifies timestamped HMAC payloads and rejects replayed timestamps", async () => {
+    const body = "body";
+    const timestamp = "1700000000";
+    const signedPayload = utf8Bytes(`${timestamp}.${body}`);
+    const signature = bytesToHex(
+      await signHmacBytes({ algorithm: "sha256", secret: "secret", payload: signedPayload }),
+    );
+    const config = {
+      type: "hmac",
+      secretRef: "secret",
+      algorithm: "sha256",
+      signature: {
+        location: "header",
+        name: "x-signature",
+        encoding: "hex",
+      },
+      signedPayload: {
+        type: "timestampBody",
+        timestampHeader: "x-timestamp",
+        delimiter: ".",
+        toleranceSeconds: 300,
+      },
+    } satisfies WebhookAuthConfig;
+
+    await expect(
+      verifyWebhookAuth({
+        config,
+        request: new Request("https://example.test/webhook", {
+          method: "POST",
+          headers: { "x-signature": signature, "x-timestamp": timestamp },
+          body,
+        }),
+        secrets: secrets({ secret: "secret" }),
+        now: new Date(1_700_000_000_000),
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      verifyWebhookAuth({
+        config,
+        request: new Request("https://example.test/webhook", {
+          method: "POST",
+          headers: { "x-signature": signature, "x-timestamp": timestamp },
+          body,
+        }),
+        secrets: secrets({ secret: "secret" }),
+        now: new Date(1_700_001_000_000),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "timestamp_out_of_range" });
+  });
+
+  it("reports auth metadata for secret lookup and request redaction", () => {
+    const configs = [
+      { type: "none" },
+      { type: "bearer", tokenRef: "token" },
+      { type: "apiKey", location: "header", name: "x-api-key", secretRef: "key" },
+      { type: "basic", usernameRef: "username", passwordRef: "password" },
+      rawBodyHmacConfig,
+    ] satisfies WebhookAuthConfig[];
+
+    expect(configs.map(getWebhookAuthSecretRefs)).toEqual([
+      [],
+      ["token"],
+      ["key"],
+      ["username", "password"],
+      ["webhook-secret"],
+    ]);
+    expect(configs.map(getSensitiveWebhookAuthValues)).toEqual([
+      [],
+      [{ location: "header", name: "authorization" }],
+      [{ location: "header", name: "x-api-key" }],
+      [{ location: "header", name: "authorization" }],
+      [{ location: "header", name: "x-signature" }],
+    ]);
+  });
+
+  it("compares text and byte credentials without accepting length mismatches", async () => {
+    await expect(timingSafeEqualText("same", "same")).resolves.toBe(true);
+    await expect(timingSafeEqualText("same", "same-plus")).resolves.toBe(false);
+    await expect(
+      timingSafeEqualBytes(new Uint8Array([1, 2]), new Uint8Array([1, 2])),
+    ).resolves.toBe(true);
+    await expect(
+      timingSafeEqualBytes(new Uint8Array([1, 2]), new Uint8Array([1, 2, 0])),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/api-fragment/src/webhooks/auth.ts
+++ b/packages/api-fragment/src/webhooks/auth.ts
@@ -1,0 +1,397 @@
+import { z } from "zod";
+
+import {
+  decodeBase64,
+  decodeBase64ToText,
+  decodeHex,
+  timingSafeEqualText as verifySecretText,
+  utf8Bytes,
+  verifyHmacSignature,
+} from "../crypto";
+
+const secretRefSchema = z.string().trim().min(1);
+const requestValueNameSchema = z.string().trim().min(1);
+
+export const webhookAuthConfigSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("none") }),
+  z.object({ type: z.literal("bearer"), tokenRef: secretRefSchema }),
+  z.object({
+    type: z.literal("apiKey"),
+    location: z.enum(["header", "query"]),
+    name: requestValueNameSchema,
+    secretRef: secretRefSchema,
+  }),
+  z.object({
+    type: z.literal("basic"),
+    usernameRef: secretRefSchema,
+    passwordRef: secretRefSchema,
+  }),
+  z.object({
+    type: z.literal("hmac"),
+    secretRef: secretRefSchema,
+    algorithm: z.enum(["sha1", "sha256", "sha512"]),
+    signature: z.object({
+      location: z.enum(["header", "query"]),
+      name: requestValueNameSchema,
+      encoding: z.enum(["hex", "base64", "base64url"]),
+      prefix: z.string().optional(),
+    }),
+    signedPayload: z.discriminatedUnion("type", [
+      z.object({ type: z.literal("rawBody") }),
+      z.object({
+        type: z.literal("timestampBody"),
+        timestampHeader: requestValueNameSchema,
+        delimiter: z.string(),
+        toleranceSeconds: z.number().int().positive(),
+      }),
+    ]),
+  }),
+]);
+
+export type WebhookAuthConfig = z.infer<typeof webhookAuthConfigSchema>;
+export type WebhookAuthType = WebhookAuthConfig["type"];
+export type WebhookAuthSecretRef = string;
+
+export type WebhookSecretResolver = {
+  get(ref: WebhookAuthSecretRef): string | undefined | Promise<string | undefined>;
+};
+
+export type WebhookAuthFailureReason =
+  | "missing_secret"
+  | "missing_credential"
+  | "invalid_credential"
+  | "timestamp_out_of_range"
+  | "bad_config";
+
+export type WebhookAuthResult = { ok: true } | { ok: false; reason: WebhookAuthFailureReason };
+
+export type SensitiveRequestValue = {
+  location: "header" | "query";
+  name: string;
+};
+
+export type WebhookAuthVerificationContext = {
+  request: Request;
+  now: Date;
+  secrets: WebhookSecretResolver;
+  rawBodyBytes(): Promise<Uint8Array>;
+};
+
+export interface WebhookAuthVerifier<TConfig extends WebhookAuthConfig> {
+  type: TConfig["type"];
+  requiredSecretRefs(config: TConfig): readonly WebhookAuthSecretRef[];
+  sensitiveRequestValues(config: TConfig): readonly SensitiveRequestValue[];
+  verify(config: TConfig, context: WebhookAuthVerificationContext): Promise<WebhookAuthResult>;
+}
+
+type WebhookAuthVerifierRegistry = {
+  [TType in WebhookAuthType]: WebhookAuthVerifier<Extract<WebhookAuthConfig, { type: TType }>>;
+};
+
+export type VerifyWebhookAuthInput = {
+  config: WebhookAuthConfig;
+  /** Pass the original web-standard Request or a clone. The body is read from request.clone(). */
+  request: Request;
+  secrets: WebhookSecretResolver;
+  now?: Date;
+};
+
+const getHeaderAuthorizationCredential = (request: Request, scheme: "basic" | "bearer") => {
+  const header = request.headers.get("authorization");
+  if (!header) {
+    return null;
+  }
+
+  const [headerScheme, ...rest] = header.split(/\s+/);
+  if (headerScheme?.toLowerCase() !== scheme || rest.length === 0) {
+    return null;
+  }
+
+  return rest.join(" ");
+};
+
+const getRequestValue = (
+  request: Request,
+  location: "header" | "query",
+  name: string,
+): string | null => {
+  if (location === "header") {
+    return request.headers.get(name);
+  }
+
+  return new URL(request.url).searchParams.get(name);
+};
+
+type WebhookAuthFailure = Extract<WebhookAuthResult, { ok: false }>;
+
+type ResolvedSecret = WebhookAuthFailure | { ok: true; secret: string };
+
+const requireSecret = async (
+  context: WebhookAuthVerificationContext,
+  ref: WebhookAuthSecretRef,
+): Promise<ResolvedSecret> => {
+  const secret = await context.secrets.get(ref);
+  if (!secret) {
+    return { ok: false, reason: "missing_secret" };
+  }
+
+  return { ok: true, secret };
+};
+
+const noneVerifier: WebhookAuthVerifier<Extract<WebhookAuthConfig, { type: "none" }>> = {
+  type: "none",
+  requiredSecretRefs: () => [],
+  sensitiveRequestValues: () => [],
+  verify: async () => ({ ok: true }),
+};
+
+const bearerVerifier: WebhookAuthVerifier<Extract<WebhookAuthConfig, { type: "bearer" }>> = {
+  type: "bearer",
+  requiredSecretRefs: (config) => [config.tokenRef],
+  sensitiveRequestValues: () => [{ location: "header", name: "authorization" }],
+  verify: async (config, context) => {
+    const secret = await requireSecret(context, config.tokenRef);
+    if (!secret.ok) {
+      return secret;
+    }
+
+    const token = getHeaderAuthorizationCredential(context.request, "bearer");
+    if (!token) {
+      return { ok: false, reason: "missing_credential" };
+    }
+
+    return (await verifySecretText(token, secret.secret))
+      ? { ok: true }
+      : { ok: false, reason: "invalid_credential" };
+  },
+};
+
+const apiKeyVerifier: WebhookAuthVerifier<Extract<WebhookAuthConfig, { type: "apiKey" }>> = {
+  type: "apiKey",
+  requiredSecretRefs: (config) => [config.secretRef],
+  sensitiveRequestValues: (config) => [{ location: config.location, name: config.name }],
+  verify: async (config, context) => {
+    const secret = await requireSecret(context, config.secretRef);
+    if (!secret.ok) {
+      return secret;
+    }
+
+    const credential = getRequestValue(context.request, config.location, config.name);
+    if (!credential) {
+      return { ok: false, reason: "missing_credential" };
+    }
+
+    return (await verifySecretText(credential, secret.secret))
+      ? { ok: true }
+      : { ok: false, reason: "invalid_credential" };
+  },
+};
+
+const basicVerifier: WebhookAuthVerifier<Extract<WebhookAuthConfig, { type: "basic" }>> = {
+  type: "basic",
+  requiredSecretRefs: (config) => [config.usernameRef, config.passwordRef],
+  sensitiveRequestValues: () => [{ location: "header", name: "authorization" }],
+  verify: async (config, context) => {
+    const username = await requireSecret(context, config.usernameRef);
+    if (!username.ok) {
+      return username;
+    }
+    const password = await requireSecret(context, config.passwordRef);
+    if (!password.ok) {
+      return password;
+    }
+
+    const encodedCredential = getHeaderAuthorizationCredential(context.request, "basic");
+    if (!encodedCredential) {
+      return { ok: false, reason: "missing_credential" };
+    }
+
+    const decodedCredential = decodeBase64ToText(encodedCredential, "base64");
+    if (decodedCredential === null) {
+      return { ok: false, reason: "invalid_credential" };
+    }
+
+    const separatorIndex = decodedCredential.indexOf(":");
+    if (separatorIndex === -1) {
+      return { ok: false, reason: "invalid_credential" };
+    }
+
+    const actualUsername = decodedCredential.slice(0, separatorIndex);
+    const actualPassword = decodedCredential.slice(separatorIndex + 1);
+
+    return (await verifySecretText(actualUsername, username.secret)) &&
+      (await verifySecretText(actualPassword, password.secret))
+      ? { ok: true }
+      : { ok: false, reason: "invalid_credential" };
+  },
+};
+
+const hmacVerifier: WebhookAuthVerifier<Extract<WebhookAuthConfig, { type: "hmac" }>> = {
+  type: "hmac",
+  requiredSecretRefs: (config) => [config.secretRef],
+  sensitiveRequestValues: (config) => [
+    { location: config.signature.location, name: config.signature.name },
+  ],
+  verify: async (config, context) => {
+    const secret = await requireSecret(context, config.secretRef);
+    if (!secret.ok) {
+      return secret;
+    }
+
+    const signatureValue = getRequestValue(
+      context.request,
+      config.signature.location,
+      config.signature.name,
+    );
+    if (!signatureValue) {
+      return { ok: false, reason: "missing_credential" };
+    }
+
+    const normalizedSignature = normalizeSignature(signatureValue, config.signature.prefix);
+    if (normalizedSignature === null) {
+      return { ok: false, reason: "invalid_credential" };
+    }
+
+    const signedPayload = await buildSignedPayload(config, context);
+    if (!signedPayload.ok) {
+      return signedPayload;
+    }
+
+    const providedSignature = decodeSignature(normalizedSignature, config.signature.encoding);
+    if (!providedSignature) {
+      return { ok: false, reason: "invalid_credential" };
+    }
+
+    return (await verifyHmacSignature({
+      algorithm: config.algorithm,
+      secret: secret.secret,
+      payload: signedPayload.payload,
+      signature: providedSignature,
+    }))
+      ? { ok: true }
+      : { ok: false, reason: "invalid_credential" };
+  },
+};
+
+export const webhookAuthVerifiers = {
+  none: noneVerifier,
+  bearer: bearerVerifier,
+  apiKey: apiKeyVerifier,
+  basic: basicVerifier,
+  hmac: hmacVerifier,
+} satisfies WebhookAuthVerifierRegistry;
+
+export async function verifyWebhookAuth({
+  config,
+  request,
+  secrets,
+  now = new Date(),
+}: VerifyWebhookAuthInput): Promise<WebhookAuthResult> {
+  const verifier = getWebhookAuthVerifier(config);
+  let rawBodyBytes: Uint8Array | null = null;
+
+  return await verifier.verify(config, {
+    request,
+    now,
+    secrets,
+    rawBodyBytes: async () => {
+      rawBodyBytes ??= new Uint8Array(await request.clone().arrayBuffer());
+      return rawBodyBytes;
+    },
+  });
+}
+
+export function getWebhookAuthSecretRefs(
+  config: WebhookAuthConfig,
+): readonly WebhookAuthSecretRef[] {
+  return getWebhookAuthVerifier(config).requiredSecretRefs(config);
+}
+
+export function getSensitiveWebhookAuthValues(
+  config: WebhookAuthConfig,
+): readonly SensitiveRequestValue[] {
+  return getWebhookAuthVerifier(config).sensitiveRequestValues(config);
+}
+
+function getWebhookAuthVerifier<TConfig extends WebhookAuthConfig>(
+  config: TConfig,
+): WebhookAuthVerifier<TConfig> {
+  return webhookAuthVerifiers[config.type] as WebhookAuthVerifier<TConfig>;
+}
+
+async function buildSignedPayload(
+  config: Extract<WebhookAuthConfig, { type: "hmac" }>,
+  context: WebhookAuthVerificationContext,
+): Promise<{ ok: true; payload: Uint8Array } | WebhookAuthFailure> {
+  if (config.signedPayload.type === "rawBody") {
+    return { ok: true, payload: await context.rawBodyBytes() };
+  }
+
+  const timestamp = context.request.headers.get(config.signedPayload.timestampHeader);
+  if (!timestamp) {
+    return { ok: false, reason: "missing_credential" };
+  }
+
+  const timestampMs = parseWebhookTimestampMs(timestamp);
+  if (timestampMs === null) {
+    return { ok: false, reason: "invalid_credential" };
+  }
+
+  const toleranceMs = config.signedPayload.toleranceSeconds * 1000;
+  if (Math.abs(context.now.getTime() - timestampMs) > toleranceMs) {
+    return { ok: false, reason: "timestamp_out_of_range" };
+  }
+
+  return {
+    ok: true,
+    payload: concatBytes(
+      utf8Bytes(`${timestamp}${config.signedPayload.delimiter}`),
+      await context.rawBodyBytes(),
+    ),
+  };
+}
+
+function normalizeSignature(signature: string, prefix: string | undefined) {
+  const trimmed = signature.trim();
+  if (!prefix) {
+    return trimmed || null;
+  }
+
+  if (!trimmed.startsWith(prefix)) {
+    return null;
+  }
+
+  const withoutPrefix = trimmed.slice(prefix.length).trim();
+  return withoutPrefix || null;
+}
+
+function decodeSignature(signature: string, encoding: "hex" | "base64" | "base64url") {
+  if (encoding === "hex") {
+    return decodeHex(signature);
+  }
+
+  return decodeBase64(signature, encoding);
+}
+
+function parseWebhookTimestampMs(value: string) {
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    return null;
+  }
+
+  const numeric = Number(normalized);
+  if (!Number.isSafeInteger(numeric) || numeric <= 0) {
+    return null;
+  }
+
+  return numeric < 1_000_000_000_000 ? numeric * 1000 : numeric;
+}
+
+function concatBytes(first: Uint8Array, second: Uint8Array) {
+  const output = new Uint8Array(first.length + second.length);
+  output.set(first, 0);
+  output.set(second, first.length);
+  return output;
+}
+
+export { timingSafeEqualBytes, timingSafeEqualText } from "../crypto";

--- a/packages/api-fragment/src/webhooks/management.test.ts
+++ b/packages/api-fragment/src/webhooks/management.test.ts
@@ -1,0 +1,341 @@
+import { assert, describe, expect, test } from "vitest";
+
+import { instantiate } from "@fragno-dev/core";
+import { buildDatabaseFragmentsTest } from "@fragno-dev/test";
+
+import { apiFragmentDefinition } from "../definition";
+import { createApiFragmentClients } from "../index";
+import { apiRoutesFactory } from "../routes";
+import { apiSchema } from "../schema";
+
+const buildApiTest = async () => {
+  const setup = await buildDatabaseFragmentsTest()
+    .withTestAdapter({ type: "kysely-sqlite" })
+    .withDbRoundtripGuard({ maxRoundtrips: 1 })
+    .withFragment(
+      "api",
+      instantiate(apiFragmentDefinition)
+        .withConfig({
+          publicBaseUrl: "https://app.test",
+        })
+        .withRoutes([apiRoutesFactory]),
+    )
+    .build();
+  return setup;
+};
+
+type ApiTest = Awaited<ReturnType<typeof buildApiTest>>;
+
+async function readWebhookSecrets(test: ApiTest, endpointId: string) {
+  const [secrets] = await test.fragments.api.db
+    .createUnitOfWork("read-webhook-secrets")
+    .forSchema(apiSchema)
+    .find("webhookSecret", (b) =>
+      b.whereIndex("idx_webhook_secret_endpoint_ref", (eb) => eb("endpointId", "=", endpointId)),
+    )
+    .executeRetrieve();
+  return secrets;
+}
+
+describe("webhook endpoint management", () => {
+  test("exports webhook endpoint client builders", () => {
+    const clients = createApiFragmentClients();
+
+    expect(clients.useWebhookEndpoints).toBeDefined();
+    expect(clients.useWebhookEndpoint).toBeDefined();
+    expect(clients.createWebhookEndpoint).toBeDefined();
+    expect(clients.updateWebhookEndpoint).toBeDefined();
+    expect(clients.deleteWebhookEndpoint).toBeDefined();
+  });
+
+  test("creates, lists, updates, and deletes webhook endpoints without leaking secrets", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    const created = await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "stripe" },
+      body: {
+        name: "Stripe",
+        status: "active",
+        deliveryIdentity: { type: "header", name: "stripe-event-id" },
+        auth: {
+          type: "hmac",
+          secret: "whsec_secret",
+          algorithm: "sha256",
+          signature: {
+            location: "header",
+            name: "stripe-signature",
+            encoding: "hex",
+            prefix: "v1=",
+          },
+          signedPayload: {
+            type: "timestampBody",
+            timestampHeader: "stripe-timestamp",
+            delimiter: ".",
+            toleranceSeconds: 300,
+          },
+        },
+      },
+    });
+    assert(created.type === "json");
+    assert(created.status === 201);
+    expect(created.data).toMatchObject({
+      id: "stripe",
+      name: "Stripe",
+      status: "active",
+      secretRefs: ["secret"],
+      authConfig: expect.objectContaining({ type: "hmac", secretRef: "secret" }),
+      deliveryIdentity: { type: "header", name: "stripe-event-id" },
+    });
+    expect(JSON.stringify(created.data)).not.toContain("whsec_secret");
+
+    const secrets = await readWebhookSecrets(setup, "stripe");
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0]).toMatchObject({ ref: "secret", payload: "whsec_secret" });
+
+    const list = await fragment.callRoute("GET", "/webhooks/endpoints");
+    assert(list.type === "json");
+    expect(list.data.endpoints).toEqual([expect.objectContaining({ id: "stripe" })]);
+
+    const read = await fragment.callRoute("GET", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "stripe" },
+    });
+    assert(read.type === "json");
+    expect(read.data).toMatchObject({ id: "stripe", name: "Stripe" });
+    expect(JSON.stringify(read.data)).not.toContain("whsec_secret");
+
+    const updated = await fragment.callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "stripe" },
+      body: {
+        status: "disabled",
+        auth: { type: "bearer", token: "new-token" },
+      },
+    });
+    assert(updated.type === "json");
+    expect(updated.data).toMatchObject({
+      id: "stripe",
+      status: "disabled",
+      secretRefs: ["token"],
+      authConfig: { type: "bearer", tokenRef: "token" },
+    });
+    expect(JSON.stringify(updated.data)).not.toContain("new-token");
+
+    const updatedSecrets = await readWebhookSecrets(setup, "stripe");
+    expect(updatedSecrets).toHaveLength(1);
+    expect(updatedSecrets[0]).toMatchObject({ ref: "token", payload: "new-token" });
+
+    const deleted = await fragment.callRoute("DELETE", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "stripe" },
+    });
+    assert(deleted.type === "empty");
+    assert(deleted.status === 204);
+
+    const repeatedDelete = await fragment.callRoute("DELETE", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "stripe" },
+    });
+    assert(repeatedDelete.type === "empty");
+    assert(repeatedDelete.status === 204);
+
+    expect(await readWebhookSecrets(setup, "stripe")).toHaveLength(0);
+
+    const missing = await fragment.callRoute("GET", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "stripe" },
+    });
+    assert(missing.type === "error");
+    assert(missing.error.code === "WEBHOOK_ENDPOINT_NOT_FOUND");
+
+    await setup.test.cleanup();
+  });
+
+  test("PATCH is idempotent and replaces webhook endpoint secrets when auth is provided", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "patched-webhook" },
+      body: {
+        name: "Before Patch",
+        status: "active",
+        deliveryIdentity: { type: "header", name: "x-event-id" },
+        auth: { type: "bearer", token: "before-token" },
+      },
+    });
+
+    const patchBody = {
+      name: "After Patch",
+      status: "disabled",
+      deliveryIdentity: { type: "query", name: "event_id" },
+      auth: { type: "basic", username: "ada", password: "lovelace" },
+    } as const;
+
+    const patched = await fragment.callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "patched-webhook" },
+      body: patchBody,
+    });
+    assert(patched.type === "json");
+    assert(patched.status === 200);
+    expect(patched.data).toMatchObject({
+      id: "patched-webhook",
+      name: "After Patch",
+      status: "disabled",
+      authConfig: { type: "basic", usernameRef: "username", passwordRef: "password" },
+      deliveryIdentity: { type: "query", name: "event_id" },
+      secretRefs: ["username", "password"],
+    });
+
+    const repeatedPatch = await fragment.callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "patched-webhook" },
+      body: patchBody,
+    });
+    assert(repeatedPatch.type === "json");
+    assert(repeatedPatch.status === 200);
+    expect(repeatedPatch.data).toMatchObject(patched.data);
+
+    const secrets = await readWebhookSecrets(setup, "patched-webhook");
+    expect(
+      secrets
+        .map((secret) => ({ ref: secret.ref, payload: secret.payload }))
+        .toSorted((left, right) => left.ref.localeCompare(right.ref)),
+    ).toEqual([
+      { ref: "password", payload: "lovelace" },
+      { ref: "username", payload: "ada" },
+    ]);
+
+    await setup.test.cleanup();
+  });
+
+  test("PATCH keeps existing webhook endpoint auth when auth is omitted", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "metadata-only" },
+      body: {
+        name: "Before",
+        status: "active",
+        deliveryIdentity: { type: "jsonBodyPath", path: ["event", "id"] },
+        auth: { type: "bearer", token: "kept-token" },
+      },
+    });
+
+    const patched = await fragment.callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "metadata-only" },
+      body: { name: "After" },
+    });
+    assert(patched.type === "json");
+    expect(patched.data).toMatchObject({
+      id: "metadata-only",
+      name: "After",
+      status: "active",
+      authConfig: { type: "bearer", tokenRef: "token" },
+      deliveryIdentity: { type: "jsonBodyPath", path: ["event", "id"] },
+      secretRefs: ["token"],
+    });
+
+    const secrets = await readWebhookSecrets(setup, "metadata-only");
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0]).toMatchObject({ ref: "token", payload: "kept-token" });
+
+    await setup.test.cleanup();
+  });
+
+  test("PATCH returns a stable not-found response for missing webhook endpoints", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    const first = await fragment.callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "missing-webhook" },
+      body: { name: "Missing" },
+    });
+    assert(first.type === "error");
+    assert(first.error.code === "WEBHOOK_ENDPOINT_NOT_FOUND");
+
+    const second = await fragment.callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "missing-webhook" },
+      body: { name: "Missing" },
+    });
+    assert(second.type === "error");
+    expect(second.error).toMatchObject(first.error);
+
+    await setup.test.cleanup();
+  });
+
+  test("DELETE is idempotent for missing webhook endpoints", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    const first = await fragment.callRoute("DELETE", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "missing-webhook" },
+    });
+    assert(first.type === "empty");
+    assert(first.status === 204);
+
+    const second = await fragment.callRoute("DELETE", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "missing-webhook" },
+    });
+    assert(second.type === "empty");
+    assert(second.status === 204);
+
+    await setup.test.cleanup();
+  });
+
+  test("PUT is idempotent and replaces webhook endpoint secrets", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    const body = {
+      name: "Idempotent",
+      status: "active",
+      deliveryIdentity: { type: "header", name: "x-event-id" },
+      auth: { type: "bearer", token: "first-token" },
+    } as const;
+
+    const created = await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "idempotent-webhook" },
+      body,
+    });
+    assert(created.type === "json");
+    assert(created.status === 201);
+
+    const repeated = await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "idempotent-webhook" },
+      body,
+    });
+    assert(repeated.type === "json");
+    assert(repeated.status === 200);
+    expect(repeated.data).toMatchObject(created.data);
+
+    const replaced = await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "idempotent-webhook" },
+      body: {
+        name: "Replaced",
+        status: "disabled",
+        deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+        auth: { type: "basic", username: "ada", password: "lovelace" },
+      },
+    });
+    assert(replaced.type === "json");
+    assert(replaced.status === 200);
+    expect(replaced.data).toMatchObject({
+      id: "idempotent-webhook",
+      name: "Replaced",
+      status: "disabled",
+      authConfig: { type: "basic", usernameRef: "username", passwordRef: "password" },
+      deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+      secretRefs: ["username", "password"],
+    });
+
+    const secrets = await readWebhookSecrets(setup, "idempotent-webhook");
+    expect(secrets).toHaveLength(2);
+    expect(
+      secrets
+        .map((secret) => ({ ref: secret.ref, payload: secret.payload }))
+        .toSorted((left, right) => left.ref.localeCompare(right.ref)),
+    ).toEqual([
+      { ref: "password", payload: "lovelace" },
+      { ref: "username", payload: "ada" },
+    ]);
+
+    await setup.test.cleanup();
+  });
+});

--- a/packages/api-fragment/src/webhooks/receive.test.ts
+++ b/packages/api-fragment/src/webhooks/receive.test.ts
@@ -1,0 +1,364 @@
+import { assert, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { instantiate } from "@fragno-dev/core";
+import { buildDatabaseFragmentsTest, drainDurableHooks } from "@fragno-dev/test";
+
+import type { WebhookDeliveryIdentity } from "../api-types";
+import { bytesToHex, signHmacBytes, utf8Bytes } from "../crypto";
+import { apiFragmentDefinition, type WebhookReceivedPayload } from "../definition";
+import { apiRoutesFactory } from "../routes";
+
+const onWebhookReceived = vi.fn();
+
+const buildApiTest = async () => {
+  const setup = await buildDatabaseFragmentsTest()
+    .withTestAdapter({ type: "kysely-sqlite" })
+    .withDbRoundtripGuard({ maxRoundtrips: 1 })
+    .withFragment(
+      "api",
+      instantiate(apiFragmentDefinition)
+        .withConfig({
+          publicBaseUrl: "https://app.test",
+          onWebhookReceived,
+        })
+        .withRoutes([apiRoutesFactory]),
+    )
+    .build();
+  return setup;
+};
+
+type ApiTest = Awaited<ReturnType<typeof buildApiTest>>;
+
+function webhookRequest(endpointId: string, init: RequestInit & { query?: string }) {
+  return new Request(
+    `https://app.test/api/api-fragment/webhooks/endpoints/${endpointId}/events${init.query ?? ""}`,
+    init,
+  );
+}
+
+async function createNoneWebhookEndpoint(
+  test: ApiTest,
+  endpointId: string,
+  deliveryIdentity: WebhookDeliveryIdentity = { type: "header", name: "x-event-id" },
+) {
+  const response = await test.fragments.api.fragment.callRoute(
+    "PUT",
+    "/webhooks/endpoints/:endpointId",
+    {
+      pathParams: { endpointId },
+      body: { name: endpointId, status: "active", deliveryIdentity, auth: { type: "none" } },
+    },
+  );
+  assert(response.type === "json");
+  return response;
+}
+
+describe("webhook receiving", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("receives webhooks through a durable hook using a header delivery ID", async () => {
+    const setup = await buildApiTest();
+    await createNoneWebhookEndpoint(setup, "incoming");
+
+    const response = await setup.fragments.api.fragment.handler(
+      webhookRequest("incoming", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-event-id": "evt_1" },
+        body: JSON.stringify({ ok: true }),
+      }),
+    );
+    assert(response.status === 202);
+    expect(onWebhookReceived).not.toHaveBeenCalled();
+
+    await drainDurableHooks(setup.fragments.api.fragment);
+
+    expect(onWebhookReceived).toHaveBeenCalledOnce();
+    expect(onWebhookReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointId: "incoming",
+        deliveryId: "evt_1",
+        hookId: expect.stringMatching(/^webhook_/),
+        headers: expect.objectContaining({
+          "content-type": "application/json",
+          "x-event-id": "evt_1",
+        }),
+        query: {},
+        body: { ok: true },
+        contentType: "application/json",
+      }) satisfies Partial<WebhookReceivedPayload>,
+    );
+
+    await setup.test.cleanup();
+  });
+
+  test("receives webhooks using a query delivery ID", async () => {
+    const setup = await buildApiTest();
+    await createNoneWebhookEndpoint(setup, "query-identity", {
+      type: "query",
+      name: "event_id",
+    });
+
+    const response = await setup.fragments.api.fragment.handler(
+      webhookRequest("query-identity", {
+        method: "POST",
+        query: "?event_id=evt_query",
+        body: "{}",
+      }),
+    );
+    assert(response.status === 202);
+
+    await drainDurableHooks(setup.fragments.api.fragment);
+
+    expect(onWebhookReceived).toHaveBeenCalledOnce();
+    expect(onWebhookReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointId: "query-identity",
+        deliveryId: "evt_query",
+        query: { event_id: "evt_query" },
+      }),
+    );
+
+    await setup.test.cleanup();
+  });
+
+  test("receives HMAC authenticated webhooks using a JSON body path delivery ID", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+    const body = JSON.stringify({ event: { id: "evt_json" }, type: "signed" });
+    const signature = bytesToHex(
+      await signHmacBytes({ algorithm: "sha256", secret: "hmac-secret", payload: utf8Bytes(body) }),
+    );
+
+    await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "signed" },
+      body: {
+        name: "Signed",
+        status: "active",
+        deliveryIdentity: { type: "jsonBodyPath", path: ["event", "id"] },
+        auth: {
+          type: "hmac",
+          secret: "hmac-secret",
+          algorithm: "sha256",
+          signature: {
+            location: "header",
+            name: "x-signature",
+            encoding: "hex",
+            prefix: "sha256=",
+          },
+          signedPayload: { type: "rawBody" },
+        },
+      },
+    });
+
+    const response = await fragment.handler(
+      webhookRequest("signed", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-signature": `sha256=${signature}` },
+        body,
+      }),
+    );
+    assert(response.status === 202);
+
+    await drainDurableHooks(fragment);
+
+    expect(onWebhookReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointId: "signed",
+        deliveryId: "evt_json",
+        headers: expect.objectContaining({ "x-signature": "[redacted]" }),
+        body: { event: { id: "evt_json" }, type: "signed" },
+      }),
+    );
+
+    await setup.test.cleanup();
+  });
+
+  test("rejects webhook deliveries before durable hook processing when endpoint auth fails", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "bearer" },
+      body: {
+        name: "Bearer",
+        status: "active",
+        deliveryIdentity: { type: "header", name: "x-event-id" },
+        auth: { type: "bearer", token: "expected-token" },
+      },
+    });
+
+    const response = await fragment.handler(
+      webhookRequest("bearer", {
+        method: "POST",
+        headers: { authorization: "Bearer wrong-token", "x-event-id": "evt_auth" },
+        body: "{}",
+      }),
+    );
+    assert(response.status === 401);
+    await expect(response.json()).resolves.toMatchObject({ code: "WEBHOOK_AUTH_FAILED" });
+
+    await drainDurableHooks(fragment);
+    expect(onWebhookReceived).not.toHaveBeenCalled();
+
+    await setup.test.cleanup();
+  });
+
+  test("rejects disabled and missing webhook endpoints without durable hook processing", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "disabled" },
+      body: {
+        name: "Disabled",
+        status: "disabled",
+        deliveryIdentity: { type: "header", name: "x-event-id" },
+        auth: { type: "none" },
+      },
+    });
+
+    const disabled = await fragment.handler(
+      webhookRequest("disabled", {
+        method: "POST",
+        headers: { "x-event-id": "evt_disabled" },
+        body: "{}",
+      }),
+    );
+    assert(disabled.status === 409);
+    await expect(disabled.json()).resolves.toMatchObject({ code: "WEBHOOK_ENDPOINT_DISABLED" });
+
+    const missing = await fragment.handler(
+      webhookRequest("missing", {
+        method: "POST",
+        headers: { "x-event-id": "evt_missing" },
+        body: "{}",
+      }),
+    );
+    assert(missing.status === 404);
+    await expect(missing.json()).resolves.toMatchObject({ code: "WEBHOOK_ENDPOINT_NOT_FOUND" });
+
+    await drainDurableHooks(fragment);
+    expect(onWebhookReceived).not.toHaveBeenCalled();
+
+    await setup.test.cleanup();
+  });
+
+  test("rejects deliveries when the configured delivery ID is missing or invalid", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+    await createNoneWebhookEndpoint(setup, "json-identity", {
+      type: "jsonBodyPath",
+      path: ["event", "id"],
+    });
+
+    const missing = await fragment.handler(
+      webhookRequest("json-identity", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ event: {} }),
+      }),
+    );
+    assert(missing.status === 400);
+    await expect(missing.json()).resolves.toMatchObject({ code: "WEBHOOK_DELIVERY_ID_MISSING" });
+
+    const invalid = await fragment.handler(
+      webhookRequest("json-identity", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ event: { id: { nested: true } } }),
+      }),
+    );
+    assert(invalid.status === 400);
+    await expect(invalid.json()).resolves.toMatchObject({ code: "WEBHOOK_DELIVERY_ID_INVALID" });
+
+    const invalidJson = await fragment.handler(
+      webhookRequest("json-identity", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{not-json",
+      }),
+    );
+    assert(invalidJson.status === 400);
+    await expect(invalidJson.json()).resolves.toMatchObject({
+      code: "WEBHOOK_BODY_INVALID",
+    });
+
+    await drainDurableHooks(fragment);
+    expect(onWebhookReceived).not.toHaveBeenCalled();
+
+    await setup.test.cleanup();
+  });
+
+  test("dedupes repeated webhook deliveries by derived durable hook ID", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+    const body = JSON.stringify({ eventId: "evt_same" });
+    await createNoneWebhookEndpoint(setup, "dedupe");
+
+    const first = await fragment.handler(
+      webhookRequest("dedupe", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-event-id": "evt_same" },
+        body,
+      }),
+    );
+    const second = await fragment.handler(
+      webhookRequest("dedupe", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-event-id": "evt_same" },
+        body,
+      }),
+    );
+    assert(first.status === 202);
+    assert(second.status === 202);
+
+    await drainDurableHooks(fragment);
+
+    expect(onWebhookReceived).toHaveBeenCalledTimes(1);
+    expect(onWebhookReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointId: "dedupe",
+        deliveryId: "evt_same",
+        body: { eventId: "evt_same" },
+      }),
+    );
+
+    await setup.test.cleanup();
+  });
+
+  test("does not dedupe different delivery IDs with the same body", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+    const body = JSON.stringify({ ok: true });
+    await createNoneWebhookEndpoint(setup, "different-deliveries");
+
+    const first = await fragment.handler(
+      webhookRequest("different-deliveries", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-event-id": "evt_1" },
+        body,
+      }),
+    );
+    const second = await fragment.handler(
+      webhookRequest("different-deliveries", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-event-id": "evt_2" },
+        body,
+      }),
+    );
+    assert(first.status === 202);
+    assert(second.status === 202);
+
+    await drainDurableHooks(fragment);
+
+    expect(onWebhookReceived).toHaveBeenCalledTimes(2);
+    expect(onWebhookReceived.mock.calls.map(([payload]) => payload.deliveryId).toSorted()).toEqual([
+      "evt_1",
+      "evt_2",
+    ]);
+
+    await setup.test.cleanup();
+  });
+});

--- a/packages/api-fragment/tsdown.config.ts
+++ b/packages/api-fragment/tsdown.config.ts
@@ -28,6 +28,7 @@ export default defineConfig([
       "./src/routes.ts",
       "./src/schema.ts",
       "./src/api-types.ts",
+      "./src/webhooks/auth.ts",
     ],
     dts: true,
     failOnWarn: true,

--- a/packages/fragno/src/api/request-input-context.ts
+++ b/packages/fragno/src/api/request-input-context.ts
@@ -22,6 +22,7 @@ export class RequestInputContext<
   readonly #searchParams: URLSearchParams;
   readonly #headers: Headers;
   readonly #body: string | undefined;
+  readonly #request: Request | undefined;
   readonly #parsedBody: RequestBodyType;
   readonly #inputSchema: TInputSchema | undefined;
   readonly #shouldValidateInput: boolean;
@@ -44,6 +45,7 @@ export class RequestInputContext<
     this.#searchParams = config.searchParams;
     this.#headers = config.headers;
     this.#body = config.rawBody;
+    this.#request = config.request;
     this.#parsedBody = config.parsedBody;
     this.#inputSchema = config.inputSchema;
     this.#shouldValidateInput = config.shouldValidateInput ?? true;
@@ -72,6 +74,7 @@ export class RequestInputContext<
       pathParams: config.state.pathParams as ExtractPathParams<TPath>,
       searchParams: config.state.searchParams,
       headers: config.state.headers,
+      request: config.request,
       parsedBody: config.state.body,
       rawBody: config.rawBody,
       inputSchema: config.inputSchema,
@@ -153,6 +156,10 @@ export class RequestInputContext<
 
   get rawBody(): string | undefined {
     return this.#body;
+  }
+
+  get request(): Request | undefined {
+    return this.#request;
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added webhook endpoint management—create, list, retrieve, update, and delete webhook endpoints.
  * Added webhook authentication support including bearer tokens, API keys, basic auth, and HMAC signatures.
  * Added webhook event receiving with delivery tracking and durable processing.
  * Added an “API webhook received” automation event and backoffice runtime/tools to manage and inspect webhook endpoints (including exposing a public URL when configured).

* **Tests**
  * Added comprehensive test coverage for webhook authentication, endpoint management, and webhook delivery flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->