### PR TITLE
fix(backoffice): repair workspace starter permissions

### DIFF
--- a/apps/backoffice/app/files/contributors/upload.test.ts
+++ b/apps/backoffice/app/files/contributors/upload.test.ts
@@ -11,7 +11,12 @@ import {
   uploadFileContributor,
   type FilePrincipal,
 } from "@/files";
-import { toUploadDirectoryMarkerFileKey } from "@/files/contributors/upload-markers";
+import { WORKSPACE_STARTER_CONTENT } from "@/files/content/starter";
+import {
+  createUploadDirectoryMarkerMetadata,
+  toUploadDirectoryMarkerFileKey,
+} from "@/files/contributors/upload-markers";
+import { seedWorkspaceStarterFiles } from "@/files/seed-workspace-starter-files";
 import { createFilesTestObjectRegistry } from "@/files/test-object-registry";
 import {
   UPLOAD_PROVIDER_DATABASE,
@@ -559,7 +564,7 @@ describe("upload file contributor", () => {
       __docsFs: {
         owner: { kind: "user", userId: "user-1" },
         group: { kind: "org", orgId: "acme-org" },
-        mode: 0o755,
+        mode: 0o775,
       },
     });
     expect(
@@ -677,6 +682,89 @@ describe("upload file contributor", () => {
         owner: { kind: "user", userId: "user-2" },
       },
     });
+  });
+
+  test("force seeding resets starter file and folder permissions without deleting custom files", async () => {
+    const runtime = createUploadRuntime({
+      [toUploadDirectoryMarkerFileKey("automations")]: {
+        content: "",
+        contentType: "application/x.fragno-directory-marker",
+        metadata: {
+          ...createUploadDirectoryMarkerMetadata(),
+          __docsFs: {
+            owner: { kind: "root" },
+            group: { kind: "root" },
+            mode: 0o755,
+          },
+        },
+      },
+      "automations/router.cm.js": {
+        content: "stale router",
+        metadata: {
+          __docsFs: {
+            owner: { kind: "root" },
+            group: { kind: "root" },
+            mode: 0o644,
+          },
+        },
+      },
+      "automations/custom.cm.js": {
+        content: "custom automation",
+        metadata: {
+          __docsFs: {
+            owner: { kind: "user", userId: "user-1" },
+            group: { kind: "org", orgId: "acme-org" },
+            mode: 0o664,
+          },
+        },
+      },
+    });
+    const objects = createFilesTestObjectRegistry({
+      uploadConfig: runtime.uploadConfig,
+      uploadRuntime: runtime,
+    });
+
+    await expect(
+      seedWorkspaceStarterFiles({ objects, orgId: "acme-org", force: true }),
+    ).resolves.toMatchObject({
+      force: true,
+      overwritten: expect.arrayContaining(["/workspace/automations/router.cm.js"]),
+    });
+
+    expect(
+      runtime.files.get(
+        composeStorageKey(UPLOAD_PROVIDER_DATABASE, toUploadDirectoryMarkerFileKey("automations")),
+      )?.metadata,
+    ).toMatchObject({
+      __docsFs: {
+        owner: { kind: "root" },
+        group: { kind: "org", orgId: "acme-org" },
+        mode: 0o775,
+      },
+    });
+    expect(
+      runtime.files.get(composeStorageKey(UPLOAD_PROVIDER_DATABASE, "automations/router.cm.js"))
+        ?.metadata,
+    ).toMatchObject({
+      __docsFs: {
+        owner: { kind: "root" },
+        group: { kind: "org", orgId: "acme-org" },
+        mode: 0o664,
+      },
+    });
+    await expect(
+      createUploadFileSystem(
+        createSystemFilesContext({
+          orgId: "acme-org",
+          origin: runtime.baseUrl,
+          objects,
+        }),
+        { provider: UPLOAD_PROVIDER_DATABASE },
+      ).readFile("/workspace/automations/router.cm.js"),
+    ).resolves.toBe(WORKSPACE_STARTER_CONTENT["automations/router.cm.js"]);
+    assert(
+      runtime.files.has(composeStorageKey(UPLOAD_PROVIDER_DATABASE, "automations/custom.cm.js")),
+    );
   });
 
   test("contributor createFileSystem returns null when uploads are unavailable", async () => {

--- a/apps/backoffice/app/files/contributors/upload.ts
+++ b/apps/backoffice/app/files/contributors/upload.ts
@@ -117,7 +117,7 @@ const concatBytes = (left: Uint8Array, right: Uint8Array): Uint8Array => {
 };
 const UPLOAD_FS_METADATA_KEY = "__docsFs";
 const DEFAULT_FILE_MODE = 0o664;
-const DEFAULT_FOLDER_MODE = 0o755;
+const DEFAULT_FOLDER_MODE = 0o775;
 const DEFAULT_MOUNT_ROOT_MODE = 0o775;
 const UPLOAD_DIRECTORY_LIST_PAGE_SIZE = "500";
 const RESERVED_UPLOAD_DIRECTORY_NAMES = new Set([".fragno"]);

--- a/apps/backoffice/app/files/permissions.ts
+++ b/apps/backoffice/app/files/permissions.ts
@@ -97,7 +97,14 @@ export const resolveActorFilePrincipal = ({
   scope: BackofficeContextScope;
 }): FilePrincipal => {
   if (actor.type === "system") {
-    return ROOT_FILE_PRINCIPAL;
+    const primaryGroup = getScopePrimaryFileGroup(scope);
+    return {
+      subject: ROOT_FILE_PRINCIPAL.subject,
+      primaryGroup,
+      groups: sameFileGroup(primaryGroup, ROOT_FILE_PRINCIPAL.primaryGroup)
+        ? [primaryGroup]
+        : [ROOT_FILE_PRINCIPAL.primaryGroup, primaryGroup],
+    };
   }
 
   if (actor.type === "user") {

--- a/apps/backoffice/app/files/seed-workspace-starter-files.ts
+++ b/apps/backoffice/app/files/seed-workspace-starter-files.ts
@@ -1,9 +1,13 @@
 import type { BackofficeObjectRegistry } from "@/backoffice-runtime/object-registry";
-import { createSystemFilesContext } from "@/files";
+import { createSystemFilesContext, type FileGroup, type FileSubject } from "@/files";
 import { WORKSPACE_STARTER_CONTENT } from "@/files/content/starter";
 import { createUploadFileSystem } from "@/files/contributors/upload";
 import { FileSystemError } from "@/files/fs-errors";
 import type { IFileSystem } from "@/files/interface";
+
+const WORKSPACE_ROOT = "/workspace";
+const WORKSPACE_STARTER_FILE_MODE = 0o664;
+const WORKSPACE_STARTER_FOLDER_MODE = 0o775;
 
 const fileExists = async (fs: IFileSystem, path: string) => {
   try {
@@ -16,6 +20,44 @@ const fileExists = async (fs: IFileSystem, path: string) => {
 
     throw error;
   }
+};
+
+const toWorkspacePath = (relativePath: string) => {
+  const normalizedPath = relativePath.replace(/^\/+/, "");
+  return normalizedPath.startsWith("workspace/")
+    ? `/${normalizedPath}`
+    : `${WORKSPACE_ROOT}/${normalizedPath}`;
+};
+
+const getParentDirectories = (path: string) => {
+  const segments = path.split("/").filter(Boolean);
+  const directories: string[] = [];
+
+  for (let index = 1; index < segments.length; index += 1) {
+    const directory = `/${segments.slice(0, index).join("/")}`;
+    if (directory !== WORKSPACE_ROOT) {
+      directories.push(directory);
+    }
+  }
+
+  return directories;
+};
+
+const resetStarterNodePermissions = async ({
+  fs,
+  path,
+  owner,
+  group,
+  mode,
+}: {
+  fs: IFileSystem;
+  path: string;
+  owner: FileSubject;
+  group: FileGroup;
+  mode: number;
+}) => {
+  await fs.chown?.(path, owner, group);
+  await fs.chmod(path, mode);
 };
 
 export type WorkspaceStarterFilesSeedOutput = {
@@ -38,22 +80,40 @@ export const seedWorkspaceStarterFiles = async ({
   const uploadDo = objects.upload.forOrg(orgId);
   const uploadConfig = await uploadDo.getAdminConfig();
   const provider = uploadConfig.defaultProvider ?? "database";
-  const fs = createUploadFileSystem(createSystemFilesContext({ orgId, objects }), {
-    mountPoint: "/workspace",
+  const fileContext = createSystemFilesContext({ orgId, objects });
+  const fs = createUploadFileSystem(fileContext, {
+    mountPoint: WORKSPACE_ROOT,
     provider,
   });
 
   const starterContent = WORKSPACE_STARTER_CONTENT;
+  const workspaceOwner = fileContext.filePrincipal.subject;
+  const workspaceGroup = fileContext.filePrincipal.primaryGroup;
 
   const created: string[] = [];
   const overwritten: string[] = [];
   const skipped: string[] = [];
 
+  const starterPaths = Object.keys(starterContent).map(toWorkspacePath);
+  const starterDirectories = Array.from(
+    new Set(starterPaths.flatMap((path) => getParentDirectories(path))),
+  ).sort((left, right) => left.localeCompare(right));
+
+  if (force) {
+    for (const directory of starterDirectories) {
+      await fs.mkdir(directory, { recursive: true });
+      await resetStarterNodePermissions({
+        fs,
+        path: directory,
+        owner: workspaceOwner,
+        group: workspaceGroup,
+        mode: WORKSPACE_STARTER_FOLDER_MODE,
+      });
+    }
+  }
+
   for (const [relativePath, content] of Object.entries(starterContent)) {
-    const normalizedPath = relativePath.replace(/^\/+/, "");
-    const path = normalizedPath.startsWith("workspace/")
-      ? `/${normalizedPath}`
-      : `/workspace/${normalizedPath}`;
+    const path = toWorkspacePath(relativePath);
     const exists = await fileExists(fs, path);
 
     if (exists && !force) {
@@ -61,7 +121,22 @@ export const seedWorkspaceStarterFiles = async ({
       continue;
     }
 
+    if (force && exists) {
+      await fs.rm(path, { force: true });
+    }
+
     await fs.writeFile(path, content);
+
+    if (force) {
+      await resetStarterNodePermissions({
+        fs,
+        path,
+        owner: workspaceOwner,
+        group: workspaceGroup,
+        mode: WORKSPACE_STARTER_FILE_MODE,
+      });
+    }
+
     (exists ? overwritten : created).push(path);
   }
 

--- a/apps/backoffice/app/fragno/automation/scenario-system-automations.test.ts
+++ b/apps/backoffice/app/fragno/automation/scenario-system-automations.test.ts
@@ -4,7 +4,12 @@ import {
   createInMemoryBackofficeRuntime,
   type InMemoryBackofficeRuntime,
 } from "@/backoffice-runtime/in-memory-runtime";
-import { createMasterFileSystem, createSystemFilesContext } from "@/files";
+import { BackofficeKernel } from "@/backoffice-runtime/kernel";
+import {
+  createBackofficeFileSystem,
+  createMasterFileSystem,
+  createSystemFilesContext,
+} from "@/files";
 
 import type { AutomationEvent } from "./contracts";
 import { createRouteBackedAutomationWorkflowRuntime } from "./workflow-route-runtime";
@@ -126,6 +131,26 @@ describe("system automation scenarios", () => {
       await expect(fs.readFile("/workspace/AGENTS.md")).resolves.toContain("Workspace guidance");
       await expect(fs.readFile("/workspace/codemode.d.ts")).resolves.toContain(
         "declare const capabilities",
+      );
+
+      const userFs = await createBackofficeFileSystem({
+        objects: runtime.objects,
+        kernel: new BackofficeKernel({ objects: runtime.objects }),
+        execution: {
+          actor: {
+            type: "user",
+            id: "user-1",
+            userId: "user-1",
+            organizationIds: [orgId],
+          },
+          scope: { kind: "org", orgId },
+        },
+      });
+      await expect(
+        userFs.writeFile("/workspace/automations/bla.txt", "dashboard can write"),
+      ).resolves.toBeUndefined();
+      await expect(userFs.readFile("/workspace/automations/bla.txt")).resolves.toBe(
+        "dashboard can write",
       );
     } finally {
       await runtime.cleanup();

--- a/apps/backoffice/app/fragno/runtime-tools/families/internal.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/internal.ts
@@ -176,7 +176,7 @@ const filesSeedExecuteTool = defineBackofficeRuntimeTool({
         options: [
           {
             name: "force",
-            description: "Overwrite starter files that already exist.",
+            description: "Replace starter files and repair starter file/folder permissions.",
           },
         ],
         examples: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Starter workspace files now restore the correct folder and file permissions when force-seeded, while preserving custom files.
  * New workspace directories created during upload-backed file handling now use the updated default permission settings.
  * System access now applies the appropriate group-based file permissions in scoped environments.

* **Documentation**
  * Improved command help text to clarify what force-seeding changes in workspace starter files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->