### PR TITLE
Wilco/better automation route UI

### DIFF
--- a/.changeset/fuzzy-auth-slugs.md
+++ b/.changeset/fuzzy-auth-slugs.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/auth": patch
+---
+
+fix: scope default auto-created organization slugs by user.

--- a/.changeset/upload-text-index-search.md
+++ b/.changeset/upload-text-index-search.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/upload": patch
+---
+
+feat: add text index powered file search.

--- a/apps/backoffice/STATIC_SYSTEM_SPLIT_NOTES.md
+++ b/apps/backoffice/STATIC_SYSTEM_SPLIT_NOTES.md
@@ -1,0 +1,130 @@
+# Static/System Filesystem Split Notes
+
+This documents the important follow-up review points for the `/static` + `/system` filesystem split.
+
+## Summary
+
+The filesystem split is now:
+
+- `/static`: product-owned, read-only, visible support files for all normal scopes.
+- `/system`: admin/system-scope filesystem for system execution files only.
+- `/workspace`: editable org/user/project workspace files.
+
+Key implementation points:
+
+- Static mount implementation: `app/files/contributors/static.ts`
+- Static content bundle: `app/files/content/static.ts`
+- System content bundle: `app/files/content/system.ts`
+- Static automation content: `app/files/content/static-automations.ts`
+- System automation content: `app/files/content/system-automations.ts`
+- Built-in contributor registration: `app/files/contributors/index.ts`
+- Mount ordering: `app/files/master-file-system.ts`
+
+## Things to be aware of
+
+### 1. `/static/codemode/**` is generated on demand
+
+Codemode declarations are no longer persisted by a sync workflow. They are generated into the
+`/static` mount when the filesystem is read.
+
+Review:
+
+- `app/fragno/codemode/static-codemode-artifacts.ts`
+- `app/files/contributors/static.ts`
+- `app/files/create-file-system.ts`
+- `app/files/system-context.ts`
+- `app/files/types.ts`
+
+Call sites that provide generated static artifacts:
+
+- `app/routes/backoffice/files/data.ts`
+- `app/routes/backoffice/automations/data.server.ts`
+- `app/routes/backoffice/terminal.server.ts`
+- `app/routes/backoffice/pi-terminal-action.ts`
+- `app/routes/dev/codemode.ts`
+- `app/routes/dev/codemode-bash.ts`
+- `app/routes/dev/codemode-system-md.ts`
+- `app/fragno/pi/pi.ts`
+- `app/fragno/automation/scenario.ts`
+
+Potential follow-up: add request/session-level caching if repeated `/static/codemode` reads become
+expensive.
+
+### 2. `internal.codemode.types.sync` was removed
+
+The old sync tool and refresh workflow/routes are gone because generated codemode files are now
+read-time artifacts.
+
+Review:
+
+- Removed from `app/fragno/runtime-tools/families/internal.ts`
+- Removed route definitions from `app/fragno/automation/content/starter-routing.ts`
+- Removed static workflow from `app/files/content/static-automations.ts`
+- Workspace initialization no longer calls it in `app/files/content/system-automations.ts`
+
+Behavioral impact: capability/MCP changes no longer create “codemode refresh” workflow history. The
+next read of `/static/codemode/**` reflects current config.
+
+### 3. `/system` visibility is now restricted
+
+`/system` is no longer the visible product content mount. Non-admin/user automation contexts should
+use `/static`.
+
+Review:
+
+- Visibility gate: `app/files/contributors/static.ts`
+- Automations default filesystem: `workers/automations.do.ts`
+- Automation roots/layers: `app/fragno/automation/catalog.ts`
+
+Important path moves:
+
+- `/system/SYSTEM.md` → `/static/SYSTEM.md`
+- `/system/skills/**` → `/static/skills/**`
+- `/system/automations/project-files-configure.workflow.js` →
+  `/static/automations/project-files-configure.workflow.js`
+- `/system/automations/workspace-file-initialization.workflow.js` stays in `/system`
+
+### 4. Workspace starter no longer seeds built-in skills
+
+Built-in skills now live only in `/static/skills`. `/workspace/skills` remains supported for
+user-authored custom skills, but built-ins are no longer copied there by starter seeding.
+
+Review:
+
+- `app/files/content/starter.ts`
+- Pi skill lookup: `app/fragno/pi/pi-skills.ts`
+- Prompt guidance: `app/files/content/static.ts`
+- Connection skill guidance: `app/files/content/skills.ts`
+
+### 5. Automation script layers now include `static`
+
+Automation catalog layers are now:
+
+- `static`
+- `system`
+- `workspace`
+
+Review:
+
+- `app/fragno/automation/catalog.ts`
+- UI/data mapping: `app/routes/backoffice/automations/data.server.ts`
+- Starter routes: `app/fragno/automation/content/starter-routing.ts`
+
+### 6. Generated `.d.ts` ordering changed
+
+`app/fragno/runtime-tools/reference.ts` now emits the provider type alias before detailed
+input/output declarations. Tests pass, but this is a generated declaration ordering change and may
+be worth a quick review.
+
+Review:
+
+- `app/fragno/runtime-tools/reference.ts`
+- `app/fragno/runtime-tools/reference.test.ts`
+
+## Validation already run
+
+```bash
+pnpm exec tsgo --noEmit --pretty false --project apps/backoffice/tsconfig.json
+```
+
+Relevant Vitest suites passed: 17 files, 175 tests.

--- a/apps/backoffice/app/components/cadence/prompt/dev/dev-input.tsx
+++ b/apps/backoffice/app/components/cadence/prompt/dev/dev-input.tsx
@@ -95,7 +95,7 @@ export function DevInput() {
               value={terminal.command}
               onChange={(event) => terminal.onCommandChange(event.target.value)}
               onKeyDown={terminal.onCommandKeyDown}
-              placeholder="Run a bash command (e.g. ls /workspace, pwd, find /system)"
+              placeholder="Run a bash command (e.g. ls /workspace, pwd, find /static)"
               className="min-w-0 flex-1 bg-transparent py-2.5 pl-3 font-mono text-sm text-[var(--cad-fg)] placeholder:text-[var(--cad-muted-2)] focus:outline-none sm:pl-0"
               autoCapitalize="off"
               autoComplete="off"

--- a/apps/backoffice/app/files/actions.test.ts
+++ b/apps/backoffice/app/files/actions.test.ts
@@ -16,6 +16,8 @@ const context: FilesContext = createSystemFilesContext({
     scope: { kind: "org", orgId: "org_123" },
   },
   backend: "backoffice",
+
+  staticFileArtifacts: () => ({}),
 });
 
 const contributors: FileContributor[] = [];

--- a/apps/backoffice/app/files/content/automations.test.ts
+++ b/apps/backoffice/app/files/content/automations.test.ts
@@ -10,16 +10,26 @@ import {
   STARTER_AUTOMATION_SCRIPT_PATHS,
   WORKSPACE_STARTER_AUTOMATION_CONTENT,
 } from "./starter-automations";
+import { STATIC_AUTOMATION_CONTENT, STATIC_AUTOMATION_SCRIPT_PATHS } from "./static-automations";
 import { SYSTEM_AUTOMATION_CONTENT, SYSTEM_AUTOMATION_SCRIPT_PATHS } from "./system-automations";
 
 type WorkspaceAutomationPath = keyof typeof WORKSPACE_STARTER_AUTOMATION_CONTENT;
 
+type StaticAutomationPath = keyof typeof STATIC_AUTOMATION_CONTENT;
 type SystemAutomationPath = keyof typeof SYSTEM_AUTOMATION_CONTENT;
 
 const readWorkspaceAutomation = (path: WorkspaceAutomationPath) => {
   const content = WORKSPACE_STARTER_AUTOMATION_CONTENT[path];
   if (typeof content !== "string") {
     throw new Error(`Expected workspace automation '${path}'.`);
+  }
+  return content;
+};
+
+const readStaticAutomation = (path: StaticAutomationPath) => {
+  const content = STATIC_AUTOMATION_CONTENT[path];
+  if (typeof content !== "string") {
+    throw new Error(`Expected static automation '${path}'.`);
   }
   return content;
 };
@@ -121,13 +131,12 @@ describe("automation content", () => {
     );
   });
 
-  test("system automation content includes built-in system workflows", () => {
+  test("automation content separates static and system workflows", () => {
+    expect(Object.keys(STATIC_AUTOMATION_CONTENT).sort()).toEqual(
+      [STATIC_AUTOMATION_SCRIPT_PATHS.projectFilesConfigure].sort(),
+    );
     expect(Object.keys(SYSTEM_AUTOMATION_CONTENT).sort()).toEqual(
-      [
-        SYSTEM_AUTOMATION_SCRIPT_PATHS.codemodeTypesRefresh,
-        SYSTEM_AUTOMATION_SCRIPT_PATHS.projectFilesConfigure,
-        SYSTEM_AUTOMATION_SCRIPT_PATHS.workspaceFileInitialization,
-      ].sort(),
+      [SYSTEM_AUTOMATION_SCRIPT_PATHS.workspaceFileInitialization].sort(),
     );
   });
 
@@ -153,7 +162,7 @@ describe("automation content", () => {
           eventType: "project.created",
           action: expect.objectContaining({
             remoteWorkflowName: "project-files-configure",
-            workflowScriptPath: "/system/automations/project-files-configure.workflow.js",
+            workflowScriptPath: "/static/automations/project-files-configure.workflow.js",
           }),
         }),
       ]),
@@ -173,7 +182,7 @@ describe("automation content", () => {
   });
 
   test("project creation workflow configures project files", () => {
-    const workflow = readSystemAutomation(SYSTEM_AUTOMATION_SCRIPT_PATHS.projectFilesConfigure);
+    const workflow = readStaticAutomation(STATIC_AUTOMATION_SCRIPT_PATHS.projectFilesConfigure);
 
     expect(workflow).toContain('{ name: "project-files-configure" }');
     expect(workflow).toContain('automationEvent.eventType !== "project.created"');

--- a/apps/backoffice/app/files/content/backoffice-capability-files.test.ts
+++ b/apps/backoffice/app/files/content/backoffice-capability-files.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, test } from "vitest";
 import { backofficeCapabilities } from "@/fragno/backoffice-capabilities/backoffice-capabilities";
 
 import type { FileSystemArtifact } from "../types";
-import { SYSTEM_FILE_CONTENT } from "./system";
+import { STATIC_FILE_CONTENT } from "./static";
 
-const SYSTEM_CONTENT = SYSTEM_FILE_CONTENT as Record<string, FileSystemArtifact>;
+const STATIC_CONTENT = STATIC_FILE_CONTENT as Record<string, FileSystemArtifact>;
 
 const skillNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 
-const readSystemText = (path: string) => {
-  const content = SYSTEM_CONTENT[path];
+const readStaticText = (path: string) => {
+  const content = STATIC_CONTENT[path];
   if (typeof content !== "string") {
     throw new Error(`Expected '${path}' to be string content.`);
   }
@@ -22,7 +22,7 @@ const readSkillName = (skill: string) => {
   return match?.groups?.name ?? "";
 };
 
-describe("Backoffice capability system skills", () => {
+describe("Backoffice capability static skills", () => {
   test("capability skills are spec-shaped static skills", () => {
     for (const capability of backofficeCapabilities) {
       const skillPaths = Object.keys(capability.files ?? {}).filter(
@@ -32,7 +32,7 @@ describe("Backoffice capability system skills", () => {
       expect(skillPaths).toHaveLength(Object.keys(capability.files ?? {}).length);
 
       for (const skillPath of skillPaths) {
-        const skill = readSystemText(skillPath);
+        const skill = readStaticText(skillPath);
         const skillName = readSkillName(skill);
 
         expect(skillName).toMatch(skillNamePattern);
@@ -40,9 +40,9 @@ describe("Backoffice capability system skills", () => {
         expect(capability.files?.[skillPath]).toBe(skill);
         expect(skill).toContain("description:");
         expect(skill).toContain("#");
-        expect(SYSTEM_CONTENT[`skills/${skillName}/references/configuration.md`]).toBeUndefined();
-        expect(SYSTEM_CONTENT[`skills/${skillName}/references/events.md`]).toBeUndefined();
-        expect(SYSTEM_CONTENT[`skills/${skillName}/references/tools.md`]).toBeUndefined();
+        expect(STATIC_CONTENT[`skills/${skillName}/references/configuration.md`]).toBeUndefined();
+        expect(STATIC_CONTENT[`skills/${skillName}/references/events.md`]).toBeUndefined();
+        expect(STATIC_CONTENT[`skills/${skillName}/references/tools.md`]).toBeUndefined();
       }
     }
   });
@@ -60,7 +60,7 @@ describe("Backoffice capability system skills", () => {
   });
 
   test("Telegram skill documents its primary event and tools", () => {
-    const skill = readSystemText("skills/telegram-connection/SKILL.md");
+    const skill = readStaticText("skills/telegram-connection/SKILL.md");
 
     expect(skill).toContain("source`: `telegram`");
     expect(skill).toContain("eventType`: `message.received`");
@@ -69,7 +69,7 @@ describe("Backoffice capability system skills", () => {
   });
 
   test("MCP skill documents OAuth setup and tools", () => {
-    const skill = readSystemText("skills/mcp-connection/SKILL.md");
+    const skill = readStaticText("skills/mcp-connection/SKILL.md");
 
     expect(skill).toContain("public OAuth callback route");
     expect(skill).toContain('auth: { type: "oauth" }');
@@ -78,14 +78,14 @@ describe("Backoffice capability system skills", () => {
   });
 
   test("general starter skills cover automations, connections, workflows, and sandbox", () => {
-    expect(readSystemText("skills/building-automations/SKILL.md")).toContain(
+    expect(readStaticText("skills/building-automations/SKILL.md")).toContain(
       "events.eventsCatalogList",
     );
-    expect(readSystemText("skills/building-automations/SKILL.md")).toContain("router.create");
-    expect(readSystemText("skills/configuring-connections/SKILL.md")).toContain(
+    expect(readStaticText("skills/building-automations/SKILL.md")).toContain("router.create");
+    expect(readStaticText("skills/configuring-connections/SKILL.md")).toContain(
       "connections.configure",
     );
-    expect(readSystemText("skills/workflows/SKILL.md")).toContain("defineWorkflow");
-    expect(readSystemText("skills/sandbox/SKILL.md")).toContain("sandbox.startSandbox");
+    expect(readStaticText("skills/workflows/SKILL.md")).toContain("defineWorkflow");
+    expect(readStaticText("skills/sandbox/SKILL.md")).toContain("sandbox.startSandbox");
   });
 });

--- a/apps/backoffice/app/files/content/skills.ts
+++ b/apps/backoffice/app/files/content/skills.ts
@@ -182,7 +182,7 @@ const telegram = await connections.get({ id: "telegram" });
 const schema = await connections.schema({ id: "telegram" });
 \`\`\`
 
-2. Read the relevant connection skill in \`/system/skills/<connection-or-system>/SKILL.md or /workspace/skills/<connection-or-system>/SKILL.md\` for capability-specific fields and gotchas.
+2. Read the relevant connection skill in \`/static/skills/<connection-or-system>/SKILL.md or /workspace/skills/<connection-or-system>/SKILL.md\` for capability-specific fields and gotchas.
 
 3. Work with the user to obtain required information. Do not invent secrets, API keys, sender addresses, webhook origins, public tunnel URLs, bucket configuration, or model provider keys.
 

--- a/apps/backoffice/app/files/content/starter.ts
+++ b/apps/backoffice/app/files/content/starter.ts
@@ -1,5 +1,4 @@
 import type { FileSystemArtifact } from "../types";
-import { GENERAL_SKILL_CONTENT } from "./skills";
 import { WORKSPACE_STARTER_AUTOMATION_CONTENT } from "./starter-automations";
 
 export const WORKSPACE_STARTER_CONTENT: Record<string, FileSystemArtifact> = {
@@ -7,7 +6,7 @@ export const WORKSPACE_STARTER_CONTENT: Record<string, FileSystemArtifact> = {
 
 This is the editable organisation workspace. User-owned automations live in \`/workspace/automations/\` and may be changed freely.
 
-System-owned guidance and automations live in \`/system\` and are read-only.
+Product-owned guidance and static automations live in \`/static\` and are read-only.
 `,
   "README.md": `# Workspace starter content
 
@@ -28,5 +27,4 @@ Describe the task you want to work on here.
 `,
   "output/.gitkeep": "",
   ...WORKSPACE_STARTER_AUTOMATION_CONTENT,
-  ...GENERAL_SKILL_CONTENT,
 };

--- a/apps/backoffice/app/files/content/static-automations.ts
+++ b/apps/backoffice/app/files/content/static-automations.ts
@@ -1,0 +1,31 @@
+import type { FileSystemArtifact } from "../types";
+
+export const STATIC_AUTOMATION_SCRIPT_PATHS = {
+  projectFilesConfigure: "automations/project-files-configure.workflow.js",
+} as const;
+
+export const STATIC_AUTOMATION_CONTENT: Record<string, FileSystemArtifact> = {
+  "automations/project-files-configure.workflow.js": `defineWorkflow(
+  { name: "project-files-configure" },
+  async (event, step) => {
+    const automationEvent = event.payload.automationEvent;
+
+    if (
+      automationEvent.source !== "automations" ||
+      automationEvent.eventType !== "project.created"
+    ) {
+      return { skipped: true, reason: "not-project-created" };
+    }
+
+    const projectId = automationEvent.subject?.projectId ?? automationEvent.payload.project?.id;
+    if (!projectId) {
+      throw new Error("project.created event is missing subject.projectId.");
+    }
+
+    return await step.do("configure project database filesystem", async () => {
+      return await internal.projectFilesConfigure({ projectId });
+    });
+  },
+);
+`,
+};

--- a/apps/backoffice/app/files/content/static.ts
+++ b/apps/backoffice/app/files/content/static.ts
@@ -1,0 +1,106 @@
+import type { FileSystemArtifact } from "../types";
+import { BACKOFFICE_CAPABILITY_FILE_CONTENT } from "./backoffice-capability-files";
+import { GENERAL_SKILL_CONTENT } from "./skills";
+import { STATIC_AUTOMATION_CONTENT } from "./static-automations";
+
+export const renderStaticGuidance = ({
+  codemodeDts,
+  stateDts,
+  workflowAuthoringDts,
+}: {
+  codemodeDts: string;
+  stateDts: string;
+  workflowAuthoringDts: string;
+}) =>
+  STATIC_GUIDANCE_MD.replace("__BACKOFFICE_CODEMODE_DTS__", codemodeDts.trimEnd())
+    .replace("__BACKOFFICE_CODEMODE_STATE_DTS__", stateDts.trimEnd())
+    .replace("__BACKOFFICE_CODEMODE_WORKFLOW_AUTHORING_DTS__", workflowAuthoringDts.trimEnd());
+
+export const STATIC_GUIDANCE_MD = `# Backoffice System Guidance
+
+You are an assistant inside The Backoffice, built by ReJot. The user sees your messages in an IM interface, so be concise and direct.
+
+Prefer acting over asking. Execute codemode over asking. NEVER present code to the user, ALWAYS execute instead.
+
+## Interacting with the system
+
+Your main way of interacting with the system is through the Codemode tool. You write JavaScript to perform tasks. Below are the basic types of the APIs available to you. Further declarations are referenced and can be read.
+
+Provider declarations are split by namespace. Read .d.ts files when relevant. Do not guess APIs, invent aliases, or rely on memory.
+
+Codemode snippets always start with either \`async () => {}\` or \`defineWorkflow\`. NEVER Both, i.e. no defineWorkflow inside an async function.
+
+Use the former for simple one-off tasks, and the latter for multi-step workflows. 
+
+Inline defined workflows automatically start running and will return their instanceId, this can be used to check its status.
+
+You do NOT have to write workflows to a file to execute them. ONLY do this when the user SPECIFICALLY asks you to save a workflow for later use.
+
+\`\`\`js
+defineWorkflow({ name: "my-workflow" }, async (event, step) => {
+  // durable steps, retries, sleeps, waits
+
+  const started = await step.do("generate-start-info", async () => {
+    return {
+      randomNumber: Math.floor(Math.random() * 1000),
+    };
+  });
+
+  await step.sleep("cooldown", "2 seconds");
+
+  return {
+    number: started.randomNumber,
+  };
+});
+\`\`\`
+
+## Codemode TypeScript reference
+
+The following declarations are always available: generated reference paths and scoped \`context.*\`, the full state API, and the workflow authoring API. Provider declarations live in the referenced provider files and should be loaded as needed.
+
+\`\`\`ts
+__BACKOFFICE_CODEMODE_DTS__
+
+__BACKOFFICE_CODEMODE_STATE_DTS__
+
+__BACKOFFICE_CODEMODE_WORKFLOW_AUTHORING_DTS__
+\`\`\`
+
+## Files and automations
+
+- Product-owned reference files live in \`/static/\` and are visible to every scope.
+- System-scoped admin automations live in \`/system/automations/\` and are only visible in system/admin contexts.
+- User-editable automations live in \`/workspace/automations/\`.
+- Automation codemode scripts read event data from \`/context/event.json\` with \`state.readFile\` and must return JSON-serializable values.
+
+## Events
+
+Backoffice is event-driven. The last 200 ingested events are available as JSON files in \`/events/YYYY-MM-DD/\`; errors are written as text files in the same directory.
+
+Before working with events, inspect the event catalog:
+
+\`\`\`js
+const catalog = await events.eventsCatalogList({});
+const telegramMessage = await events.eventsCatalogGet({
+  source: "telegram",
+  type: "message.received",
+});
+const entry = await events.getEvent({ hookId });
+\`\`\`
+
+## Skills
+
+When available skills list a matching skill, read the corresponding \`/static/skills/<skill-name>/SKILL.md\` or \`/workspace/skills/<skill-name>/SKILL.md\` before proceeding. NEVER use \`limit\` when reading skills.
+
+## Bash reference
+
+Prefer codemode for Backoffice work. Use bash for shell-oriented tasks. The bash host also exposes \`isogit\`, a thin isomorphic-git command with \`clone\`, \`status\`, and bounded non-network \`call\` support. Run \`isogit --help\` for usage.
+
+`;
+
+export const STATIC_FILE_CONTENT = {
+  "SYSTEM.md": STATIC_GUIDANCE_MD,
+  ...STATIC_AUTOMATION_CONTENT,
+  ...BACKOFFICE_CAPABILITY_FILE_CONTENT,
+  ...GENERAL_SKILL_CONTENT,
+} satisfies Record<string, FileSystemArtifact>;

--- a/apps/backoffice/app/files/content/system-automations.ts
+++ b/apps/backoffice/app/files/content/system-automations.ts
@@ -2,43 +2,9 @@ import type { FileSystemArtifact } from "../types";
 
 export const SYSTEM_AUTOMATION_SCRIPT_PATHS = {
   workspaceFileInitialization: "automations/workspace-file-initialization.workflow.js",
-  projectFilesConfigure: "automations/project-files-configure.workflow.js",
-  codemodeTypesRefresh: "automations/codemode-types-refresh.workflow.js",
 } as const;
 
 export const SYSTEM_AUTOMATION_CONTENT: Record<string, FileSystemArtifact> = {
-  "automations/codemode-types-refresh.workflow.js": `defineWorkflow(
-  { name: "codemode-types-refresh" },
-  async (_event, step) => {
-    return await step.do("sync codemode dts", async () => {
-      return await internal.codemodeTypesSync({});
-    });
-  },
-);
-`,
-  "automations/project-files-configure.workflow.js": `defineWorkflow(
-  { name: "project-files-configure" },
-  async (event, step) => {
-    const automationEvent = event.payload.automationEvent;
-
-    if (
-      automationEvent.source !== "automations" ||
-      automationEvent.eventType !== "project.created"
-    ) {
-      return { skipped: true, reason: "not-project-created" };
-    }
-
-    const projectId = automationEvent.subject?.projectId ?? automationEvent.payload.project?.id;
-    if (!projectId) {
-      throw new Error("project.created event is missing subject.projectId.");
-    }
-
-    return await step.do("configure project database filesystem", async () => {
-      return await internal.projectFilesConfigure({ projectId });
-    });
-  },
-);
-`,
   "automations/workspace-file-initialization.workflow.js": `defineWorkflow(
   { name: "workspace-file-initialization" },
   async (event, step) => {
@@ -74,11 +40,7 @@ export const SYSTEM_AUTOMATION_CONTENT: Record<string, FileSystemArtifact> = {
       return await org.internal.automationsRoutesSeedStarter({});
     });
 
-    const codemodeTypes = await step.do("write codemode dts", async () => {
-      return await org.internal.codemodeTypesSync({});
-    });
-
-    return { ...configured, seeded, automationRoutes, codemodeTypes };
+    return { ...configured, seeded, automationRoutes };
   },
 );
 `,

--- a/apps/backoffice/app/files/content/system.ts
+++ b/apps/backoffice/app/files/content/system.ts
@@ -1,105 +1,19 @@
 import type { FileSystemArtifact } from "../types";
-import { BACKOFFICE_CAPABILITY_FILE_CONTENT } from "./backoffice-capability-files";
-import { GENERAL_SKILL_CONTENT } from "./skills";
 import { SYSTEM_AUTOMATION_CONTENT } from "./system-automations";
 
-export const renderSystemGuidance = ({
-  codemodeDts,
-  stateDts,
-  workflowAuthoringDts,
-}: {
-  codemodeDts: string;
-  stateDts: string;
-  workflowAuthoringDts: string;
-}) =>
-  SYSTEM_MD.replace("__BACKOFFICE_CODEMODE_DTS__", codemodeDts.trimEnd())
-    .replace("__BACKOFFICE_CODEMODE_STATE_DTS__", stateDts.trimEnd())
-    .replace("__BACKOFFICE_CODEMODE_WORKFLOW_AUTHORING_DTS__", workflowAuthoringDts.trimEnd());
+export const SYSTEM_README = `# Backoffice System Filesystem
 
-export const SYSTEM_MD = `# Backoffice System Guidance
+This is the admin-only system-scope filesystem.
 
-You are an assistant inside The Backoffice, built by ReJot. The user sees your messages in an IM interface, so be concise and direct.
+- Product-owned reference files live in \`/static\`.
+- System-scoped admin automations live in \`/system/automations\`.
+- User/org/project editable files live in \`/workspace\` for the selected scope.
 
-Prefer acting over asking. Execute codemode over asking. NEVER present code to the user, ALWAYS execute instead.
-
-## Interacting with the system
-
-Your main way of interacting with the system is through the Codemode tool. You write JavaScript to perform tasks. Below are the basic types of the APIs available to you. Further declarations are referenced and can be read.
-
-Provider declarations are split by namespace. Read .d.ts files when relevant. Do not guess APIs, invent aliases, or rely on memory.
-
-Codemode snippets always start with either \`async () => {}\` or \`defineWorkflow\`. NEVER Both, i.e. no defineWorkflow inside an async function.
-
-Use the former for simple one-off tasks, and the latter for multi-step workflows. 
-
-Inline defined workflows automatically start running and will return their instanceId, this can be used to check its status.
-
-You do NOT have to write workflows to a file to execute them. ONLY do this when the user SPECIFICALLY asks you to save a workflow for later use.
-
-\`\`\`js
-defineWorkflow({ name: "my-workflow" }, async (event, step) => {
-  // durable steps, retries, sleeps, waits
-
-  const started = await step.do("generate-start-info", async () => {
-    return {
-      randomNumber: Math.floor(Math.random() * 1000),
-    };
-  });
-
-  await step.sleep("cooldown", "2 seconds");
-
-  return {
-    number: started.randomNumber,
-  };
-});
-\`\`\`
-
-## Codemode TypeScript reference
-
-The following declarations are always available: generated reference paths and scoped \`context.*\`, the full state API, and the workflow authoring API. Provider declarations live in the referenced provider files and should be loaded as needed.
-
-\`\`\`ts
-__BACKOFFICE_CODEMODE_DTS__
-
-__BACKOFFICE_CODEMODE_STATE_DTS__
-
-__BACKOFFICE_CODEMODE_WORKFLOW_AUTHORING_DTS__
-\`\`\`
-
-## Files and automations
-
-- System-owned automations live in \`/system/automations/\`.
-- User-editable automations live in \`/workspace/automations/\`.
-- Automation codemode scripts read event data from \`/context/event.json\` with \`state.readFile\` and must return JSON-serializable values.
-
-## Events
-
-Backoffice is event-driven. The last 200 ingested events are available as JSON files in \`/events/YYYY-MM-DD/\`; errors are written as text files in the same directory.
-
-Before working with events, inspect the event catalog:
-
-\`\`\`js
-const catalog = await events.eventsCatalogList({});
-const telegramMessage = await events.eventsCatalogGet({
-  source: "telegram",
-  type: "message.received",
-});
-const entry = await events.getEvent({ hookId });
-\`\`\`
-
-## Skills
-
-When available skills list a matching skill, read the corresponding \`/system/skills/<skill-name>/SKILL.md\` or \`/workspace/skills/<skill-name>/SKILL.md\` before proceeding. NEVER use \`limit\` when reading skills.
-
-## Bash reference
-
-Prefer codemode for Backoffice work. Use bash for shell-oriented tasks. The bash host also exposes \`isogit\`, a thin isomorphic-git command with \`clone\`, \`status\`, and bounded non-network \`call\` support. Run \`isogit --help\` for usage.
-
+Files in this mount are intended for system-scope execution. Do not put broadly visible skills,
+guidance, or codemode declarations here; those belong in \`/static\`.
 `;
 
 export const SYSTEM_FILE_CONTENT = {
-  "SYSTEM.md": SYSTEM_MD,
+  "README.md": SYSTEM_README,
   ...SYSTEM_AUTOMATION_CONTENT,
-  ...BACKOFFICE_CAPABILITY_FILE_CONTENT,
-  ...GENERAL_SKILL_CONTENT,
 } satisfies Record<string, FileSystemArtifact>;

--- a/apps/backoffice/app/files/contributors/content.ts
+++ b/apps/backoffice/app/files/contributors/content.ts
@@ -19,19 +19,41 @@ const TEXT_DECODER = new TextDecoder();
 const ENTRY_SORTER = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
 const UNKNOWN_MTIME = new Date(0);
 
+type LazyContentArtifacts = {
+  pathPrefix: string;
+  load(): Promise<Record<string, FileSystemArtifact>> | Record<string, FileSystemArtifact>;
+};
+
+export type ReadOnlyContentFileSystemOptions = {
+  lazyArtifacts?: readonly LazyContentArtifacts[];
+};
+
 export const createReadOnlyContentFileSystem = (
   mountPoint: string,
   artifacts: Record<string, FileSystemArtifact>,
+  options: ReadOnlyContentFileSystemOptions = {},
 ): IFileSystem => ({
   async readFile(path) {
-    const artifact = readContentText(mountPoint, artifacts, path);
+    const resolvedArtifacts = await resolveContentArtifactsForPath(
+      mountPoint,
+      artifacts,
+      options.lazyArtifacts ?? [],
+      path,
+    );
+    const artifact = readContentText(mountPoint, resolvedArtifacts, path);
     if (artifact === null) {
       throw createPathNotFoundFileSystemError("read", path);
     }
     return artifact;
   },
   async readFileBuffer(path) {
-    const artifact = readContentBuffer(mountPoint, artifacts, path);
+    const resolvedArtifacts = await resolveContentArtifactsForPath(
+      mountPoint,
+      artifacts,
+      options.lazyArtifacts ?? [],
+      path,
+    );
+    const artifact = readContentBuffer(mountPoint, resolvedArtifacts, path);
     if (artifact === null) {
       throw createPathNotFoundFileSystemError("read", path);
     }
@@ -44,10 +66,32 @@ export const createReadOnlyContentFileSystem = (
     throw createReadOnlyFileSystemError("append", path);
   },
   async exists(path) {
-    return statContentEntry(mountPoint, artifacts, path, true) !== null;
+    return (
+      statContentEntry(
+        mountPoint,
+        await resolveContentArtifactsForPath(
+          mountPoint,
+          artifacts,
+          options.lazyArtifacts ?? [],
+          path,
+        ),
+        path,
+        true,
+      ) !== null
+    );
   },
   async stat(path) {
-    const stat = statContentEntry(mountPoint, artifacts, path, true);
+    const stat = statContentEntry(
+      mountPoint,
+      await resolveContentArtifactsForPath(
+        mountPoint,
+        artifacts,
+        options.lazyArtifacts ?? [],
+        path,
+      ),
+      path,
+      true,
+    );
     if (!stat) {
       throw createPathNotFoundFileSystemError("stat", path);
     }
@@ -57,10 +101,28 @@ export const createReadOnlyContentFileSystem = (
     throw createReadOnlyFileSystemError("mkdir", path);
   },
   async readdir(path) {
-    return listContentChildNames(mountPoint, artifacts, path);
+    return listContentChildNames(
+      mountPoint,
+      await resolveContentArtifactsForDirectory(
+        mountPoint,
+        artifacts,
+        options.lazyArtifacts ?? [],
+        path,
+      ),
+      path,
+    );
   },
   async readdirWithFileTypes(path) {
-    return listContentDirents(mountPoint, artifacts, path);
+    return listContentDirents(
+      mountPoint,
+      await resolveContentArtifactsForDirectory(
+        mountPoint,
+        artifacts,
+        options.lazyArtifacts ?? [],
+        path,
+      ),
+      path,
+    );
   },
   async rm(path) {
     throw createReadOnlyFileSystemError("rm", path);
@@ -77,7 +139,13 @@ export const createReadOnlyContentFileSystem = (
   },
   resolvePath,
   getAllPaths() {
-    return [mountPoint, ...Object.keys(artifacts).map((path) => `${mountPoint}/${path}`)];
+    return [
+      mountPoint,
+      ...Object.keys(artifacts).map((path) => `${mountPoint}/${path}`),
+      ...(options.lazyArtifacts ?? []).map(
+        (lazyArtifacts) => `${normalizeMountPoint(mountPoint)}/${lazyArtifacts.pathPrefix}`,
+      ),
+    ];
   },
   async chmod(path) {
     throw createReadOnlyFileSystemError("chmod", path);
@@ -106,6 +174,108 @@ export const createReadOnlyContentFileSystem = (
 });
 
 type MutableFolderEntry = FileEntryDescriptor & { kind: "folder"; children: FileEntryDescriptor[] };
+
+type NormalizedLazyContentArtifacts = LazyContentArtifacts & { pathPrefix: string };
+
+const normalizeLazyContentArtifacts = (
+  lazyArtifacts: readonly LazyContentArtifacts[],
+): NormalizedLazyContentArtifacts[] =>
+  lazyArtifacts.map((entry) => ({ ...entry, pathPrefix: normalizeRelativePath(entry.pathPrefix) }));
+
+const relativeLookupPath = (mountPoint: string, path: string): string | null => {
+  const normalizedMountPoint = normalizeMountPoint(mountPoint);
+  const normalizedPath = normalizeDirectoryLookupPath(path);
+  if (
+    normalizedPath === normalizedMountPoint ||
+    normalizedPath === ensureFolderPath(normalizedMountPoint)
+  ) {
+    return "";
+  }
+  if (!normalizedPath.startsWith(`${normalizedMountPoint}/`)) {
+    return null;
+  }
+  return normalizeRelativePath(normalizedPath.slice(normalizedMountPoint.length + 1));
+};
+
+const lazyArtifactsAffectPath = (lazyArtifacts: NormalizedLazyContentArtifacts, path: string) =>
+  path === lazyArtifacts.pathPrefix || path.startsWith(`${lazyArtifacts.pathPrefix}/`);
+
+const lazyArtifactsAffectDirectory = (
+  lazyArtifacts: NormalizedLazyContentArtifacts,
+  directory: string,
+) => {
+  if (!directory) {
+    return false;
+  }
+  return (
+    lazyArtifactsAffectPath(lazyArtifacts, directory) ||
+    lazyArtifacts.pathPrefix.startsWith(`${directory}/`)
+  );
+};
+
+const loadMatchingLazyArtifacts = async (
+  lazyArtifacts: readonly NormalizedLazyContentArtifacts[],
+  matches: (entry: NormalizedLazyContentArtifacts) => boolean,
+): Promise<Record<string, FileSystemArtifact>> => {
+  const entries = await Promise.all(
+    lazyArtifacts.filter(matches).map(async (entry) => Object.entries(await entry.load())),
+  );
+  return Object.fromEntries(entries.flat());
+};
+
+const withLazyRootPlaceholders = (
+  artifacts: Record<string, FileSystemArtifact>,
+  lazyArtifacts: readonly NormalizedLazyContentArtifacts[],
+): Record<string, FileSystemArtifact> => {
+  const placeholders = Object.fromEntries(
+    lazyArtifacts.map((entry) => [`${entry.pathPrefix}/.lazy-artifacts-placeholder`, ""]),
+  );
+  return { ...artifacts, ...placeholders };
+};
+
+const resolveContentArtifactsForPath = async (
+  mountPoint: string,
+  artifacts: Record<string, FileSystemArtifact>,
+  rawLazyArtifacts: readonly LazyContentArtifacts[],
+  path: string,
+): Promise<Record<string, FileSystemArtifact>> => {
+  const lazyArtifacts = normalizeLazyContentArtifacts(rawLazyArtifacts);
+  const relativePath = relativeLookupPath(mountPoint, path);
+  if (relativePath === null) {
+    return artifacts;
+  }
+
+  if (!relativePath || lazyArtifacts.some((entry) => entry.pathPrefix === relativePath)) {
+    return withLazyRootPlaceholders(artifacts, lazyArtifacts);
+  }
+
+  const loaded = await loadMatchingLazyArtifacts(lazyArtifacts, (entry) =>
+    lazyArtifactsAffectPath(entry, relativePath),
+  );
+  return { ...artifacts, ...loaded };
+};
+
+const resolveContentArtifactsForDirectory = async (
+  mountPoint: string,
+  artifacts: Record<string, FileSystemArtifact>,
+  rawLazyArtifacts: readonly LazyContentArtifacts[],
+  path: string,
+): Promise<Record<string, FileSystemArtifact>> => {
+  const lazyArtifacts = normalizeLazyContentArtifacts(rawLazyArtifacts);
+  const relativePath = relativeLookupPath(mountPoint, path);
+  if (relativePath === null) {
+    return artifacts;
+  }
+
+  if (!relativePath) {
+    return withLazyRootPlaceholders(artifacts, lazyArtifacts);
+  }
+
+  const loaded = await loadMatchingLazyArtifacts(lazyArtifacts, (entry) =>
+    lazyArtifactsAffectDirectory(entry, relativePath),
+  );
+  return { ...artifacts, ...loaded };
+};
 
 const buildContentTree = (
   mountPoint: string,

--- a/apps/backoffice/app/files/contributors/index.ts
+++ b/apps/backoffice/app/files/contributors/index.ts
@@ -1,7 +1,7 @@
 import { automationHooksFileContributor } from "./durable-hooks";
 import { projectWorkspacesFileContributor } from "./project-workspaces";
 import { resendFileContributor } from "./resend";
-import { staticFileContributor } from "./static";
+import { staticFileContributor, systemFileContributor } from "./static";
 import { tmpFileContributor } from "./tmp";
 import {
   uploadFileContributor,
@@ -11,6 +11,7 @@ import {
 
 const BUILT_IN_FILE_CONTRIBUTORS = [
   staticFileContributor,
+  systemFileContributor,
   uploadFileContributor,
   uploadR2BindingFileContributor,
   uploadR2RemoteFileContributor,

--- a/apps/backoffice/app/files/contributors/project-workspaces.ts
+++ b/apps/backoffice/app/files/contributors/project-workspaces.ts
@@ -126,6 +126,7 @@ const resolveProjectPath = async (
       objects: ctx.objects,
       execution,
       filePrincipal: ctx.kernel.resolveFilePrincipal(execution),
+      staticFileArtifacts: ctx.staticFileArtifacts,
     }),
     {
       mountPoint: `${PROJECTS_MOUNT_POINT}/${project.slug}`,

--- a/apps/backoffice/app/files/contributors/resend.test.ts
+++ b/apps/backoffice/app/files/contributors/resend.test.ts
@@ -177,6 +177,8 @@ describe("resend file contributor", () => {
           actor: { type: "system", id: "system" },
           scope: { kind: "org", orgId: "org_123" },
         },
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 
@@ -196,6 +198,8 @@ describe("resend file contributor", () => {
             fetch: async (request: Request) => await resendRequestHandler(request),
           },
         }),
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 
@@ -221,6 +225,8 @@ describe("resend file contributor", () => {
             fetch: async (request: Request) => await resendRequestHandler(request),
           },
         }),
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 
@@ -260,6 +266,8 @@ describe("resend file contributor", () => {
             fetch: async (request: Request) => await resendRequestHandler(request),
           },
         }),
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 

--- a/apps/backoffice/app/files/contributors/static.test.ts
+++ b/apps/backoffice/app/files/contributors/static.test.ts
@@ -1,36 +1,80 @@
 import { describe, expect, test } from "vitest";
 
 import {
-  SYSTEM_FILE_CONTENT,
+  STATIC_FILE_CONTENT,
   STATIC_FILE_MOUNT_POINT,
+  createSystemFilesContext,
   staticFileContributor,
   staticFileMount,
 } from "@/files";
 
+const createStaticFs = (
+  staticFileArtifacts: () => Record<string, string> | Promise<Record<string, string>>,
+) => {
+  const fs = staticFileContributor.createFileSystem?.(
+    createSystemFilesContext({
+      execution: {
+        actor: { type: "system", id: "system" },
+        scope: { kind: "org", orgId: "org_123" },
+      },
+      staticFileArtifacts,
+    }),
+  );
+  if (!fs || "fs" in fs || fs instanceof Promise) {
+    throw new Error("Expected static filesystem.");
+  }
+  return fs;
+};
+
 describe("static file contributor", () => {
-  test("exposes the /system mount metadata", async () => {
+  test("exposes the /static mount metadata", async () => {
     expect(staticFileMount).toMatchObject({
-      id: "system",
+      id: "static",
       kind: "static",
-      mountPoint: "/system",
+      mountPoint: "/static",
       readOnly: true,
       persistence: "persistent",
     });
     expect(staticFileContributor).toMatchObject(staticFileMount);
   });
 
-  test("renders and reads the built-in /system docs pack", async () => {
+  test("renders and reads the built-in /static docs pack", async () => {
     const entries = await staticFileContributor.readdirWithFileTypes?.(STATIC_FILE_MOUNT_POINT);
     expect(await staticFileContributor.readFile?.(`${STATIC_FILE_MOUNT_POINT}/SYSTEM.md`)).toEqual(
-      SYSTEM_FILE_CONTENT["SYSTEM.md"],
+      STATIC_FILE_CONTENT["SYSTEM.md"],
     );
 
     expect(entries?.map((entry) => entry.name)).toEqual(expect.arrayContaining(["SYSTEM.md"]));
     expect(staticFileContributor.getAllPaths?.()).toEqual(
       expect.arrayContaining([
-        "/system",
-        ...Object.keys(SYSTEM_FILE_CONTENT).map((path) => `/system/${path}`),
+        "/static",
+        ...Object.keys(STATIC_FILE_CONTENT).map((path) => `/static/${path}`),
       ]),
     );
+  });
+
+  test("does not load codemode artifacts for unrelated static files", async () => {
+    const fs = createStaticFs(() => {
+      throw new Error("codemode unavailable");
+    });
+
+    await expect(fs.readFile("/static/SYSTEM.md")).resolves.toEqual(
+      STATIC_FILE_CONTENT["SYSTEM.md"],
+    );
+    await expect(fs.readdir("/static")).resolves.toEqual(
+      expect.arrayContaining(["SYSTEM.md", "codemode"]),
+    );
+    await expect(fs.readFile("/static/codemode/system.d.ts")).rejects.toThrow(
+      "codemode unavailable",
+    );
+  });
+
+  test("loads codemode artifacts only for codemode paths", async () => {
+    const fs = createStaticFs(() => ({ "codemode/system.d.ts": "declare const ok: true;" }));
+
+    await expect(fs.readFile("/static/codemode/system.d.ts")).resolves.toBe(
+      "declare const ok: true;",
+    );
+    await expect(fs.readdir("/static/codemode")).resolves.toEqual(["system.d.ts"]);
   });
 });

--- a/apps/backoffice/app/files/contributors/static.ts
+++ b/apps/backoffice/app/files/contributors/static.ts
@@ -1,22 +1,56 @@
+import { STATIC_FILE_CONTENT } from "../content/static";
 import { SYSTEM_FILE_CONTENT } from "../content/system";
-import type { FileContributor, FileMountMetadata } from "../types";
+import type { FileContributor, FileMountMetadata, FilesContext } from "../types";
 import { createReadOnlyContentFileSystem } from "./content";
 
-const STATIC_FILE_MOUNT_ID = "system";
-export const STATIC_FILE_MOUNT_POINT = "/system";
+const STATIC_FILE_MOUNT_ID = "static";
+export const STATIC_FILE_MOUNT_POINT = "/static";
 
 export const staticFileMount: FileMountMetadata = {
   id: STATIC_FILE_MOUNT_ID,
   kind: "static",
   mountPoint: STATIC_FILE_MOUNT_POINT,
-  title: "System",
+  title: "Static",
   readOnly: true,
   persistence: "persistent",
   description:
-    "Immutable TS-owned guidance, skills, and system automations for the built-in /system filesystem.",
+    "Immutable product-owned guidance, skills, codemode declarations, and static automations.",
 };
+
+const createStaticFileSystem = (ctx: FilesContext) =>
+  createReadOnlyContentFileSystem(STATIC_FILE_MOUNT_POINT, STATIC_FILE_CONTENT, {
+    lazyArtifacts: [{ pathPrefix: "codemode", load: ctx.staticFileArtifacts }],
+  });
 
 export const staticFileContributor: FileContributor = {
   ...staticFileMount,
-  ...createReadOnlyContentFileSystem(STATIC_FILE_MOUNT_POINT, SYSTEM_FILE_CONTENT),
+  ...createReadOnlyContentFileSystem(STATIC_FILE_MOUNT_POINT, STATIC_FILE_CONTENT),
+  createFileSystem: (ctx) => createStaticFileSystem(ctx),
+};
+
+const SYSTEM_FILE_MOUNT_ID = "system";
+export const SYSTEM_FILE_MOUNT_POINT = "/system";
+
+export const systemFileMount: FileMountMetadata = {
+  id: SYSTEM_FILE_MOUNT_ID,
+  kind: "static",
+  mountPoint: SYSTEM_FILE_MOUNT_POINT,
+  title: "System",
+  readOnly: true,
+  persistence: "persistent",
+  description: "Admin-only system-scope filesystem for system automations and metadata.",
+};
+
+const canSeeSystemFileMount = ({ execution }: FilesContext): boolean =>
+  execution.scope.kind === "system" ||
+  execution.actor.type === "system" ||
+  (execution.actor.type === "user" && execution.actor.role === "admin");
+
+export const systemFileContributor: FileContributor = {
+  ...systemFileMount,
+  ...createReadOnlyContentFileSystem(SYSTEM_FILE_MOUNT_POINT, SYSTEM_FILE_CONTENT),
+  createFileSystem: (ctx) =>
+    canSeeSystemFileMount(ctx)
+      ? createReadOnlyContentFileSystem(SYSTEM_FILE_MOUNT_POINT, SYSTEM_FILE_CONTENT)
+      : null,
 };

--- a/apps/backoffice/app/files/contributors/upload.test.ts
+++ b/apps/backoffice/app/files/contributors/upload.test.ts
@@ -111,6 +111,7 @@ describe("upload file contributor", () => {
 
   test("exposes built-in contributors in deterministic order", () => {
     expect(getBuiltInFileContributors().map((contributor) => contributor.id)).toEqual([
+      "static",
       "system",
       "workspace",
       "r2",
@@ -281,6 +282,8 @@ describe("upload file contributor", () => {
       backend: "pi",
       objects: createFilesTestObjectRegistry({ uploadConfig, uploadRuntime: runtime }),
       request: new Request("https://docs.example.test/backoffice/files"),
+
+      staticFileArtifacts: () => ({}),
     });
     const fs = createUploadFileSystem(context, {
       provider: UPLOAD_PROVIDER_R2_BINDING,
@@ -307,6 +310,8 @@ describe("upload file contributor", () => {
         uploadRuntime: runtime,
       }),
       request: new Request("https://docs.example.test/backoffice/files"),
+
+      staticFileArtifacts: () => ({}),
     });
     const fs = createUploadFileSystem(context, {
       provider: UPLOAD_PROVIDER_R2,
@@ -334,6 +339,8 @@ describe("upload file contributor", () => {
         uploadConfig: runtime.uploadConfig,
         uploadRuntime: runtime,
       }),
+
+      staticFileArtifacts: () => ({}),
     });
 
     const fs = createUploadFileSystem(context, {
@@ -777,6 +784,8 @@ describe("upload file contributor", () => {
           },
           origin: runtime.baseUrl,
           objects,
+
+          staticFileArtifacts: () => ({}),
         }),
         { provider: UPLOAD_PROVIDER_DATABASE },
       ).readFile("/workspace/automations/telegram-user-linking.workflow.js"),
@@ -794,6 +803,8 @@ describe("upload file contributor", () => {
           scope: { kind: "org", orgId: "acme-org" },
         },
         backend: "backoffice",
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 
@@ -855,6 +866,8 @@ const createUploadFs = (
     }),
     request: new Request("https://docs.example.test/backoffice/files"),
     ...(options.filePrincipal ? { filePrincipal: options.filePrincipal } : {}),
+
+    staticFileArtifacts: () => ({}),
   });
 
   return {

--- a/apps/backoffice/app/files/create-file-system.ts
+++ b/apps/backoffice/app/files/create-file-system.ts
@@ -1,6 +1,8 @@
 import type { BackofficeExecutionContext } from "@/backoffice-runtime/context";
 import type { BackofficeKernel } from "@/backoffice-runtime/kernel";
 import type { BackofficeObjectRegistry } from "@/backoffice-runtime/object-registry";
+import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
+import { createCodemodeStaticArtifactsResolver } from "@/fragno/codemode/static-codemode-artifacts";
 import type { DurableHookQueueOptions, DurableHookQueueResponse } from "@/fragno/durable-hooks";
 
 import { createMasterFileSystem, type MasterFileSystem } from "./master-file-system";
@@ -14,6 +16,7 @@ export type CreateBackofficeFileSystemOptions = {
    * instead of going through an external stub (avoids deadlock during init).
    */
   automationHookQueue?: (opts?: DurableHookQueueOptions) => Promise<DurableHookQueueResponse>;
+  config: BackofficeRuntimeConfig;
   execution: BackofficeExecutionContext;
   kernel: BackofficeKernel;
 };
@@ -30,5 +33,10 @@ export const createBackofficeFileSystem = async (
     kernel: options.kernel,
     filePrincipal,
     ...(options.automationHookQueue ? { automationHookQueue: options.automationHookQueue } : {}),
+    staticFileArtifacts: createCodemodeStaticArtifactsResolver({
+      objects: options.objects,
+      config: options.config,
+      execution: options.execution,
+    }),
   });
 };

--- a/apps/backoffice/app/files/index.ts
+++ b/apps/backoffice/app/files/index.ts
@@ -3,7 +3,9 @@ export type {
   FileEntryDescriptor,
   FileMountMetadata,
   FilesContext,
+  StaticFileArtifactsResolver,
 } from "./types";
+export { emptyStaticFileArtifacts } from "./types";
 export type { DirentEntry, IFileSystem } from "./interface";
 export { createUnsupportedFileSystem } from "./interface";
 
@@ -29,8 +31,11 @@ export { getBuiltInFileContributors } from "./contributors";
 
 export {
   STATIC_FILE_MOUNT_POINT,
+  SYSTEM_FILE_MOUNT_POINT,
   staticFileContributor,
   staticFileMount,
+  systemFileContributor,
+  systemFileMount,
 } from "./contributors/static";
 
 export {
@@ -39,13 +44,15 @@ export {
   uploadFileContributor,
 } from "./contributors/upload";
 export { WORKSPACE_STARTER_CONTENT } from "./content/starter";
+export { STATIC_AUTOMATION_SCRIPT_PATHS } from "./content/static-automations";
 export { SYSTEM_AUTOMATION_SCRIPT_PATHS } from "./content/system-automations";
 export { STARTER_AUTOMATION_SCRIPT_PATHS } from "./content/starter-automations";
 export {
-  SYSTEM_FILE_CONTENT,
-  SYSTEM_MD as SYSTEM_GUIDANCE,
-  renderSystemGuidance,
-} from "./content/system";
+  STATIC_FILE_CONTENT,
+  STATIC_GUIDANCE_MD as STATIC_GUIDANCE,
+  renderStaticGuidance,
+} from "./content/static";
+export { SYSTEM_FILE_CONTENT, SYSTEM_README } from "./content/system";
 export { MasterFileSystem, createMasterFileSystem } from "./master-file-system";
 export type { CreateMasterFileSystemOptions } from "./master-file-system";
 export { createBackofficeFileSystem } from "./create-file-system";

--- a/apps/backoffice/app/files/master-file-system.test.ts
+++ b/apps/backoffice/app/files/master-file-system.test.ts
@@ -10,7 +10,7 @@ import { createUnsupportedFileSystem, type FileContent, type FsStat } from "./in
 import { createMasterFileSystem, MasterFileSystem } from "./master-file-system";
 import { isMountPointParentOf, normalizeMountPoint, normalizeRelativePath } from "./normalize-path";
 import { createSystemFilesContext } from "./system-context";
-import type { FileContributor, FilesContext } from "./types";
+import { emptyStaticFileArtifacts, type FileContributor, type FilesContext } from "./types";
 
 const context = createSystemFilesContext({
   execution: {
@@ -18,6 +18,8 @@ const context = createSystemFilesContext({
     scope: { kind: "org", orgId: "org_123" },
   },
   backend: "backoffice",
+
+  staticFileArtifacts: () => ({}),
 }) satisfies FilesContext;
 
 const DIRECTORY_STAT: FsStat = {
@@ -60,6 +62,7 @@ describe("createMasterFileSystem", () => {
     const resolved = await createTestMasterFileSystem();
 
     expect(resolved.mounts.map((mount) => mount.mountPoint)).toEqual([
+      "/static",
       "/system",
       "/docs",
       "/examples",
@@ -73,7 +76,11 @@ describe("createMasterFileSystem", () => {
       execution: { actor: { type: "system", id: "system" }, scope: { kind: "system" } },
     });
 
-    expect(resolved.mounts.map((mount) => mount.mountPoint)).toEqual(["/system", "/tmp"]);
+    expect(resolved.mounts.map((mount) => mount.mountPoint)).toEqual([
+      "/static",
+      "/system",
+      "/tmp",
+    ]);
   });
 
   test("rejects duplicate mount points", async () => {
@@ -260,10 +267,10 @@ describe("createMasterFileSystem", () => {
 
     const master = await createTestMasterFileSystem();
 
-    await expect(master.cp("/system/SYSTEM.md", "/project/README.md")).rejects.toThrow(
+    await expect(master.cp("/static/SYSTEM.md", "/project/README.md")).rejects.toThrow(
       /Cross-mount copy/,
     );
-    await expect(master.mv("/system/SYSTEM.md", "/project/README.md")).rejects.toThrow(
+    await expect(master.mv("/static/SYSTEM.md", "/project/README.md")).rejects.toThrow(
       /Cross-mount move/,
     );
   });
@@ -348,6 +355,7 @@ describe("createMasterFileSystem", () => {
       objects: context.objects,
       kernel,
       filePrincipal: kernel.resolveFilePrincipal(execution),
+      staticFileArtifacts: emptyStaticFileArtifacts,
     });
 
     await master.writeFile("/workspace/automations/router.cm.js", "ok");

--- a/apps/backoffice/app/files/master-file-system.ts
+++ b/apps/backoffice/app/files/master-file-system.ts
@@ -35,7 +35,13 @@ import type {
   ResolvedFileMount,
 } from "./types";
 
-const STANDARD_MOUNT_POINT_ORDER = ["/system", "/workspace", "/r2", "/r2-remote"] as const;
+const STANDARD_MOUNT_POINT_ORDER = [
+  "/static",
+  "/system",
+  "/workspace",
+  "/r2",
+  "/r2-remote",
+] as const;
 const ROOT_DIR_MODE = 0o755;
 const FILE_SYSTEM_SORTER = new Intl.Collator("en", {
   numeric: true,

--- a/apps/backoffice/app/files/seed-workspace-starter-files.ts
+++ b/apps/backoffice/app/files/seed-workspace-starter-files.ts
@@ -86,6 +86,7 @@ export const seedWorkspaceStarterFiles = async ({
       actor: { type: "system", id: "system" },
       scope: { kind: "org", orgId },
     },
+    staticFileArtifacts: () => ({}),
   });
   const fs = createUploadFileSystem(fileContext, {
     mountPoint: WORKSPACE_ROOT,

--- a/apps/backoffice/app/files/service.test.ts
+++ b/apps/backoffice/app/files/service.test.ts
@@ -57,12 +57,15 @@ describe("files service", () => {
           uploadConfig: runtime.uploadConfig,
           uploadRuntime: runtime,
         }),
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 
     expect(
       master.mounts.map((mount) => [mount.mountPoint, mount.id, mount.uploadProvider ?? null]),
     ).toEqual([
+      ["/static", "static", null],
       ["/system", "system", null],
       ["/workspace", "workspace", UPLOAD_PROVIDER_DATABASE],
       ["/r2-remote", "r2-remote", UPLOAD_PROVIDER_R2],
@@ -85,11 +88,19 @@ describe("files service", () => {
           uploadConfig: runtime.uploadConfig,
           uploadRuntime: runtime,
         }),
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 
     const tree = await listFilesTree(master);
-    expect(tree.map((node) => node.path)).toEqual(["/system", "/workspace", "/r2-remote", "/tmp"]);
+    expect(tree.map((node) => node.path)).toEqual([
+      "/static",
+      "/system",
+      "/workspace",
+      "/r2-remote",
+      "/tmp",
+    ]);
 
     const workspaceChildren = await listFilesChildren(master, "/workspace");
     expect(workspaceChildren.map((node) => [node.kind, node.path, node.title])).toEqual([
@@ -111,10 +122,10 @@ describe("files service", () => {
       ]),
     );
 
-    const systemDetail = await getFilesNodeDetail(master, "/system/SYSTEM.md");
+    const systemDetail = await getFilesNodeDetail(master, "/static/SYSTEM.md");
     expect(systemDetail?.node).toMatchObject({
       kind: "file",
-      path: "/system/SYSTEM.md",
+      path: "/static/SYSTEM.md",
       title: "SYSTEM.md",
     });
     expect(systemDetail?.textContent).toContain("Backoffice");
@@ -141,6 +152,8 @@ describe("files service", () => {
         request: new Request(
           "https://docs.example.test/backoffice/files/org_123?path=%2Fworkspace",
         ),
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 
@@ -191,13 +204,15 @@ describe("files service", () => {
           scope: { kind: "org", orgId: "org_123" },
         },
         backend: "backoffice",
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 
     const tree = await listFilesTree(master);
-    expect(tree.map((node) => node.path)).toEqual(["/system", "/tmp"]);
+    expect(tree.map((node) => node.path)).toEqual(["/static", "/system", "/tmp"]);
 
-    const detail = await getFilesNodeDetail(master, "/system/SYSTEM.md");
+    const detail = await getFilesNodeDetail(master, "/static/SYSTEM.md");
     expect(detail?.textContent).toContain("Backoffice");
     expect(detail?.capabilities).toMatchObject({
       canCreateFolder: false,
@@ -214,6 +229,8 @@ describe("files service", () => {
           scope: { kind: "org", orgId: "org_123" },
         },
         backend: "backoffice",
+
+        staticFileArtifacts: () => ({}),
       }),
     );
 

--- a/apps/backoffice/app/files/system-context.ts
+++ b/apps/backoffice/app/files/system-context.ts
@@ -13,6 +13,7 @@ export type CreateSystemFilesContextOptions = {
   execution: BackofficeExecutionContext;
   filePrincipal?: FilePrincipal;
   automationHookQueue?: FilesContext["automationHookQueue"];
+  staticFileArtifacts: FilesContext["staticFileArtifacts"];
 };
 
 /**
@@ -35,5 +36,6 @@ export const createSystemFilesContext = ({
     execution,
     kernel,
     filePrincipal: filePrincipal ?? kernel.resolveFilePrincipal(execution),
+    staticFileArtifacts: filesContext.staticFileArtifacts,
   };
 };

--- a/apps/backoffice/app/files/types.ts
+++ b/apps/backoffice/app/files/types.ts
@@ -21,6 +21,12 @@ export type FileEntryKind = (typeof FILE_ENTRY_KINDS)[number];
 
 export type FileSystemArtifact = FileContent;
 
+export type StaticFileArtifactsResolver = () =>
+  | Promise<Record<string, FileSystemArtifact>>
+  | Record<string, FileSystemArtifact>;
+
+export const emptyStaticFileArtifacts: StaticFileArtifactsResolver = () => ({});
+
 /**
  * Static metadata for a mounted filesystem.
  *
@@ -63,6 +69,7 @@ export type FilesContext = {
   kernel: BackofficeKernel;
   filePrincipal: FilePrincipal;
   automationHookQueue?: (options?: DurableHookQueueOptions) => Promise<DurableHookQueueResponse>;
+  staticFileArtifacts: StaticFileArtifactsResolver;
 };
 
 export type FileSystemResolution =

--- a/apps/backoffice/app/fragno/automation/catalog.test.ts
+++ b/apps/backoffice/app/fragno/automation/catalog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { STARTER_AUTOMATION_SCRIPT_PATHS } from "@/files";
 import { WORKSPACE_STARTER_AUTOMATION_CONTENT } from "@/files/content/starter-automations";
+import { STATIC_AUTOMATION_CONTENT } from "@/files/content/static-automations";
 import { SYSTEM_AUTOMATION_CONTENT } from "@/files/content/system-automations";
 
 import {
@@ -26,8 +27,14 @@ const createAutomationFileSystem = async (files: Record<string, string> = {}) =>
   );
 
 describe("automation filesystem catalog", () => {
-  test("loads system and workspace workflow files", async () => {
+  test("loads static, system, and workspace workflow files", async () => {
     const fileSystem = createTestMasterFileSystem({
+      ...Object.fromEntries(
+        Object.entries(STATIC_AUTOMATION_CONTENT).map(([path, content]) => [
+          `/static/${path}`,
+          content,
+        ]),
+      ),
       ...Object.fromEntries(
         Object.entries(SYSTEM_AUTOMATION_CONTENT).map(([path, content]) => [
           `/system/${path}`,

--- a/apps/backoffice/app/fragno/automation/catalog.ts
+++ b/apps/backoffice/app/fragno/automation/catalog.ts
@@ -8,10 +8,15 @@ import {
 } from "@/files";
 import { FileSystemError } from "@/files/fs-errors";
 
+export const AUTOMATION_STATIC_ROOT = "/static/automations";
 export const AUTOMATION_SYSTEM_ROOT = "/system/automations";
 export const AUTOMATION_WORKSPACE_ROOT = "/workspace/automations";
 export const AUTOMATION_SCRIPTS_ROOT = AUTOMATION_WORKSPACE_ROOT;
-const AUTOMATION_ROOTS = [AUTOMATION_SYSTEM_ROOT, AUTOMATION_WORKSPACE_ROOT] as const;
+const AUTOMATION_ROOTS = [
+  AUTOMATION_STATIC_ROOT,
+  AUTOMATION_SYSTEM_ROOT,
+  AUTOMATION_WORKSPACE_ROOT,
+] as const;
 
 export type AutomationFileSystemResolvePurpose = "route" | "runtime";
 
@@ -62,7 +67,7 @@ export type AutomationCatalog = {
   scripts: AutomationScriptCatalogEntry[];
 };
 
-export type AutomationScriptLayer = "system" | "workspace";
+export type AutomationScriptLayer = "static" | "system" | "workspace";
 
 export type AutomationWorkspaceScriptEntry = {
   layer: AutomationScriptLayer;
@@ -273,8 +278,15 @@ const readAutomationWorkspaceTextFile = async (
   }
 };
 
-const getAutomationLayerForPath = (absolutePath: string): AutomationScriptLayer =>
-  absolutePath.startsWith(`${AUTOMATION_SYSTEM_ROOT}/`) ? "system" : "workspace";
+export const getAutomationLayerForPath = (absolutePath: string): AutomationScriptLayer => {
+  if (absolutePath.startsWith(`${AUTOMATION_STATIC_ROOT}/`)) {
+    return "static";
+  }
+  if (absolutePath.startsWith(`${AUTOMATION_SYSTEM_ROOT}/`)) {
+    return "system";
+  }
+  return "workspace";
+};
 
 const toScriptKey = (path: string) => path.replace(/^scripts\//, "").replace(/\.[^.]+$/, "");
 
@@ -376,7 +388,9 @@ export const resolveAutomationFileSystem = async (
     return config.automationFileSystem;
   }
 
-  return createMasterFileSystem(createSystemFilesContext({ execution: input.execution }));
+  return createMasterFileSystem(
+    createSystemFilesContext({ execution: input.execution, staticFileArtifacts: () => ({}) }),
+  );
 };
 
 export const loadAutomationCatalog = async (

--- a/apps/backoffice/app/fragno/automation/content/starter-routing.ts
+++ b/apps/backoffice/app/fragno/automation/content/starter-routing.ts
@@ -107,22 +107,8 @@ export const STARTER_AUTOMATION_ROUTES: readonly AutomationRouteDefinition[] = [
     priority: 15,
     action: startWorkflowAction({
       remoteWorkflowName: "project-files-configure",
-      workflowScriptPath: "/system/automations/project-files-configure.workflow.js",
+      workflowScriptPath: "/static/automations/project-files-configure.workflow.js",
       instanceIdTemplate: "project-files-configure-${event.id}",
-    }),
-  },
-  {
-    id: "system-codemode-types-refresh-capability",
-    name: "Refresh codemode types after capability configuration",
-    enabled: true,
-    source: "*",
-    eventType: "capability.configured",
-    matcher: null,
-    priority: 20,
-    action: startWorkflowAction({
-      remoteWorkflowName: "codemode-types-refresh",
-      workflowScriptPath: "/system/automations/codemode-types-refresh.workflow.js",
-      instanceIdTemplate: "codemode-types-refresh-${event.id}",
     }),
   },
   {
@@ -143,34 +129,6 @@ export const STARTER_AUTOMATION_ROUTES: readonly AutomationRouteDefinition[] = [
       remoteWorkflowName: "pi-default-agent-configure",
       workflowScriptPath: "/workspace/automations/pi-default-agent-configure.workflow.js",
       instanceIdTemplate: "pi-default-agent-configure-${event.id}",
-    }),
-  },
-  {
-    id: "system-codemode-types-refresh-mcp-changed",
-    name: "Refresh codemode types after MCP server changes",
-    enabled: true,
-    source: "mcp",
-    eventType: "server.configuration.changed",
-    matcher: null,
-    priority: 20,
-    action: startWorkflowAction({
-      remoteWorkflowName: "codemode-types-refresh",
-      workflowScriptPath: "/system/automations/codemode-types-refresh.workflow.js",
-      instanceIdTemplate: "codemode-types-refresh-${event.id}",
-    }),
-  },
-  {
-    id: "system-codemode-types-refresh-mcp-deleted",
-    name: "Refresh codemode types after MCP server deletion",
-    enabled: true,
-    source: "mcp",
-    eventType: "server.configuration.deleted",
-    matcher: null,
-    priority: 20,
-    action: startWorkflowAction({
-      remoteWorkflowName: "codemode-types-refresh",
-      workflowScriptPath: "/system/automations/codemode-types-refresh.workflow.js",
-      instanceIdTemplate: "codemode-types-refresh-${event.id}",
     }),
   },
   {

--- a/apps/backoffice/app/fragno/automation/engine/test-master-file-system.test-utils.ts
+++ b/apps/backoffice/app/fragno/automation/engine/test-master-file-system.test-utils.ts
@@ -9,6 +9,7 @@ export const createTestMasterFileSystem = (
 ): MasterFileSystem =>
   new MasterFileSystem({
     mounts: [
+      ...(hasMountedFiles(files, "/static") ? [createTestMount("static", "/static", files)] : []),
       ...(hasMountedFiles(files, "/system") ? [createTestMount("system", "/system", files)] : []),
       createTestMount("workspace", "/workspace", files),
     ],

--- a/apps/backoffice/app/fragno/automation/index.ts
+++ b/apps/backoffice/app/fragno/automation/index.ts
@@ -43,8 +43,10 @@ export function createAutomationFragment(
 
 export type { AutomationFragmentConfig };
 export {
+  AUTOMATION_STATIC_ROOT,
   AUTOMATION_SYSTEM_ROOT,
   AUTOMATION_WORKSPACE_ROOT,
+  getAutomationLayerForPath,
   listAutomationWorkspaceScripts,
   readAutomationWorkspaceScript,
 } from "./catalog";

--- a/apps/backoffice/app/fragno/automation/project-event-routing.cloudflare.test.ts
+++ b/apps/backoffice/app/fragno/automation/project-event-routing.cloudflare.test.ts
@@ -77,7 +77,7 @@ describe("project automation event routing", () => {
           kind: "start_workflow",
           workflowName: "automation-codemode-script",
           remoteWorkflowName: "project-files-configure",
-          workflowScriptPath: "/system/automations/project-files-configure.workflow.js",
+          workflowScriptPath: "/static/automations/project-files-configure.workflow.js",
           instanceIdTemplate: "project-files-configure-${event.id}",
         },
       },
@@ -235,6 +235,8 @@ describe("project automation event routing", () => {
           actor: { type: "user", id: "user-1", userId: "user-1", organizationIds: [orgId] },
           scope: { kind: "org", orgId },
         },
+
+        staticFileArtifacts: () => ({}),
       }),
     );
     await expect(fs.readdir("/projects")).resolves.toEqual(["mounted-plan"]);
@@ -248,6 +250,8 @@ describe("project automation event routing", () => {
           actor: { type: "user", id: "user-1", userId: "user-1", organizationIds: [orgId] },
           scope: { kind: "project", orgId, projectId },
         },
+
+        staticFileArtifacts: () => ({}),
       }),
     );
     await expect(projectFs.readFile("/workspace/notes.txt")).resolves.toBe("project notes");

--- a/apps/backoffice/app/fragno/automation/routes-bindings.test.ts
+++ b/apps/backoffice/app/fragno/automation/routes-bindings.test.ts
@@ -48,6 +48,8 @@ const createAutomation = async (
             actor: { type: "system", id: "system" },
             scope: ownerScope,
           },
+
+          staticFileArtifacts: () => ({}),
         }),
       ),
       runtime: options.runtime,

--- a/apps/backoffice/app/fragno/automation/routes-scripts.test.ts
+++ b/apps/backoffice/app/fragno/automation/routes-scripts.test.ts
@@ -5,6 +5,7 @@ import { InMemoryAdapter } from "@fragno-dev/db";
 import {
   createMasterFileSystem,
   createSystemFilesContext,
+  STATIC_AUTOMATION_SCRIPT_PATHS,
   SYSTEM_AUTOMATION_SCRIPT_PATHS,
 } from "@/files";
 
@@ -50,6 +51,8 @@ describe("automation routes /scripts", () => {
             actor: { type: "system", id: "system" },
             scope: { kind: "org", orgId: "org_123" },
           },
+
+          staticFileArtifacts: () => ({}),
         }),
       ),
     });
@@ -64,7 +67,7 @@ describe("automation routes /scripts", () => {
       expect(response.data).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            path: SYSTEM_AUTOMATION_SCRIPT_PATHS.codemodeTypesRefresh.replace(
+            path: STATIC_AUTOMATION_SCRIPT_PATHS.projectFilesConfigure.replace(
               /^automations\//u,
               "",
             ),

--- a/apps/backoffice/app/fragno/automation/scenario-system-automations.test.ts
+++ b/apps/backoffice/app/fragno/automation/scenario-system-automations.test.ts
@@ -10,6 +10,7 @@ import {
   createMasterFileSystem,
   createSystemFilesContext,
 } from "@/files";
+import { createCodemodeStaticArtifactsResolver } from "@/fragno/codemode/static-codemode-artifacts";
 import { createInteractiveBashHost } from "@/fragno/runtime-tools/automation-host";
 import { createRouteBackedRuntimeContext } from "@/fragno/runtime-tools/route-backed-runtime-context";
 
@@ -37,47 +38,7 @@ vi.mock("cloudflare:workers", () => ({
   WorkerEntrypoint,
 }));
 
-import {
-  backofficeFiles,
-  defineBackofficeScenario,
-  runBackofficeScenario,
-  type BackofficeScenarioContext,
-} from "./scenario";
-
-const createScenarioFileActor = (orgId: string) => ({
-  type: "user" as const,
-  id: "scenario-user",
-  userId: "scenario-user",
-  organizationIds: [orgId],
-});
-
-const createScenarioOrgFileSystem = async (ctx: BackofficeScenarioContext, orgId: string) =>
-  await createBackofficeFileSystem({
-    objects: ctx.runtime.objects,
-    kernel: new BackofficeKernel({ objects: ctx.runtime.objects }),
-    execution: { actor: createScenarioFileActor(orgId), scope: { kind: "org", orgId } },
-  });
-
-const clearGeneratedCodemodeTypes = async (ctx: BackofficeScenarioContext, orgId: string) => {
-  const fs = await createScenarioOrgFileSystem(ctx, orgId);
-  const removeIfExists = async (path: string) => {
-    if (await fs.exists(path)) {
-      await fs.rm(path, { force: true });
-    }
-  };
-
-  await removeIfExists("/workspace/codemode/system.d.ts");
-  await removeIfExists("/workspace/codemode/workflow-authoring.d.ts");
-  await removeIfExists("/workspace/codemode/state.d.ts");
-
-  if (await fs.exists("/workspace/codemode/providers")) {
-    for (const name of await fs.readdir("/workspace/codemode/providers")) {
-      if (name.endsWith(".d.ts")) {
-        await removeIfExists(`/workspace/codemode/providers/${name}`);
-      }
-    }
-  }
-};
+import { backofficeFiles, defineBackofficeScenario, runBackofficeScenario } from "./scenario";
 
 const systemUnrelatedEvent = {
   id: "github:issue.opened:1",
@@ -112,7 +73,15 @@ describe("system automation scenarios", () => {
     runtime = await createInMemoryBackofficeRuntime({
       getAutomationFileSystem: async ({ execution }) =>
         await createMasterFileSystem(
-          createSystemFilesContext({ objects: runtime.objects, execution }),
+          createSystemFilesContext({
+            objects: runtime.objects,
+            execution,
+            staticFileArtifacts: createCodemodeStaticArtifactsResolver({
+              objects: runtime.objects,
+              config: runtime.config,
+              execution,
+            }),
+          }),
         ),
     });
 
@@ -173,19 +142,20 @@ describe("system automation scenarios", () => {
       expect(instances.instances).toHaveLength(1);
       assert(instances.instances[0]!.details.status === "complete");
 
-      const fs = await createMasterFileSystem(
-        createSystemFilesContext({
-          objects: runtime.objects,
-          execution: {
-            actor: { type: "system", id: "system" },
-            scope: { kind: "org", orgId },
-          },
-        }),
-      );
+      const systemExecution = {
+        actor: { type: "system" as const, id: "system" },
+        scope: { kind: "org" as const, orgId },
+      };
+      const fs = await createBackofficeFileSystem({
+        objects: runtime.objects,
+        kernel: new BackofficeKernel({ objects: runtime.objects }),
+        execution: systemExecution,
+        config: runtime.config,
+      });
       await expect(fs.readFile("/workspace/AGENTS.md")).resolves.toContain("Workspace guidance");
-      await expect(
-        fs.readFile("/workspace/codemode/providers/capabilities.d.ts"),
-      ).resolves.toContain("declare const capabilities");
+      await expect(fs.readFile("/static/codemode/providers/capabilities.d.ts")).resolves.toContain(
+        "declare const capabilities",
+      );
 
       // Regression: an org member (not root) must be able to edit a seeded
       // workspace automation. Seeded files are group-owned by the org, so the
@@ -205,6 +175,7 @@ describe("system automation scenarios", () => {
             },
             scope: { kind: "org", orgId },
           },
+          staticFileArtifacts: () => ({}),
         }),
       );
       const telegramPath = "/workspace/automations/telegram-test-command.workflow.js";
@@ -270,6 +241,7 @@ describe("system automation scenarios", () => {
                   actor: { type: "system", id: "system" },
                   scope: { kind: "org", orgId: "org-1" },
                 },
+                staticFileArtifacts: () => ({}),
               }),
             );
             await fs.writeFile(
@@ -326,7 +298,6 @@ describe("system automation scenarios", () => {
               "configure upload database connection",
               "seed workspace starter files",
               "seed starter automation routes",
-              "write codemode dts",
             ],
           }),
 
@@ -354,7 +325,7 @@ describe("system automation scenarios", () => {
                 action: {
                   kind: "start_workflow",
                   remoteWorkflowName: "project-files-configure",
-                  workflowScriptPath: "/system/automations/project-files-configure.workflow.js",
+                  workflowScriptPath: "/static/automations/project-files-configure.workflow.js",
                 },
               },
               {
@@ -365,7 +336,6 @@ describe("system automation scenarios", () => {
                   workflowScriptPath: "/workspace/automations/telegram-test-command.workflow.js",
                 },
               },
-              "system-codemode-types-refresh-capability",
             ],
           }),
 
@@ -388,7 +358,7 @@ describe("system automation scenarios", () => {
           }),
           then.files.contains({
             orgId: "org-1",
-            path: "/workspace/codemode/system.d.ts",
+            path: "/static/codemode/system.d.ts",
             text: "declare",
           }),
           then.assert(
@@ -412,6 +382,7 @@ describe("system automation scenarios", () => {
                 objects: ctx.runtime.objects,
                 kernel,
                 execution,
+                config: ctx.runtime.config,
               });
               const { bash } = createInteractiveBashHost({
                 fs,
@@ -577,9 +548,6 @@ describe("system automation scenarios", () => {
           then.workflow.missing({
             remoteWorkflowName: "workspace-file-initialization",
           }),
-          then.workflow.missing({
-            remoteWorkflowName: "codemode-types-refresh",
-          }),
           then.workflow.noErrored({ orgId: "org-1" }),
         ],
       }),
@@ -620,10 +588,10 @@ describe("system automation scenarios", () => {
     );
   });
 
-  test("capability.configured writes missing codemode types", async () => {
+  test("configured capabilities expose codemode types from /static on demand", async () => {
     await runBackofficeScenario(
       defineBackofficeScenario({
-        name: "system capability configuration writes missing codemode types",
+        name: "configured capabilities expose generated static codemode types",
 
         files: backofficeFiles.systemOnly(),
 
@@ -631,7 +599,7 @@ describe("system automation scenarios", () => {
           telegram: fake.telegram(),
         }),
 
-        setup: ({ given, runner, then }) => [
+        setup: ({ given, runner }) => [
           given.organization.exists({ id: "org-1", name: "Ada Labs" }),
           given.connection.configured({
             orgId: "org-1",
@@ -644,50 +612,27 @@ describe("system automation scenarios", () => {
             botUsername: "fragno_bot",
           }),
           runner.drain(),
-          then.assert("clear generated codemode types", (ctx) =>
-            clearGeneratedCodemodeTypes(ctx, "org-1"),
-          ),
         ],
 
-        steps: ({ when, then }) => [
-          when.capability.configured({
-            orgId: "org-1",
-            source: "telegram",
-            capabilityId: "telegram",
-            capabilityLabel: "Telegram",
-            eventId: "telegram-capability-1",
-          }),
-
-          then.workflow.instance({
-            instanceId: "codemode-types-refresh-telegram-capability-1",
-            status: "complete",
-            output: {
-              changed: true,
-              path: "/workspace/codemode/system.d.ts",
-            },
-          }),
-          then.workflow.steps({
-            instanceId: "codemode-types-refresh-telegram-capability-1",
-            include: ["sync codemode dts"],
-          }),
+        steps: ({ then }) => [
           then.files.contains({
             orgId: "org-1",
-            path: "/workspace/codemode/providers/capabilities.d.ts",
+            path: "/static/codemode/providers/capabilities.d.ts",
             text: "declare const capabilities",
           }),
           then.files.contains({
             orgId: "org-1",
-            path: "/workspace/codemode/providers/connections.d.ts",
+            path: "/static/codemode/providers/connections.d.ts",
             text: "declare const connections",
           }),
           then.files.contains({
             orgId: "org-1",
-            path: "/workspace/codemode/providers/connections.d.ts",
+            path: "/static/codemode/providers/connections.d.ts",
             text: "configure(input: ConnectionsConfigureInput)",
           }),
           then.files.contains({
             orgId: "org-1",
-            path: "/workspace/codemode/providers/telegram.d.ts",
+            path: "/static/codemode/providers/telegram.d.ts",
             text: "declare const telegram",
           }),
           then.workflow.noErrored({ orgId: "org-1" }),
@@ -696,10 +641,10 @@ describe("system automation scenarios", () => {
     );
   });
 
-  test("mcp server configuration changes write installed MCP codemode provider types", async () => {
+  test("installed MCP servers expose codemode provider types from /static on demand", async () => {
     await runBackofficeScenario(
       defineBackofficeScenario({
-        name: "system MCP server configuration writes codemode provider types",
+        name: "installed MCP servers expose generated static codemode provider types",
 
         files: backofficeFiles.systemOnly(),
 
@@ -727,7 +672,7 @@ describe("system automation scenarios", () => {
           }),
         }),
 
-        setup: ({ given, runner, then }) => [
+        setup: ({ given, runner }) => [
           given.organization.exists({ id: "org-1", name: "Ada Labs" }),
           given.connection.configured({
             orgId: "org-1",
@@ -736,197 +681,28 @@ describe("system automation scenarios", () => {
           }),
           given.connection.configured({ orgId: "org-1", id: "mcp" }),
           runner.drain(),
-          then.assert("clear generated codemode types", (ctx) =>
-            clearGeneratedCodemodeTypes(ctx, "org-1"),
-          ),
         ],
 
-        steps: ({ when, then }) => [
-          when.automation.ingestEvent({
-            id: "mcp-server-changed-1",
-            scope: { kind: "org", orgId: "org-1" },
-            source: "mcp",
-            eventType: "server.configuration.changed",
-            occurredAt: "2026-01-01T00:00:00.000Z",
-            payload: {
-              serverId: "cloudflare-mcp",
-              current: { tools: [{ name: "search-docs" }] },
-            },
-            actor: { scope: "internal", type: "system", id: "mcp" },
-            actors: [{ scope: "internal", type: "system", id: "mcp" }],
-            subject: { orgId: "org-1", serverId: "cloudflare-mcp" },
-          }),
-
-          then.workflow.instance({
-            instanceId: "codemode-types-refresh-mcp-server-changed-1",
-            status: "complete",
-            output: {
-              changed: true,
-              path: "/workspace/codemode/system.d.ts",
-            },
+        steps: ({ then }) => [
+          then.files.contains({
+            orgId: "org-1",
+            path: "/static/codemode/system.d.ts",
+            text: "/static/codemode/providers/mcp_cloudflare_mcp.d.ts",
           }),
           then.files.contains({
             orgId: "org-1",
-            path: "/workspace/codemode/system.d.ts",
-            text: "/workspace/codemode/providers/mcp_cloudflare_mcp.d.ts",
-          }),
-          then.files.contains({
-            orgId: "org-1",
-            path: "/workspace/codemode/providers/mcp_cloudflare_mcp.d.ts",
+            path: "/static/codemode/providers/mcp_cloudflare_mcp.d.ts",
             text: "declare const mcp_cloudflare_mcp",
           }),
           then.files.contains({
             orgId: "org-1",
-            path: "/workspace/codemode/providers/mcp_cloudflare_mcp.d.ts",
+            path: "/static/codemode/providers/mcp_cloudflare_mcp.d.ts",
             text: "search_docs(input: McpCloudflareMcpSearchDocsInput)",
           }),
           then.files.contains({
             orgId: "org-1",
-            path: "/workspace/codemode/providers/mcp_cloudflare_mcp.d.ts",
+            path: "/static/codemode/providers/mcp_cloudflare_mcp.d.ts",
             text: "query: string",
-          }),
-          then.workflow.noErrored({ orgId: "org-1" }),
-        ],
-      }),
-    );
-  });
-
-  test("capability.configured overwrites stale codemode types", async () => {
-    await runBackofficeScenario(
-      defineBackofficeScenario({
-        name: "system capability configuration overwrites stale codemode types",
-
-        files: backofficeFiles.systemOnly(),
-
-        fakes: ({ fake }) => ({
-          telegram: fake.telegram(),
-        }),
-
-        setup: ({ given, runner, then }) => [
-          given.organization.exists({ id: "org-1", name: "Ada Labs" }),
-          given.connection.configured({
-            orgId: "org-1",
-            id: "upload",
-            payload: { provider: "database" },
-          }),
-          runner.drain(),
-          given.telegram.configured({
-            orgId: "org-1",
-            botUsername: "fragno_bot",
-          }),
-          runner.drain(),
-          then.assert("write stale canonical codemode types", async (ctx) => {
-            await clearGeneratedCodemodeTypes(ctx, "org-1");
-            const fs = await createScenarioOrgFileSystem(ctx, "org-1");
-            await fs.mkdir("/workspace/codemode", { recursive: true });
-            await fs.writeFile("/workspace/codemode/system.d.ts", "stale codemode types");
-          }),
-        ],
-
-        steps: ({ when, then }) => [
-          when.capability.configured({
-            orgId: "org-1",
-            source: "telegram",
-            capabilityId: "telegram",
-            capabilityLabel: "Telegram",
-            eventId: "telegram-capability-stale",
-          }),
-
-          then.workflow.instance({
-            instanceId: "codemode-types-refresh-telegram-capability-stale",
-            status: "complete",
-            output: {
-              changed: true,
-              path: "/workspace/codemode/system.d.ts",
-            },
-          }),
-          then.files.contains({
-            orgId: "org-1",
-            path: "/workspace/codemode/system.d.ts",
-            text: '/// <reference path="/workspace/codemode/workflow-authoring.d.ts" />',
-          }),
-          then.files.contains({
-            orgId: "org-1",
-            path: "/workspace/codemode/providers/telegram.d.ts",
-            text: "declare const telegram",
-          }),
-          then.workflow.noErrored({ orgId: "org-1" }),
-        ],
-      }),
-    );
-  });
-
-  test("capability.configured leaves identical codemode types unchanged", async () => {
-    await runBackofficeScenario(
-      defineBackofficeScenario({
-        name: "system capability configuration keeps identical codemode types",
-
-        files: backofficeFiles.systemOnly(),
-
-        fakes: ({ fake }) => ({
-          telegram: fake.telegram(),
-        }),
-
-        setup: ({ given, runner, then }) => [
-          given.organization.exists({ id: "org-1", name: "Ada Labs" }),
-          given.connection.configured({
-            orgId: "org-1",
-            id: "upload",
-            payload: { provider: "database" },
-          }),
-          runner.drain(),
-          given.telegram.configured({
-            orgId: "org-1",
-            botUsername: "fragno_bot",
-          }),
-          runner.drain(),
-          then.assert("clear generated codemode types", (ctx) =>
-            clearGeneratedCodemodeTypes(ctx, "org-1"),
-          ),
-        ],
-
-        steps: ({ when, then }) => [
-          when.capability.configured({
-            orgId: "org-1",
-            source: "telegram",
-            capabilityId: "telegram",
-            capabilityLabel: "Telegram",
-            eventId: "telegram-capability-first",
-          }),
-
-          then.workflow.instance({
-            instanceId: "codemode-types-refresh-telegram-capability-first",
-            status: "complete",
-            output: {
-              changed: true,
-              path: "/workspace/codemode/system.d.ts",
-            },
-          }),
-
-          when.capability.configured({
-            orgId: "org-1",
-            source: "telegram",
-            capabilityId: "telegram",
-            capabilityLabel: "Telegram",
-            eventId: "telegram-capability-second",
-          }),
-
-          then.workflow.instance({
-            instanceId: "codemode-types-refresh-telegram-capability-second",
-            status: "complete",
-            output: {
-              changed: false,
-              path: "/workspace/codemode/system.d.ts",
-            },
-          }),
-          then.workflow.steps({
-            instanceId: "codemode-types-refresh-telegram-capability-second",
-            include: ["sync codemode dts"],
-          }),
-          then.files.contains({
-            orgId: "org-1",
-            path: "/workspace/codemode/providers/telegram.d.ts",
-            text: "declare const telegram",
           }),
           then.workflow.noErrored({ orgId: "org-1" }),
         ],

--- a/apps/backoffice/app/fragno/automation/scenario.ts
+++ b/apps/backoffice/app/fragno/automation/scenario.ts
@@ -25,6 +25,7 @@ import type {
 import { backofficeContextScopeSinglePathSegment } from "@/backoffice-runtime/scope-codec";
 import {
   createBackofficeFileSystem,
+  STATIC_FILE_CONTENT,
   SYSTEM_FILE_CONTENT,
   WORKSPACE_STARTER_CONTENT,
 } from "@/files";
@@ -695,7 +696,7 @@ export type BackofficeScenarioStepBuilders<TVars extends ScenarioVars = Scenario
 };
 
 const mapContentToMountedFiles = (
-  mountPoint: "/system" | "/workspace",
+  mountPoint: "/static" | "/system" | "/workspace",
   files: Record<string, string | Uint8Array>,
 ) =>
   Object.fromEntries(
@@ -718,11 +719,16 @@ const createPreset = (
 });
 
 export const backofficeFiles = {
-  systemOnly: () => createPreset(mapContentToMountedFiles("/system", SYSTEM_FILE_CONTENT)),
+  systemOnly: () =>
+    createPreset({
+      ...mapContentToMountedFiles("/static", STATIC_FILE_CONTENT),
+      ...mapContentToMountedFiles("/system", SYSTEM_FILE_CONTENT),
+    }),
   workspaceStarter: () =>
     createPreset(mapContentToMountedFiles("/workspace", WORKSPACE_STARTER_CONTENT)),
   fullStarter: () =>
     createPreset({
+      ...mapContentToMountedFiles("/static", STATIC_FILE_CONTENT),
       ...mapContentToMountedFiles("/system", SYSTEM_FILE_CONTENT),
       ...mapContentToMountedFiles("/workspace", WORKSPACE_STARTER_CONTENT),
     }),
@@ -1474,10 +1480,12 @@ const getReadableScenarioFileSystem = async (
     return scenarioFs;
   }
 
+  const execution = { actor: createScenarioActor(orgId), scope: { kind: "org" as const, orgId } };
   const orgFs = await createBackofficeFileSystem({
     objects: ctx.runtime.objects,
     kernel: new BackofficeKernel({ objects: ctx.runtime.objects }),
-    execution: { actor: createScenarioActor(orgId), scope: { kind: "org", orgId } },
+    execution,
+    config: ctx.runtime.config,
   });
   if (await fileExists(orgFs, path)) {
     return orgFs;
@@ -3339,10 +3347,15 @@ const collectDiagnostics = async (ctx: BackofficeScenarioContext): Promise<unkno
 
     try {
       const scenarioFs = ctx.files.forOrg(orgId);
+      const execution = {
+        actor: createScenarioActor(orgId),
+        scope: { kind: "org" as const, orgId },
+      };
       const orgFs = await createBackofficeFileSystem({
         objects: ctx.runtime.objects,
         kernel: new BackofficeKernel({ objects: ctx.runtime.objects }),
-        execution: { actor: createScenarioActor(orgId), scope: { kind: "org", orgId } },
+        execution,
+        config: ctx.runtime.config,
       });
       filesByOrg[orgId] = {
         scenarioPaths: scenarioFs.getAllPaths(),

--- a/apps/backoffice/app/fragno/codemode/codemode-dts.ts
+++ b/apps/backoffice/app/fragno/codemode/codemode-dts.ts
@@ -1,4 +1,4 @@
-import { renderSystemGuidance } from "@/files";
+import { renderStaticGuidance } from "@/files";
 import type { IFileSystem } from "@/files/interface";
 import {
   backofficeCapabilities,
@@ -17,14 +17,14 @@ import {
 } from "@/fragno/runtime-tools/reference";
 import type { BackofficeRuntimeToolFamily } from "@/fragno/runtime-tools/runtime-tools";
 
-export const CODEMODE_TYPES_DIR_PATH = "/workspace/codemode";
+export const CODEMODE_TYPES_DIR_PATH = "/static/codemode";
 export const CODEMODE_SYSTEM_DTS_PATH = `${CODEMODE_TYPES_DIR_PATH}/system.d.ts`;
 export const CODEMODE_STATE_DTS_PATH = `${CODEMODE_TYPES_DIR_PATH}/state.d.ts`;
 export const CODEMODE_WORKFLOW_AUTHORING_DTS_PATH = `${CODEMODE_TYPES_DIR_PATH}/workflow-authoring.d.ts`;
 export const CODEMODE_PROVIDER_TYPES_DIR_PATH = `${CODEMODE_TYPES_DIR_PATH}/providers`;
 
 export const renderCodemodeSystemPrompt = async ({ fileSystem }: { fileSystem: IFileSystem }) =>
-  renderSystemGuidance({
+  renderStaticGuidance({
     codemodeDts: await fileSystem.readFile(CODEMODE_SYSTEM_DTS_PATH),
     stateDts: await fileSystem.readFile(CODEMODE_STATE_DTS_PATH),
     workflowAuthoringDts: await fileSystem.readFile(CODEMODE_WORKFLOW_AUTHORING_DTS_PATH),
@@ -48,6 +48,16 @@ export type CodemodeTypeFile = {
   path: string;
   content: string;
 };
+
+export const codemodeTypeFilesToStaticArtifacts = (files: readonly CodemodeTypeFile[]) =>
+  Object.fromEntries(
+    files.map((file) => {
+      if (!file.path.startsWith("/static/")) {
+        throw new Error(`Codemode type file must live under /static: ${file.path}`);
+      }
+      return [file.path.slice("/static/".length), file.content];
+    }),
+  );
 
 const getCapabilityRuntimeNamespaces = (
   capabilityId: BackofficeCapabilityId,

--- a/apps/backoffice/app/fragno/codemode/static-codemode-artifacts.ts
+++ b/apps/backoffice/app/fragno/codemode/static-codemode-artifacts.ts
@@ -1,0 +1,129 @@
+import type { BackofficeExecutionContext } from "@/backoffice-runtime/context";
+import type { BackofficeObjectRegistry } from "@/backoffice-runtime/object-registry";
+import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
+import { emptyStaticFileArtifacts, type StaticFileArtifactsResolver } from "@/files/types";
+import {
+  backofficeCapabilities,
+  type BackofficeCapabilityId,
+} from "@/fragno/backoffice-capabilities/backoffice-capabilities";
+import {
+  codemodeTypeFilesToStaticArtifacts,
+  CODEMODE_SYSTEM_DTS_PATH,
+  createCodemodeTypeFiles,
+  type CodemodeTypeFile,
+} from "@/fragno/codemode/codemode-dts";
+import { createMcpCodemodeServers } from "@/fragno/codemode/mcp-codemode-tools";
+import { STATE_TYPES } from "@/fragno/codemode/state-prompt";
+import { createMcpRuntime } from "@/fragno/runtime-tools/families/mcp-runtime";
+import type { BackofficeRuntimeToolFamily } from "@/fragno/runtime-tools/runtime-tools";
+import { runtimeToolFamilies } from "@/fragno/runtime-tools/tool-families";
+
+export type CodemodeStaticArtifactsResult = {
+  path: typeof CODEMODE_SYSTEM_DTS_PATH;
+  files: CodemodeTypeFile[];
+  artifacts: Record<string, string>;
+  configuredCapabilities: BackofficeCapabilityId[];
+};
+
+const isCapabilityBindingAvailable = (
+  config: BackofficeRuntimeConfig,
+  capabilityId: BackofficeCapabilityId,
+) => {
+  if (capabilityId === "cloudflare") {
+    return config.bindings.cloudflareWorkers;
+  }
+
+  if (capabilityId in config.bindings) {
+    return config.bindings[capabilityId as keyof BackofficeRuntimeConfig["bindings"]];
+  }
+
+  return true;
+};
+
+export const createCodemodeStaticArtifacts = async ({
+  objects,
+  config,
+  orgId,
+  origin = "https://backoffice.local",
+  families = runtimeToolFamilies,
+}: {
+  objects: BackofficeObjectRegistry;
+  config: BackofficeRuntimeConfig;
+  orgId: string;
+  origin?: string;
+  families?: readonly BackofficeRuntimeToolFamily[];
+}): Promise<CodemodeStaticArtifactsResult> => {
+  const configuredCapabilities: BackofficeCapabilityId[] = [];
+
+  for (const capability of backofficeCapabilities) {
+    if (capability.kind === "system") {
+      configuredCapabilities.push(capability.id);
+      continue;
+    }
+
+    if (!isCapabilityBindingAvailable(config, capability.id)) {
+      continue;
+    }
+
+    const status = await capability.connection.getStatus({
+      objects,
+      config,
+      scope: { kind: "org", orgId },
+      orgId,
+      origin,
+    });
+    if (status.configured) {
+      configuredCapabilities.push(capability.id);
+    }
+  }
+
+  const mcpServers = configuredCapabilities.includes("mcp")
+    ? await createMcpRuntime(objects.mcp.forOrg(orgId))
+        .listServers()
+        .then(({ servers }) => createMcpCodemodeServers(servers))
+    : [];
+
+  const files = createCodemodeTypeFiles({
+    configuredCapabilityIds: configuredCapabilities,
+    families,
+    mcpServers,
+    stateTypes: STATE_TYPES,
+  });
+
+  return {
+    path: CODEMODE_SYSTEM_DTS_PATH,
+    files,
+    artifacts: codemodeTypeFilesToStaticArtifacts(files),
+    configuredCapabilities,
+  };
+};
+
+export const createCodemodeStaticArtifactsResolver = ({
+  objects,
+  config,
+  execution,
+  origin,
+  families,
+}: {
+  objects: BackofficeObjectRegistry;
+  config: BackofficeRuntimeConfig;
+  execution: BackofficeExecutionContext;
+  origin?: string;
+  families?: readonly BackofficeRuntimeToolFamily[];
+}): StaticFileArtifactsResolver => {
+  if (execution.scope.kind !== "org" && execution.scope.kind !== "project") {
+    return emptyStaticFileArtifacts;
+  }
+
+  const orgId = execution.scope.orgId;
+  return async () =>
+    (
+      await createCodemodeStaticArtifacts({
+        objects,
+        config,
+        orgId,
+        ...(origin ? { origin } : {}),
+        ...(families ? { families } : {}),
+      })
+    ).artifacts;
+};

--- a/apps/backoffice/app/fragno/pi/exec-code-mode.cloudflare.test.ts
+++ b/apps/backoffice/app/fragno/pi/exec-code-mode.cloudflare.test.ts
@@ -9,6 +9,7 @@ import { buildDatabaseFragmentsTest } from "@fragno-dev/test";
 
 import { BackofficeKernel } from "@/backoffice-runtime/kernel";
 import type { BackofficeObjectRegistry } from "@/backoffice-runtime/object-registry";
+import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
 import { MasterFileSystem } from "@/files/master-file-system";
 import type { ResolvedFileMount } from "@/files/types";
 
@@ -24,6 +25,24 @@ import { createPiCodemodeRuntime } from "./pi-codemode";
 import type { PiCodemodeWorkflowParams } from "./pi-codemode-workflow";
 
 const unusedObjects = {} as BackofficeObjectRegistry;
+const testRuntimeConfig: BackofficeRuntimeConfig = {
+  bindings: {
+    api: false,
+    auth: false,
+    automations: false,
+    telegram: false,
+    otp: false,
+    pi: false,
+    resend: false,
+    reson8: false,
+    mcp: false,
+    upload: false,
+    github: false,
+    cloudflareWorkers: false,
+    githubWebhookRouter: false,
+    sandbox: false,
+  },
+};
 
 function makeFakeEsmSh(files: Record<string, string>): typeof fetch {
   return (async (input: RequestInfo | URL) => {
@@ -50,6 +69,7 @@ const createPiSessionFileSystemContext = () => ({
   orgId: "org-1",
   objects: unusedObjects,
   kernel: new BackofficeKernel({ objects: unusedObjects }),
+  runtimeConfig: testRuntimeConfig,
   execution: {
     actor: {
       type: "user" as const,

--- a/apps/backoffice/app/fragno/pi/pi-shared.ts
+++ b/apps/backoffice/app/fragno/pi/pi-shared.ts
@@ -1,5 +1,5 @@
 import type { BackofficeContextScope } from "@/backoffice-runtime/context";
-import { SYSTEM_FILE_CONTENT } from "@/files";
+import { STATIC_FILE_CONTENT } from "@/files";
 
 export type PiSteeringMode = "all" | "one-at-a-time";
 export type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
@@ -93,7 +93,7 @@ export const DEFAULT_PI_HARNESSES: PiHarnessConfig[] = [
     label: "Default",
     description:
       "Built-in harness with codemode, read, and bash access to the combined session filesystem.",
-    systemPrompt: SYSTEM_FILE_CONTENT["SYSTEM.md"],
+    systemPrompt: STATIC_FILE_CONTENT["SYSTEM.md"],
     tools: ["execCodeMode", "read", "bash"],
     thinkingLevel: "low",
   },

--- a/apps/backoffice/app/fragno/pi/pi-skills.ts
+++ b/apps/backoffice/app/fragno/pi/pi-skills.ts
@@ -69,7 +69,7 @@ export const loadBackofficePiSkills = async (
   options: { root?: string; roots?: readonly string[] } = {},
 ): Promise<PiSkillRegistry> => {
   const roots =
-    options.roots ?? (options.root ? [options.root] : ["/system/skills", "/workspace/skills"]);
+    options.roots ?? (options.root ? [options.root] : ["/static/skills", "/workspace/skills"]);
   const skills: PiSkillRegistry = {};
 
   for (const root of roots) {

--- a/apps/backoffice/app/fragno/pi/pi.test.ts
+++ b/apps/backoffice/app/fragno/pi/pi.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi, assert } from "vitest";
 
 import { BackofficeKernel } from "@/backoffice-runtime/kernel";
+import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
 import * as files from "@/files";
 import { EMPTY_BASH_HOST_CONTEXT } from "@/fragno/runtime-tools/bash-host.test-utils";
 import { createUnavailableAutomationRouterRuntime } from "@/fragno/runtime-tools/families/automations-routing";
@@ -14,6 +15,25 @@ import {
   type PiSessionFileSystemContext,
 } from "./pi";
 import { loadBackofficePiSkills } from "./pi-skills";
+
+const testRuntimeConfig: BackofficeRuntimeConfig = {
+  bindings: {
+    api: false,
+    auth: false,
+    automations: false,
+    telegram: false,
+    otp: false,
+    pi: false,
+    resend: false,
+    reson8: false,
+    mcp: false,
+    upload: false,
+    github: false,
+    cloudflareWorkers: false,
+    githubWebhookRouter: false,
+    sandbox: false,
+  },
+};
 
 const createMockEnv = () =>
   ({
@@ -115,13 +135,17 @@ const createMockBashContext = (): PiBashCommandContext => ({
 
 describe("Backoffice Pi skills", () => {
   test("loads starter skills from the Pi filesystem", async () => {
-    const fs = await files.createBackofficeFileSystem(createContext());
+    const context = createContext();
+    const fs = await files.createBackofficeFileSystem({
+      ...context,
+      config: context.runtimeConfig,
+    });
     const skills = await loadBackofficePiSkills(fs);
 
     expect(Object.keys(skills)).toContain("building-automations");
     expect(skills["building-automations"]).toMatchObject({
-      location: "/system/skills/building-automations/SKILL.md",
-      directory: "/system/skills/building-automations",
+      location: "/static/skills/building-automations/SKILL.md",
+      directory: "/static/skills/building-automations",
     });
     expect(skills["building-automations"]?.body).toContain("events.eventsCatalogList");
   });
@@ -169,13 +193,13 @@ Filesystem-defined instructions.
 
     assert(readTool.name === "read");
     const result = await readTool.execute("tool-call-skill-1", {
-      path: "/system/skills/building-automations/SKILL.md",
+      path: "/static/skills/building-automations/SKILL.md",
       offset: 1,
       limit: 8,
     } as never);
 
     expect(result.details).toMatchObject({
-      path: "/system/skills/building-automations/SKILL.md",
+      path: "/static/skills/building-automations/SKILL.md",
       offset: 1,
       limit: 8,
     });
@@ -226,7 +250,7 @@ describe("Pi bash tool", () => {
       "dev",
       "projects",
       "resend",
-      "system",
+      "static",
       "tmp",
     ]);
   });
@@ -253,7 +277,7 @@ describe("Pi bash tool", () => {
 
     const result = await tool.execute("tool-call-3", {
       script: "ls",
-      cwd: "/system",
+      cwd: "/static",
     } as never);
     expect(result.details).toMatchObject({
       stderr: "",
@@ -262,6 +286,7 @@ describe("Pi bash tool", () => {
     expect((result.details as { stdout: string }).stdout.split("\n")).toEqual([
       "SYSTEM.md",
       "automations",
+      "codemode",
       "skills",
     ]);
   });
@@ -287,13 +312,13 @@ describe("Pi bash tool", () => {
     } as never);
 
     const result = await tool.execute("tool-call-automations-1", {
-      script: "cat /system/automations/codemode-types-refresh.workflow.js",
+      script: "cat /static/automations/project-files-configure.workflow.js",
     } as never);
     expect(result.details).toMatchObject({
       stderr: "",
       exitCode: 0,
     });
-    expect((result.details as { stdout: string }).stdout).toContain("codemode-types-refresh");
+    expect((result.details as { stdout: string }).stdout).toContain("project-files-configure");
   });
 
   test("mounts resend thread snapshots when a resend runtime is available", async () => {
@@ -452,7 +477,7 @@ describe("Pi bash tool", () => {
     } as never);
 
     const touchResult = await tool.execute("tool-call-readonly-1", {
-      script: "touch /system/SYSTEM.md",
+      script: "touch /static/SYSTEM.md",
     } as never);
     expect(touchResult.details).toMatchObject({
       stdout: "",
@@ -558,6 +583,7 @@ const createContext = (
     orgId: "acme-org",
     objects,
     kernel: new BackofficeKernel({ objects }),
+    runtimeConfig: testRuntimeConfig,
     execution: {
       actor: {
         type: "user",

--- a/apps/backoffice/app/fragno/pi/pi.ts
+++ b/apps/backoffice/app/fragno/pi/pi.ts
@@ -94,6 +94,7 @@ export type PiSessionFileSystemContext = {
   objects: BackofficeObjectRegistry;
   kernel: BackofficeKernel;
   execution: BackofficeExecutionContext;
+  runtimeConfig: import("@/backoffice-runtime/runtime-services").BackofficeRuntimeConfig;
 };
 
 export type PiCodemodeRuntime = {
@@ -156,7 +157,7 @@ const createReadTool = (fs: MasterFileSystem): AgentTool =>
     name: "read",
     label: "Read",
     description:
-      "Read a file from the combined Pi session filesystem. Use this to load matching skills from /system/skills/<skill-name>/SKILL.md or /workspace/skills/<skill-name>/SKILL.md before applying them.",
+      "Read a file from the combined Pi session filesystem. Use this to load matching skills from /static/skills/<skill-name>/SKILL.md or /workspace/skills/<skill-name>/SKILL.md before applying them.",
     parameters: readParametersSchema,
     execute: async (_toolCallId, params, signal) => {
       if (signal?.aborted) {
@@ -404,6 +405,7 @@ const getSessionFs = async (
     objects: context.objects,
     kernel: context.kernel,
     execution: context.execution,
+    config: context.runtimeConfig,
   });
 
   cache.set(sessionId, pendingFileSystem);

--- a/apps/backoffice/app/fragno/runtime-tools/families/backoffice-capabilities.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/backoffice-capabilities.ts
@@ -926,14 +926,14 @@ export const createBackofficeCapabilitiesRuntime = ({
         id: capability.id,
         label: capability.label,
         overview: hasSkill
-          ? `Use /system/${skillPath} for setup, event, and tool guidance.`
+          ? `Use /static/${skillPath} for setup, event, and tool guidance.`
           : `${capability.label} does not provide a setup guide yet.`,
         manualSteps: hasSkill
           ? [
               {
                 id: "read-agent-skill",
                 title: "Read agent skill",
-                instructions: `Open /system/${skillPath} and follow its guidance.`,
+                instructions: `Open /static/${skillPath} and follow its guidance.`,
               },
             ]
           : [],

--- a/apps/backoffice/app/fragno/runtime-tools/families/internal.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/internal.ts
@@ -1,11 +1,8 @@
 import { z } from "zod";
 
-import { BackofficeKernel } from "@/backoffice-runtime/kernel";
 import type { BackofficeObjectRegistry } from "@/backoffice-runtime/object-registry";
 import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
-import { createBackofficeFileSystem } from "@/files/create-file-system";
 import { FileSystemError } from "@/files/fs-errors";
-import type { IFileSystem } from "@/files/interface";
 import { createMasterFileSystem } from "@/files/master-file-system";
 import {
   seedWorkspaceStarterFiles,
@@ -13,21 +10,7 @@ import {
 } from "@/files/seed-workspace-starter-files";
 import { createSystemFilesContext } from "@/files/system-context";
 import type { StarterAutomationRoutesSeedResult } from "@/fragno/automation";
-import {
-  backofficeCapabilities,
-  type BackofficeCapabilityId,
-} from "@/fragno/backoffice-capabilities/backoffice-capabilities";
-import {
-  CODEMODE_PROVIDER_TYPES_DIR_PATH,
-  CODEMODE_SYSTEM_DTS_PATH,
-  CODEMODE_TYPES_DIR_PATH,
-  createCodemodeTypeFiles,
-  type CodemodeTypeFile,
-} from "@/fragno/codemode/codemode-dts";
-import { createMcpCodemodeServers } from "@/fragno/codemode/mcp-codemode-tools";
-import { STATE_TYPES } from "@/fragno/codemode/state-prompt";
 import { defineCliArgsParser, readOutputOptions } from "@/fragno/runtime-tools/bash-cli";
-import { createMcpRuntime } from "@/fragno/runtime-tools/families/mcp-runtime";
 
 import {
   defineBackofficeRuntimeTool,
@@ -35,12 +18,6 @@ import {
   type BackofficeRuntimeToolFamily,
   type BackofficeToolContext,
 } from "../runtime-tools";
-
-export type CodemodeTypesSyncOutput = {
-  path: typeof CODEMODE_SYSTEM_DTS_PATH;
-  changed: boolean;
-  configuredCapabilities: BackofficeCapabilityId[];
-};
 
 export type ProjectDatabaseFileSystemConfigureOutput = {
   projectId: string;
@@ -52,7 +29,6 @@ export type ProjectDatabaseFileSystemConfigureOutput = {
 
 export type InternalRuntime = {
   seedWorkspaceStarterFiles(input?: { force?: boolean }): Promise<WorkspaceStarterFilesSeedOutput>;
-  syncCodemodeTypes(): Promise<CodemodeTypesSyncOutput>;
   configureProjectDatabaseFileSystem(input: {
     projectId: string;
   }): Promise<ProjectDatabaseFileSystemConfigureOutput>;
@@ -67,12 +43,6 @@ const workspaceStarterFilesSeedOutputSchema = z.object({
   created: z.array(z.string()),
   overwritten: z.array(z.string()),
   skipped: z.array(z.string()),
-});
-
-const codemodeTypesSyncOutputSchema = z.object({
-  path: z.literal(CODEMODE_SYSTEM_DTS_PATH),
-  changed: z.boolean(),
-  configuredCapabilities: z.array(z.string()),
 });
 
 const projectDatabaseFileSystemConfigureOutputSchema = z.object({
@@ -95,55 +65,12 @@ const getRuntime = (context: InternalToolContext) => {
   return context.runtimes.internal;
 };
 
-const ensureDirectory = async (fs: IFileSystem, path: string) => {
-  if (await fs.exists(path)) {
-    const stat = await fs.stat(path);
-    if (!stat.isDirectory) {
-      throw new Error(`Codemode types path exists but is not a directory: ${path}`);
-    }
-    return;
-  }
-
-  await fs.mkdir(path, { recursive: true });
-};
-
-const syncCodemodeTypeFiles = async (
-  fs: IFileSystem,
-  files: readonly CodemodeTypeFile[],
-): Promise<boolean> => {
-  await ensureDirectory(fs, CODEMODE_TYPES_DIR_PATH);
-  await ensureDirectory(fs, CODEMODE_PROVIDER_TYPES_DIR_PATH);
-
-  const expectedPaths = new Set(files.map((file) => file.path));
-  let changed = false;
-
-  for (const name of await fs.readdir(CODEMODE_PROVIDER_TYPES_DIR_PATH)) {
-    const path = `${CODEMODE_PROVIDER_TYPES_DIR_PATH}/${name}`;
-    if (!name.endsWith(".d.ts") || expectedPaths.has(path)) {
-      continue;
-    }
-    await fs.rm(path, { force: true });
-    changed = true;
-  }
-
-  for (const file of files) {
-    const existing = (await fs.exists(file.path)) ? await fs.readFile(file.path) : null;
-    if (existing === file.content) {
-      continue;
-    }
-    await fs.writeFile(file.path, file.content);
-    changed = true;
-  }
-
-  return changed;
-};
-
 export const createInternalRuntime = ({
   objects,
-  config,
+  config: _config,
   orgId,
   origin = "https://backoffice.local",
-  families,
+  families: _families,
 }: {
   objects: BackofficeObjectRegistry;
   config: BackofficeRuntimeConfig;
@@ -151,49 +78,6 @@ export const createInternalRuntime = ({
   origin?: string;
   families: readonly BackofficeRuntimeToolFamily[];
 }): InternalRuntime => {
-  const renderCodemodeTypes = async (): Promise<{
-    path: typeof CODEMODE_SYSTEM_DTS_PATH;
-    files: CodemodeTypeFile[];
-    configuredCapabilities: BackofficeCapabilityId[];
-  }> => {
-    const configuredCapabilities: BackofficeCapabilityId[] = [];
-
-    for (const capability of backofficeCapabilities) {
-      if (capability.kind === "system") {
-        configuredCapabilities.push(capability.id);
-        continue;
-      }
-
-      const status = await capability.connection.getStatus({
-        objects,
-        config,
-        scope: { kind: "org", orgId },
-        orgId,
-        origin,
-      });
-      if (status.configured) {
-        configuredCapabilities.push(capability.id);
-      }
-    }
-
-    const mcpServers = configuredCapabilities.includes("mcp")
-      ? await createMcpRuntime(objects.mcp.forOrg(orgId))
-          .listServers()
-          .then(({ servers }) => createMcpCodemodeServers(servers))
-      : [];
-
-    return {
-      path: CODEMODE_SYSTEM_DTS_PATH,
-      files: createCodemodeTypeFiles({
-        configuredCapabilityIds: configuredCapabilities,
-        families,
-        mcpServers,
-        stateTypes: STATE_TYPES,
-      }),
-      configuredCapabilities,
-    };
-  };
-
   return {
     seedWorkspaceStarterFiles: async (input) =>
       await seedWorkspaceStarterFiles({ objects, orgId, force: input?.force }),
@@ -213,6 +97,7 @@ export const createInternalRuntime = ({
             actor: { type: "system", id: "backoffice-project-files" },
             scope: { kind: "project", orgId, projectId },
           },
+          staticFileArtifacts: () => ({}),
         }),
       );
       const created: string[] = [];
@@ -238,25 +123,6 @@ export const createInternalRuntime = ({
         configured: config.providers.database?.configured === true,
         created,
         skipped,
-      };
-    },
-    syncCodemodeTypes: async () => {
-      const rendered = await renderCodemodeTypes();
-      const kernel = new BackofficeKernel({ objects });
-      const fs = await createBackofficeFileSystem({
-        objects,
-        kernel,
-        execution: {
-          actor: { type: "system", id: "system" },
-          scope: { kind: "org", orgId },
-        },
-      });
-      const changed = await syncCodemodeTypeFiles(fs, rendered.files);
-
-      return {
-        path: rendered.path,
-        changed,
-        configuredCapabilities: rendered.configuredCapabilities,
       };
     },
   };
@@ -368,41 +234,10 @@ const automationRoutesSeedStarterTool = defineBackofficeRuntimeTool({
   },
 });
 
-const codemodeTypesSyncTool = defineBackofficeRuntimeTool({
-  id: "internal.codemode.types.sync",
-  namespace: "internal",
-  name: "codemodeTypesSync",
-  description: "Render and write the org-scoped codemode TypeScript declarations if changed.",
-  requiredPermissions: ["manage"],
-  inputSchema: z.object({}).optional().default({}),
-  outputSchema: codemodeTypesSyncOutputSchema,
-  execute: async (_input, context: InternalToolContext) =>
-    await getRuntime(context).syncCodemodeTypes(),
-  adapters: {
-    bash: {
-      command: "internal.codemode.types.sync",
-      help: {
-        summary: "internal.codemode.types.sync writes /workspace/codemode/system.d.ts if changed.",
-        options: [],
-        examples: ["internal.codemode.types.sync --format json"],
-      },
-      parse: () => ({}),
-      outputOptions: (_args, parsed) => readOutputOptions(parsed),
-      format: (output, options) =>
-        options.format === "json" || options.print
-          ? { data: output }
-          : {
-              stdout: `path=${output.path}\nchanged=${output.changed ? "yes" : "no"}\nconfiguredCapabilities=${output.configuredCapabilities.join(",")}\n`,
-            },
-    },
-  },
-});
-
 const internalRuntimeTools = [
   filesSeedExecuteTool,
   projectFilesConfigureTool,
   automationRoutesSeedStarterTool,
-  codemodeTypesSyncTool,
 ] as const;
 
 export const internalToolFamily = defineBackofficeRuntimeToolFamily({

--- a/apps/backoffice/app/fragno/runtime-tools/reference.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/reference.test.ts
@@ -424,6 +424,12 @@ describe("runtime tool reference generation", () => {
         "// ── Backoffice domain tool providers ───────────────────────────────────
 
         // reson8 tools
+        type Reson8CodemodeProvider = {
+          /** Transcribe a prerecorded audio file via Reson8. */
+          transcribePrerecorded(input: Reson8TranscribePrerecordedInput): Promise<Reson8TranscribePrerecordedOutput>;
+        };
+        declare const reson8: Reson8CodemodeProvider;
+
         type Reson8TranscribePrerecordedInput = {
           audio?: unknown;
           encoding?: "auto" | "pcm_s16le";
@@ -445,12 +451,6 @@ describe("runtime tool reference generation", () => {
               confidence?: number;
             }[];
         };
-
-        type Reson8CodemodeProvider = {
-          /** Transcribe a prerecorded audio file via Reson8. */
-          transcribePrerecorded(input: Reson8TranscribePrerecordedInput): Promise<Reson8TranscribePrerecordedOutput>;
-        };
-        declare const reson8: Reson8CodemodeProvider;
 
         // Scoped context handles target a selected Backoffice context.
         type BackofficeCodemodeScopedProviders = {
@@ -475,6 +475,20 @@ describe("runtime tool reference generation", () => {
         "// ── Backoffice domain tool providers ───────────────────────────────────
 
         // telegram tools
+        type TelegramCodemodeProvider = {
+          /** Resolve Telegram attachment metadata. */
+          getFile(input: TelegramGetFileInput): Promise<TelegramGetFileOutput>;
+          /** Download a Telegram file and return its bytes. */
+          downloadFile(input: TelegramDownloadFileInput): Promise<TelegramDownloadFileOutput>;
+          /** Queue a message to be sent to a Telegram chat. */
+          sendMessage(input: TelegramSendMessageInput): Promise<TelegramSendMessageOutput>;
+          /** Send a Telegram chat action. */
+          sendChatAction(input: TelegramSendChatActionInput): Promise<TelegramSendChatActionOutput>;
+          /** Queue an edit of an existing Telegram message. */
+          editMessage(input: TelegramEditMessageInput): Promise<TelegramEditMessageOutput>;
+        };
+        declare const telegram: TelegramCodemodeProvider;
+
         type TelegramGetFileInput = {
           fileId: string;
         };
@@ -520,20 +534,6 @@ describe("runtime tool reference generation", () => {
           ok: boolean;
           queued: boolean;
         };
-
-        type TelegramCodemodeProvider = {
-          /** Resolve Telegram attachment metadata. */
-          getFile(input: TelegramGetFileInput): Promise<TelegramGetFileOutput>;
-          /** Download a Telegram file and return its bytes. */
-          downloadFile(input: TelegramDownloadFileInput): Promise<TelegramDownloadFileOutput>;
-          /** Queue a message to be sent to a Telegram chat. */
-          sendMessage(input: TelegramSendMessageInput): Promise<TelegramSendMessageOutput>;
-          /** Send a Telegram chat action. */
-          sendChatAction(input: TelegramSendChatActionInput): Promise<TelegramSendChatActionOutput>;
-          /** Queue an edit of an existing Telegram message. */
-          editMessage(input: TelegramEditMessageInput): Promise<TelegramEditMessageOutput>;
-        };
-        declare const telegram: TelegramCodemodeProvider;
 
         // Scoped context handles target a selected Backoffice context.
         type BackofficeCodemodeScopedProviders = {
@@ -600,10 +600,10 @@ describe("runtime tool reference generation", () => {
     });
     const index = files.find((file) => file.path === CODEMODE_SYSTEM_DTS_PATH)?.content;
 
-    expect(index).toContain('/// <reference path="/workspace/codemode/workflow-authoring.d.ts" />');
+    expect(index).toContain('/// <reference path="/static/codemode/workflow-authoring.d.ts" />');
     expect(index).toContain("type BackofficeCodemodeScopedProviders = {");
     expect(index).toContain("declare const context");
-    expect(index).not.toContain('/// <reference path="/workspace/codemode/state.d.ts" />');
+    expect(index).not.toContain('/// <reference path="/static/codemode/state.d.ts" />');
     assert(files.some((file) => file.path === CODEMODE_STATE_DTS_PATH));
   });
 
@@ -625,7 +625,7 @@ describe("runtime tool reference generation", () => {
       families: runtimeToolFamilies,
       stateTypes: "declare const state: unknown;",
     });
-    const types = readGeneratedFile(files, "/workspace/codemode/providers/router.d.ts");
+    const types = readGeneratedFile(files, "/static/codemode/providers/router.d.ts");
 
     expect(types).toContain("declare const router");
     expect(types).toContain("type AutomationEventMatcher =");
@@ -688,21 +688,21 @@ describe("runtime tool reference generation", () => {
     });
     const capabilitiesTypes = readGeneratedFile(
       files,
-      "/workspace/codemode/providers/capabilities.d.ts",
+      "/static/codemode/providers/capabilities.d.ts",
     );
     const connectionsTypes = readGeneratedFile(
       files,
-      "/workspace/codemode/providers/connections.d.ts",
+      "/static/codemode/providers/connections.d.ts",
     );
-    const workflowTypes = readGeneratedFile(files, "/workspace/codemode/providers/workflow.d.ts");
-    const eventTypes = readGeneratedFile(files, "/workspace/codemode/providers/event.d.ts");
-    const otpTypes = readGeneratedFile(files, "/workspace/codemode/providers/otp.d.ts");
+    const workflowTypes = readGeneratedFile(files, "/static/codemode/providers/workflow.d.ts");
+    const eventTypes = readGeneratedFile(files, "/static/codemode/providers/event.d.ts");
+    const otpTypes = readGeneratedFile(files, "/static/codemode/providers/otp.d.ts");
 
     expect(capabilitiesTypes).toContain("declare const capabilities");
     expect(connectionsTypes).toContain("declare const connections");
     expect(connectionsTypes).toContain("list(input: ConnectionsListInput)");
     expect(connectionsTypes).toContain("configure(input: ConnectionsConfigureInput)");
-    expect(readGeneratedFile(files, "/workspace/codemode/providers/store.d.ts")).toContain(
+    expect(readGeneratedFile(files, "/static/codemode/providers/store.d.ts")).toContain(
       "declare const store",
     );
     expect(workflowTypes).toContain("declare const workflow");
@@ -712,8 +712,8 @@ describe("runtime tool reference generation", () => {
     expect(eventTypes).toContain("declare const event");
     expect(eventTypes).toContain("emit(input: EventEmitInput)");
     expect(otpTypes).toContain("declare const otp");
-    assert(!files.some((file) => file.path === "/workspace/codemode/providers/pi.d.ts"));
-    assert(!files.some((file) => file.path === "/workspace/codemode/providers/telegram.d.ts"));
+    assert(!files.some((file) => file.path === "/static/codemode/providers/pi.d.ts"));
+    assert(!files.some((file) => file.path === "/static/codemode/providers/telegram.d.ts"));
   });
 
   test("renders scoped context handles", () => {
@@ -744,11 +744,11 @@ describe("runtime tool reference generation", () => {
       stateTypes: "declare const state: unknown;",
     });
 
-    expect(readGeneratedFile(piFiles, "/workspace/codemode/providers/pi.d.ts")).toContain(
+    expect(readGeneratedFile(piFiles, "/static/codemode/providers/pi.d.ts")).toContain(
       "declare const pi",
     );
-    assert(!piFiles.some((file) => file.path === "/workspace/codemode/providers/sandbox.d.ts"));
-    expect(readGeneratedFile(sandboxFiles, "/workspace/codemode/providers/sandbox.d.ts")).toContain(
+    assert(!piFiles.some((file) => file.path === "/static/codemode/providers/sandbox.d.ts"));
+    expect(readGeneratedFile(sandboxFiles, "/static/codemode/providers/sandbox.d.ts")).toContain(
       "declare const sandbox",
     );
   });
@@ -777,7 +777,7 @@ describe("runtime tool reference generation", () => {
         },
       ],
     });
-    const types = readGeneratedFile(files, "/workspace/codemode/providers/mcp_cloudflare_mcp.d.ts");
+    const types = readGeneratedFile(files, "/static/codemode/providers/mcp_cloudflare_mcp.d.ts");
 
     expect(types).toContain("declare const mcp_cloudflare_mcp");
     expect(types).toContain("search_docs(input: McpCloudflareMcpSearchDocsInput)");

--- a/apps/backoffice/app/fragno/runtime-tools/reference.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/reference.ts
@@ -358,14 +358,16 @@ const renderCodemodeProviderSection = ({
       .join("\n");
   });
 
+  const providerTypeName = `${pascalCase(namespace)}CodemodeProvider`;
+
   return [
     `// ${namespace} tools`,
-    ...typeDeclarations,
-    "",
-    `type ${pascalCase(namespace)}CodemodeProvider = {`,
+    `type ${providerTypeName} = {`,
     ...methods,
     `};`,
-    `declare const ${namespace}: ${pascalCase(namespace)}CodemodeProvider;`,
+    `declare const ${namespace}: ${providerTypeName};`,
+    "",
+    ...typeDeclarations,
   ].join("\n");
 };
 

--- a/apps/backoffice/app/routes/backoffice/automations/data.server.ts
+++ b/apps/backoffice/app/routes/backoffice/automations/data.server.ts
@@ -6,8 +6,10 @@ import { BackofficeKernel } from "@/backoffice-runtime/kernel";
 import { createBackofficeFileSystem } from "@/files";
 import { requireBackofficeContext } from "@/fragno/auth/backoffice-principal.server";
 import {
+  AUTOMATION_STATIC_ROOT,
   AUTOMATION_SYSTEM_ROOT,
   AUTOMATION_WORKSPACE_ROOT,
+  getAutomationLayerForPath,
   listAutomationWorkspaceScripts,
   readAutomationWorkspaceScript,
   type AutomationWorkspaceScriptEntry,
@@ -105,7 +107,12 @@ const createBackofficeAutomationFileSystem = async ({
   const { runtime } = context.get(BackofficeWorkerContext);
   const kernel = new BackofficeKernel({ objects: runtime.objects });
   const execution = await requireBackofficeContext(request, context, scope);
-  return createBackofficeFileSystem({ objects: runtime.objects, kernel, execution });
+  return createBackofficeFileSystem({
+    objects: runtime.objects,
+    kernel,
+    execution,
+    config: runtime.config,
+  });
 };
 
 const normalizeAutomationScriptPath = (value: string) => {
@@ -114,7 +121,7 @@ const normalizeAutomationScriptPath = (value: string) => {
     return "";
   }
 
-  for (const root of [AUTOMATION_SYSTEM_ROOT, AUTOMATION_WORKSPACE_ROOT]) {
+  for (const root of [AUTOMATION_STATIC_ROOT, AUTOMATION_SYSTEM_ROOT, AUTOMATION_WORKSPACE_ROOT]) {
     const prefix = `${root}/`;
     if (trimmed.startsWith(prefix)) {
       return trimmed.slice(prefix.length);
@@ -141,12 +148,25 @@ const buildAutomationScriptName = (path: string) => {
   return segments.join(" ") || path;
 };
 
+const isAutomationScriptLayerVisibleInScope = (
+  layer: AutomationWorkspaceScriptEntry["layer"],
+  scope: BackofficeContextScope,
+) => {
+  if (scope.kind === "system") {
+    return layer === "system";
+  }
+  if (layer === "static") {
+    return scope.kind === "org";
+  }
+  return layer === "workspace";
+};
+
 const buildWorkspaceScriptRecord = (
   script: AutomationWorkspaceScriptEntry,
 ): AutomationScriptRecord => ({
   id: toAutomationScriptId(script),
   layer: script.layer,
-  readOnly: script.layer === "system",
+  readOnly: script.layer === "static" || script.layer === "system",
   key: buildAutomationScriptKey(script.path),
   name: buildAutomationScriptName(script.path),
   engine: script.engine,
@@ -171,6 +191,9 @@ const fromAutomationScriptId = (value: string): string => {
     pathParts.length > 0 ? pathParts.join(":") : normalized,
   );
 
+  if (layer === "static") {
+    return `${AUTOMATION_STATIC_ROOT}/${path}`;
+  }
   if (layer === "system") {
     return `${AUTOMATION_SYSTEM_ROOT}/${path}`;
   }
@@ -217,6 +240,7 @@ export async function loadAutomationWorkspaceData({
 
   return {
     scripts: workspaceScripts
+      .filter((script) => isAutomationScriptLayerVisibleInScope(script.layer, resolvedScope))
       .map(buildWorkspaceScriptRecord)
       .sort(
         (left, right) =>
@@ -286,6 +310,14 @@ export async function loadAutomationScriptSource({
 
   try {
     const scriptPath = fromAutomationScriptId(scriptId);
+    const layer = getAutomationLayerForPath(scriptPath);
+    if (!isAutomationScriptLayerVisibleInScope(layer, resolvedScope)) {
+      return {
+        script: null,
+        scriptError: `Automation script '${scriptPath}' is not visible in ${resolvedScope.kind} scope.`,
+      };
+    }
+
     const script = await readAutomationWorkspaceScript(fileSystem, scriptPath);
     return {
       script: script.body,

--- a/apps/backoffice/app/routes/backoffice/automations/data.test.ts
+++ b/apps/backoffice/app/routes/backoffice/automations/data.test.ts
@@ -39,8 +39,10 @@ beforeEach(() => {
 describe("automation backoffice workspace data", () => {
   test("shows org filesystem scripts from the workspace root", async () => {
     const fileSystem = createStubAutomationFileSystem({
-      "/system/automations/codemode-types-refresh.workflow.js":
-        "defineWorkflow({ name: 'codemode-types-refresh' }, async () => {})",
+      "/static/automations/project-files-configure.workflow.js":
+        "defineWorkflow({ name: 'project-files-configure' }, async () => {})",
+      "/system/automations/workspace-file-initialization.workflow.js":
+        "defineWorkflow({ name: 'workspace-file-initialization' }, async () => {})",
       "/workspace/automations/custom.cm.js": "async () => true",
       "/workspace/automations/unbound.sh": 'echo "unbound"',
       "/workspace/automations/workflow.workflow.js":
@@ -81,11 +83,11 @@ describe("automation backoffice workspace data", () => {
     expect(result.scripts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "automation-script:system:codemode-types-refresh.workflow.js",
-          key: "codemode-types-refresh.workflow",
-          layer: "system",
+          id: "automation-script:static:project-files-configure.workflow.js",
+          key: "project-files-configure.workflow",
+          layer: "static",
           readOnly: true,
-          path: "codemode-types-refresh.workflow.js",
+          path: "project-files-configure.workflow.js",
           enabled: false,
         }),
       ]),
@@ -100,8 +102,34 @@ describe("automation backoffice workspace data", () => {
     expect(fileSystem.readFileCalls).toEqual([]);
   });
 
+  test("shows project workspace scripts without org static scripts in project scope", async () => {
+    const fileSystem = createStubAutomationFileSystem({
+      "/static/automations/project-files-configure.workflow.js":
+        "defineWorkflow({ name: 'project-files-configure' }, async () => {})",
+      "/workspace/automations/project-only.cm.js": "async () => true",
+    });
+    createBackofficeFileSystemMock.mockResolvedValue(fileSystem.fs);
+
+    const result = await loadAutomationWorkspaceData({
+      request,
+      context: mockContext,
+      scope: { kind: "project", orgId: "acme-org", projectId: "project-1" },
+    });
+
+    expect(result.scripts).toEqual([
+      expect.objectContaining({
+        id: "automation-script:workspace:project-only.cm.js",
+        layer: "workspace",
+        readOnly: false,
+        path: "project-only.cm.js",
+      }),
+    ]);
+  });
+
   test("shows system scripts in system scope", async () => {
     const fileSystem = createStubAutomationFileSystem({
+      "/static/automations/project-files-configure.workflow.js":
+        "defineWorkflow({ name: 'project-files-configure' }, async () => {})",
       "/system/automations/workspace-file-initialization.workflow.js":
         "defineWorkflow({ name: 'workspace-file-initialization' }, async () => {})",
       "/workspace/automations/custom.cm.js": "async () => true",
@@ -114,23 +142,21 @@ describe("automation backoffice workspace data", () => {
       scope: { kind: "system" },
     });
 
-    expect(result.scripts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "automation-script:system:workspace-file-initialization.workflow.js",
-          key: "workspace-file-initialization.workflow",
-          layer: "system",
-          readOnly: true,
-          path: "workspace-file-initialization.workflow.js",
-          enabled: false,
-        }),
-      ]),
-    );
+    expect(result.scripts).toEqual([
+      expect.objectContaining({
+        id: "automation-script:system:workspace-file-initialization.workflow.js",
+        key: "workspace-file-initialization.workflow",
+        layer: "system",
+        readOnly: true,
+        path: "workspace-file-initialization.workflow.js",
+        enabled: false,
+      }),
+    ]);
   });
 
-  test("reads visible system script source from org scope", async () => {
+  test("reads visible static script source from org scope", async () => {
     const fileSystem = createStubAutomationFileSystem({
-      "/system/automations/codemode-types-refresh.workflow.js": "refresh",
+      "/static/automations/project-files-configure.workflow.js": "configure",
     });
     createBackofficeFileSystemMock.mockResolvedValue(fileSystem.fs);
 
@@ -138,16 +164,58 @@ describe("automation backoffice workspace data", () => {
       request,
       context: mockContext,
       orgId: "acme-org",
-      scriptId: "automation-script:system:codemode-types-refresh.workflow.js",
+      scriptId: "automation-script:static:project-files-configure.workflow.js",
     });
 
     expect(result).toEqual({
-      script: "refresh",
+      script: "configure",
       scriptError: null,
     });
     expect(fileSystem.readFileCalls).toEqual([
-      "/system/automations/codemode-types-refresh.workflow.js",
+      "/static/automations/project-files-configure.workflow.js",
     ]);
+  });
+
+  test("rejects org static script source from project scope", async () => {
+    const fileSystem = createStubAutomationFileSystem({
+      "/static/automations/project-files-configure.workflow.js": "configure",
+    });
+    createBackofficeFileSystemMock.mockResolvedValue(fileSystem.fs);
+
+    const result = await loadAutomationScriptSource({
+      request,
+      context: mockContext,
+      scope: { kind: "project", orgId: "acme-org", projectId: "project-1" },
+      scriptId: "automation-script:static:project-files-configure.workflow.js",
+    });
+
+    expect(result).toEqual({
+      script: null,
+      scriptError:
+        "Automation script '/static/automations/project-files-configure.workflow.js' is not visible in project scope.",
+    });
+    expect(fileSystem.readFileCalls).toEqual([]);
+  });
+
+  test("rejects hidden system script source from org scope", async () => {
+    const fileSystem = createStubAutomationFileSystem({
+      "/system/automations/workspace-file-initialization.workflow.js": "initialize",
+    });
+    createBackofficeFileSystemMock.mockResolvedValue(fileSystem.fs);
+
+    const result = await loadAutomationScriptSource({
+      request,
+      context: mockContext,
+      orgId: "acme-org",
+      scriptId: "automation-script:system:workspace-file-initialization.workflow.js",
+    });
+
+    expect(result).toEqual({
+      script: null,
+      scriptError:
+        "Automation script '/system/automations/workspace-file-initialization.workflow.js' is not visible in org scope.",
+    });
+    expect(fileSystem.readFileCalls).toEqual([]);
   });
 
   test("reads the selected script source only when the user opens it", async () => {

--- a/apps/backoffice/app/routes/backoffice/automations/scripts.tsx
+++ b/apps/backoffice/app/routes/backoffice/automations/scripts.tsx
@@ -16,6 +16,21 @@ const compareScriptsByName = <TScript extends { path: string; name: string }>(
   right: TScript,
 ) => left.name.localeCompare(right.name) || left.path.localeCompare(right.path);
 
+const visibleScriptSectionDefinitions = (
+  scopeKind: AutomationLayoutContext["selectedScope"]["kind"],
+) => {
+  if (scopeKind === "system") {
+    return [{ id: "system" as const, label: "System", emptyLabel: "No system scripts." }];
+  }
+  if (scopeKind === "org") {
+    return [
+      { id: "static" as const, label: "Static", emptyLabel: "No static scripts." },
+      { id: "workspace" as const, label: "Workspace", emptyLabel: "No workspace scripts." },
+    ];
+  }
+  return [{ id: "workspace" as const, label: "Workspace", emptyLabel: "No workspace scripts." }];
+};
+
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const selectedScriptId = url.searchParams.get("script")?.trim() ?? "";
@@ -68,18 +83,10 @@ export default function BackofficeOrganisationAutomationScripts() {
   const isDetailVisible = Boolean(selectedScript);
   const basePath = automationScopeTabPath(selectedScope, "scripts");
   const hasScriptLoadError = Boolean(scriptsError);
-  const scriptSections = [
-    {
-      id: "system" as const,
-      label: "System",
-      scripts: scripts.filter((script) => script.layer === "system").sort(compareScriptsByName),
-    },
-    {
-      id: "workspace" as const,
-      label: "Workspace",
-      scripts: scripts.filter((script) => script.layer === "workspace").sort(compareScriptsByName),
-    },
-  ].filter((section) => section.scripts.length > 0);
+  const scriptSections = visibleScriptSectionDefinitions(selectedScope.kind).map((section) => ({
+    ...section,
+    scripts: scripts.filter((script) => script.layer === section.id).sort(compareScriptsByName),
+  }));
 
   if (hasScriptLoadError && scripts.length === 0) {
     return (
@@ -134,30 +141,36 @@ export default function BackofficeOrganisationAutomationScripts() {
                 </div>
 
                 <div className="space-y-1">
-                  {section.scripts.map((script) => {
-                    const isSelected = script.id === selectedScriptId;
+                  {section.scripts.length > 0 ? (
+                    section.scripts.map((script) => {
+                      const isSelected = script.id === selectedScriptId;
 
-                    return (
-                      <Link
-                        key={script.id}
-                        to={buildScriptLink({ basePath, scriptId: script.id })}
-                        preventScrollReset
-                        aria-current={isSelected ? "page" : undefined}
-                        className={
-                          isSelected
-                            ? "block border-l-2 border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] px-3 py-2.5 text-left"
-                            : "block border-l-2 border-transparent px-3 py-2.5 text-left transition-colors hover:border-[color:var(--bo-border-strong)] hover:bg-[var(--bo-panel-2)]"
-                        }
-                      >
-                        <p className="truncate text-sm font-medium text-[var(--bo-fg)]">
-                          {script.name}
-                        </p>
-                        <p className="mt-1 truncate font-mono text-[11px] text-[var(--bo-muted-2)]">
-                          {script.path}
-                        </p>
-                      </Link>
-                    );
-                  })}
+                      return (
+                        <Link
+                          key={script.id}
+                          to={buildScriptLink({ basePath, scriptId: script.id })}
+                          preventScrollReset
+                          aria-current={isSelected ? "page" : undefined}
+                          className={
+                            isSelected
+                              ? "block border-l-2 border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] px-3 py-2.5 text-left"
+                              : "block border-l-2 border-transparent px-3 py-2.5 text-left transition-colors hover:border-[color:var(--bo-border-strong)] hover:bg-[var(--bo-panel-2)]"
+                          }
+                        >
+                          <p className="truncate text-sm font-medium text-[var(--bo-fg)]">
+                            {script.name}
+                          </p>
+                          <p className="mt-1 truncate font-mono text-[11px] text-[var(--bo-muted-2)]">
+                            {script.path}
+                          </p>
+                        </Link>
+                      );
+                    })
+                  ) : (
+                    <p className="border border-dashed border-[color:var(--bo-border)] px-3 py-2.5 text-xs text-[var(--bo-muted-2)]">
+                      {section.emptyLabel}
+                    </p>
+                  )}
                 </div>
               </div>
             ))}

--- a/apps/backoffice/app/routes/backoffice/automations/shared.tsx
+++ b/apps/backoffice/app/routes/backoffice/automations/shared.tsx
@@ -3,7 +3,11 @@ import { Link, isRouteErrorResponse } from "react-router";
 
 import { BackofficePageHeader } from "@/components/backoffice";
 import type { AuthMeData } from "@/fragno/auth/auth-client";
-import type { AutomationEventRecord, AutomationRouteDefinition } from "@/fragno/automation";
+import type {
+  AutomationEventRecord,
+  AutomationRouteDefinition,
+  AutomationScriptLayer,
+} from "@/fragno/automation";
 import type { AutomationEventActor } from "@/fragno/automation/contracts";
 import type { SandboxInstanceSummary } from "@/sandbox/contracts";
 
@@ -21,7 +25,7 @@ export type AutomationScriptItem = {
   key: string;
   name: string;
   engine: string;
-  layer: "system" | "workspace";
+  layer: AutomationScriptLayer;
   readOnly: boolean;
   script: string | null;
   path: string;

--- a/apps/backoffice/app/routes/backoffice/dashboard-terminal-panel.tsx
+++ b/apps/backoffice/app/routes/backoffice/dashboard-terminal-panel.tsx
@@ -28,7 +28,7 @@ const suggestionKindLabel = (suggestion: DashboardAutocompleteSuggestion) => {
 export function DashboardTerminalPanel({
   scopeId,
   scopeName,
-  description = "Command output is executed against the backoffice Pi-backed filesystem (/system, /workspace).",
+  description = "Command output is executed against the backoffice Pi-backed filesystem (/static, /workspace).",
   commandSpecs = [],
 }: DashboardTerminalPanelProps) {
   const commandFetcher = useFetcher<DashboardTerminalActionResult>();
@@ -188,7 +188,7 @@ export function DashboardTerminalPanel({
               value={terminal.command}
               onChange={(event) => terminal.onCommandChange(event.target.value)}
               onKeyDown={terminal.onCommandKeyDown}
-              placeholder="Run a bash command (e.g. ls /workspace, pwd, find /system)"
+              placeholder="Run a bash command (e.g. ls /workspace, pwd, find /static)"
               className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm text-[var(--bo-fg)] outline-none"
               autoCapitalize="off"
               autoComplete="off"

--- a/apps/backoffice/app/routes/backoffice/files/data.test.ts
+++ b/apps/backoffice/app/routes/backoffice/files/data.test.ts
@@ -55,6 +55,8 @@ beforeEach(() => {
           actor: { type: "system", id: "system" },
           scope: { kind: "org", orgId: "acme-org" },
         },
+
+        staticFileArtifacts: () => ({}),
       }),
       {
         contributors: [...getBuiltInFileContributors(), ...contributors],
@@ -71,9 +73,9 @@ describe("files explorer route data", () => {
       orgId: "acme-org",
     });
 
-    expect(result.tree.map((root) => root.path)).toEqual(["/system", "/tmp"]);
-    assert(result.selectedPath === "/system");
-    assert(result.selectedDetail?.node.path === "/system");
+    expect(result.tree.map((root) => root.path)).toEqual(["/static", "/system", "/tmp"]);
+    assert(result.selectedPath === "/static");
+    assert(result.selectedDetail?.node.path === "/static");
     assert(result.loadError === "Path '/missing' could not be found.");
   });
 

--- a/apps/backoffice/app/routes/backoffice/files/data.ts
+++ b/apps/backoffice/app/routes/backoffice/files/data.ts
@@ -45,7 +45,12 @@ export async function createBackofficeFilesFileSystem({
   const { runtime } = context.get(BackofficeWorkerContext);
   const kernel = new BackofficeKernel({ objects: runtime.objects });
   const execution = await requireBackofficeContext(request, context, { kind: "org", orgId });
-  return createBackofficeFileSystem({ objects: runtime.objects, kernel, execution });
+  return createBackofficeFileSystem({
+    objects: runtime.objects,
+    kernel,
+    execution,
+    config: runtime.config,
+  });
 }
 
 export async function loadFilesExplorerData({

--- a/apps/backoffice/app/routes/backoffice/files/download.test.ts
+++ b/apps/backoffice/app/routes/backoffice/files/download.test.ts
@@ -64,6 +64,8 @@ describe("backoffice files download route", () => {
             actor: { type: "system", id: "system" },
             scope: { kind: "org", orgId: "org_123" },
           },
+
+          staticFileArtifacts: () => ({}),
         }),
         {
           contributors: [...getBuiltInFileContributors(), ...contributors],
@@ -82,14 +84,14 @@ describe("backoffice files download route", () => {
     const response = toResponse(
       await loader(
         createLoaderArgs(
-          "https://example.com/backoffice/files/org_123/download?path=%2Fsystem%2FSYSTEM.md",
+          "https://example.com/backoffice/files/org_123/download?path=%2Fstatic%2FSYSTEM.md",
         ),
       ),
     );
 
     assert(response.status === 302);
     expect(response.headers.get("Location")).toBe(
-      `https://example.com${buildBackofficeLoginPath("/backoffice/files/org_123/download?path=%2Fsystem%2FSYSTEM.md")}`,
+      `https://example.com${buildBackofficeLoginPath("/backoffice/files/org_123/download?path=%2Fstatic%2FSYSTEM.md")}`,
     );
   });
 
@@ -99,7 +101,7 @@ describe("backoffice files download route", () => {
     const response = toResponse(
       await loader(
         createLoaderArgs(
-          "https://example.com/backoffice/files/org_123/download?path=%2Fsystem%2FSYSTEM.md",
+          "https://example.com/backoffice/files/org_123/download?path=%2Fstatic%2FSYSTEM.md",
         ),
       ),
     );
@@ -225,7 +227,7 @@ describe("backoffice files download route", () => {
     await expect(
       loader(
         createLoaderArgs(
-          "https://example.com/backoffice/files/org_123/download?path=%2Fsystem%2Fskills",
+          "https://example.com/backoffice/files/org_123/download?path=%2Fstatic%2Fskills",
         ),
       ),
     ).rejects.toMatchObject({

--- a/apps/backoffice/app/routes/backoffice/pi-terminal-action.ts
+++ b/apps/backoffice/app/routes/backoffice/pi-terminal-action.ts
@@ -174,6 +174,7 @@ const handlePathAutocomplete = async ({
       objects: runtime.objects,
       kernel,
       execution,
+      config: runtime.config,
     });
     return {
       ...autocompleteRequest,
@@ -344,6 +345,7 @@ const handleRunCommand = async ({
       objects: runtime.objects,
       kernel,
       execution,
+      config: runtime.config,
     });
     const { bash } = createInteractiveBashHost({
       fs: fileSystem,

--- a/apps/backoffice/app/routes/backoffice/terminal.server.ts
+++ b/apps/backoffice/app/routes/backoffice/terminal.server.ts
@@ -149,6 +149,7 @@ export const runBackofficeTerminalAction = async ({
         objects: runtime.objects,
         kernel,
         execution,
+        config: runtime.config,
       });
       return {
         ...autocompleteRequest,
@@ -184,6 +185,7 @@ export const runBackofficeTerminalAction = async ({
       objects: runtime.objects,
       kernel,
       execution,
+      config: runtime.config,
     });
     const { bash } = createInteractiveBashHost({
       fs: fileSystem,

--- a/apps/backoffice/app/routes/dev/codemode-bash.ts
+++ b/apps/backoffice/app/routes/dev/codemode-bash.ts
@@ -83,7 +83,12 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const { runtime } = context.get(BackofficeWorkerContext);
   const kernel = new BackofficeKernel({ objects: runtime.objects });
   const execution = await requireBackofficeContext(request, context, { kind: "org", orgId });
-  const fs = await createBackofficeFileSystem({ objects: runtime.objects, kernel, execution });
+  const fs = await createBackofficeFileSystem({
+    objects: runtime.objects,
+    kernel,
+    execution,
+    config: runtime.config,
+  });
   const { bash, commandCallsResult } = createInteractiveBashHost({
     fs,
     context: createRouteBackedRuntimeContext({

--- a/apps/backoffice/app/routes/dev/codemode-system-md.ts
+++ b/apps/backoffice/app/routes/dev/codemode-system-md.ts
@@ -29,7 +29,12 @@ const readOrgSystemGuidance = async ({
 }) => {
   const { runtime } = context.get(BackofficeWorkerContext);
   const kernel = new BackofficeKernel({ objects: runtime.objects });
-  const fs = await createBackofficeFileSystem({ objects: runtime.objects, kernel, execution });
+  const fs = await createBackofficeFileSystem({
+    objects: runtime.objects,
+    kernel,
+    execution,
+    config: runtime.config,
+  });
 
   return await renderCodemodeSystemPrompt({ fileSystem: fs });
 };

--- a/apps/backoffice/app/routes/dev/codemode.ts
+++ b/apps/backoffice/app/routes/dev/codemode.ts
@@ -48,7 +48,12 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const { env, runtime } = context.get(BackofficeWorkerContext);
   const kernel = new BackofficeKernel({ objects: runtime.objects });
 
-  const fs = await createBackofficeFileSystem({ objects: runtime.objects, kernel, execution });
+  const fs = await createBackofficeFileSystem({
+    objects: runtime.objects,
+    kernel,
+    execution,
+    config: runtime.config,
+  });
   const routeRuntimeContext = createRouteBackedRuntimeContext({
     runtime,
     kernel,

--- a/apps/backoffice/scripts/create-dev-account.sh
+++ b/apps/backoffice/scripts/create-dev-account.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 BACKOFFICE_URL="${BACKOFFICE_URL:-http://localhost:5173}"
+MAX_RETRIES=10
 EMAIL="${BACKOFFICE_EMAIL:-${USER}@rejot.dev}"
 PASSWORD="${BACKOFFICE_PASSWORD:-wachtwoord}"
 
@@ -10,19 +11,74 @@ if [[ -z "${USER:-}" && -z "${BACKOFFICE_EMAIL:-}" ]]; then
   exit 1
 fi
 
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--port)
+      if [[ $# -lt 2 ]]; then
+        echo "Usage: $0 [-p|--port PORT]" >&2
+        exit 1
+      fi
+      PORT="$2"
+      if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
+        echo "Port must be numeric: $PORT" >&2
+        exit 1
+      fi
+      BACKOFFICE_URL="$(
+        printf '%s' "$BACKOFFICE_URL" |
+          sed -E "s#^(https?://[^/ :]+)(:[0-9]+)?(.*)$#\1:${PORT}\3#"
+      )"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [-p|--port PORT]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [-p|--port PORT]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 url="${BACKOFFICE_URL%/}/api/auth/sign-up"
 body=$(printf '{"email":"%s","password":"%s"}' "$EMAIL" "$PASSWORD")
 
 response_file=$(mktemp)
-status=$(curl \
-  --silent \
-  --show-error \
-  --output "$response_file" \
-  --write-out "%{http_code}" \
-  --header "Content-Type: application/json" \
-  --request POST \
-  --data "$body" \
-  "$url")
+attempt=1
+status=""
+curl_exit=0
+
+while true; do
+  : > "$response_file"
+  set +e
+  status=$(curl \
+    --silent \
+    --show-error \
+    --output "$response_file" \
+    --write-out "%{http_code}" \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data "$body" \
+    "$url")
+  curl_exit=$?
+  set -e
+
+  if [[ $curl_exit -eq 0 ]]; then
+    break
+  fi
+
+  if [[ $curl_exit -eq 7 && $attempt -lt $MAX_RETRIES ]]; then
+    echo "Backoffice not ready yet (attempt $attempt/$MAX_RETRIES), retrying in 1s..."
+    sleep 1
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  echo "Failed to create dev account: curl error $curl_exit" >&2
+  cat "$response_file" >&2
+  exit 1
+done
 
 case "$status" in
   200|201)

--- a/apps/backoffice/workers/automations.do.ts
+++ b/apps/backoffice/workers/automations.do.ts
@@ -19,7 +19,9 @@ import {
   createBackofficeFileSystem,
   createMasterFileSystem,
   createSystemFilesContext,
+  emptyStaticFileArtifacts,
   staticFileContributor,
+  systemFileContributor,
   type MasterFileSystem,
 } from "@/files";
 import { tmpFileContributor } from "@/files/contributors/tmp";
@@ -73,11 +75,13 @@ export const createDefaultAutomationFileSystem = async ({
   kernel,
   execution,
   automationHookQueue,
+  config,
 }: {
   objects: BackofficeObjectRegistry;
   kernel: BackofficeKernel;
   execution: BackofficeExecutionContext;
   automationHookQueue?: (opts?: DurableHookQueueOptions) => Promise<DurableHookQueueResponse>;
+  config: BackofficeRuntimeServices["config"];
 }): Promise<MasterFileSystem> => {
   if (execution.scope.kind === "org" || execution.scope.kind === "project") {
     return createBackofficeFileSystem({
@@ -85,6 +89,7 @@ export const createDefaultAutomationFileSystem = async ({
       kernel,
       execution,
       ...(automationHookQueue ? { automationHookQueue } : {}),
+      config,
     });
   }
 
@@ -92,8 +97,9 @@ export const createDefaultAutomationFileSystem = async ({
     createSystemFilesContext({
       objects,
       execution,
+      staticFileArtifacts: emptyStaticFileArtifacts,
     }),
-    { contributors: [staticFileContributor, tmpFileContributor] },
+    { contributors: [staticFileContributor, systemFileContributor, tmpFileContributor] },
   );
 };
 
@@ -302,6 +308,7 @@ export class InMemoryAutomationsObject extends RpcTarget implements AutomationsO
       objects: this.#runtimeServices.objects,
       kernel,
       execution,
+      config: this.#runtimeServices.config,
       automationHookQueue: async (opts) =>
         await (
           await automationHookObject.getDurableHookRepository("automation")

--- a/apps/backoffice/workers/automations.test.ts
+++ b/apps/backoffice/workers/automations.test.ts
@@ -4,6 +4,7 @@ import type { BackofficeExecutionContext } from "@/backoffice-runtime/context";
 import { createInMemoryBackofficeRuntime } from "@/backoffice-runtime/in-memory-runtime";
 import { BackofficeKernel } from "@/backoffice-runtime/kernel";
 import type { BackofficeObjectRegistry } from "@/backoffice-runtime/object-registry";
+import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
 import { loadAutomationCatalog } from "@/fragno/automation/catalog";
 import type { AutomationEvent } from "@/fragno/automation/contracts";
 
@@ -27,12 +28,31 @@ vi.mock("cloudflare:workers", () => ({ DurableObject, RpcTarget, WorkerEntrypoin
 import { createDefaultAutomationFileSystem } from "./automations.do";
 
 const objects = {} as BackofficeObjectRegistry;
+const config: BackofficeRuntimeConfig = {
+  bindings: {
+    api: false,
+    auth: false,
+    automations: false,
+    telegram: false,
+    otp: false,
+    pi: false,
+    resend: false,
+    reson8: false,
+    mcp: false,
+    upload: false,
+    github: false,
+    cloudflareWorkers: false,
+    githubWebhookRouter: false,
+    sandbox: false,
+  },
+};
 
 const createFileSystem = (execution: BackofficeExecutionContext) =>
   createDefaultAutomationFileSystem({
     objects,
     kernel: new BackofficeKernel({ objects }),
     execution,
+    config,
   });
 
 const scopedEvent = (orgId: string): AutomationEvent => ({
@@ -60,7 +80,7 @@ const scopedEvent = (orgId: string): AutomationEvent => ({
 });
 
 describe("createDefaultAutomationFileSystem", () => {
-  test("loads the full catalog filesystem for system automation scope", async () => {
+  test("loads static and system automation files for system automation scope", async () => {
     const fs = await createFileSystem({
       actor: { type: "system", id: "system" },
       scope: { kind: "system" },
@@ -70,14 +90,13 @@ describe("createDefaultAutomationFileSystem", () => {
 
     expect(catalog.scripts.map((script) => script.absolutePath)).toEqual(
       expect.arrayContaining([
-        "/system/automations/codemode-types-refresh.workflow.js",
-        "/system/automations/project-files-configure.workflow.js",
+        "/static/automations/project-files-configure.workflow.js",
         "/system/automations/workspace-file-initialization.workflow.js",
       ]),
     );
   });
 
-  test("loads the same system automations for user automation scope", async () => {
+  test("loads static automations for user automation scope", async () => {
     const fs = await createFileSystem({
       actor: { type: "automation", id: "automation:event-1" },
       scope: { kind: "user", userId: "user-1" },
@@ -86,11 +105,10 @@ describe("createDefaultAutomationFileSystem", () => {
     const catalog = await loadAutomationCatalog(fs);
 
     expect(catalog.scripts.map((script) => script.absolutePath)).toEqual(
-      expect.arrayContaining([
-        "/system/automations/codemode-types-refresh.workflow.js",
-        "/system/automations/project-files-configure.workflow.js",
-        "/system/automations/workspace-file-initialization.workflow.js",
-      ]),
+      expect.arrayContaining(["/static/automations/project-files-configure.workflow.js"]),
+    );
+    expect(catalog.scripts.map((script) => script.absolutePath)).not.toContain(
+      "/system/automations/workspace-file-initialization.workflow.js",
     );
   });
 });

--- a/apps/backoffice/workers/pi.do.ts
+++ b/apps/backoffice/workers/pi.do.ts
@@ -286,6 +286,7 @@ export class InMemoryPiObject implements PiObject {
       objects: this.#runtimeServices.objects,
       kernel,
       execution,
+      runtimeConfig: this.#runtimeServices.config,
     };
 
     return createPiRuntime({

--- a/packages/auth/src/auth-fragment-configuration.test.ts
+++ b/packages/auth/src/auth-fragment-configuration.test.ts
@@ -205,6 +205,95 @@ describe("auth-fragment auto-create organizations", async () => {
   });
 });
 
+describe("auth-fragment default auto-create organization slugs", async () => {
+  const { fragments, test } = await buildDatabaseFragmentsTest()
+    .withTestAdapter({ type: "kysely-sqlite" })
+    .withFragment(
+      "auth",
+      instantiate(authFragmentDefinition)
+        .withConfig({
+          organizations: {
+            autoCreateOrganization: {},
+          },
+        })
+        .withRoutes([userActionsRoutesFactory, sessionRoutesFactory]),
+    )
+    .build();
+
+  const fragment = fragments.auth;
+
+  afterAll(async () => {
+    await test.cleanup();
+  });
+
+  it("scopes generated slugs by user so matching email local parts can sign up", async () => {
+    const firstSignUpResponse = await fragment.callRoute("POST", "/sign-up", {
+      body: { email: "wilco@rejot.dev", password: "password" },
+    });
+    const secondSignUpResponse = await fragment.callRoute("POST", "/sign-up", {
+      body: { email: "wilco@is3a.nl", password: "password" },
+    });
+
+    assert(firstSignUpResponse.type === "json");
+    assert(secondSignUpResponse.type === "json");
+
+    const firstMeResponse = await fragment.callRoute("GET", "/me", {
+      headers: authHeaders(firstSignUpResponse.data.auth.token as string),
+    });
+    const secondMeResponse = await fragment.callRoute("GET", "/me", {
+      headers: authHeaders(secondSignUpResponse.data.auth.token as string),
+    });
+
+    assert(firstMeResponse.type === "json");
+    assert(secondMeResponse.type === "json");
+
+    const firstSlug = firstMeResponse.data.organizations[0]?.organization.slug;
+    const secondSlug = secondMeResponse.data.organizations[0]?.organization.slug;
+
+    expect(firstSlug).toMatch(/^wilcos-organization-[a-z0-9]{8}$/);
+    expect(secondSlug).toMatch(/^wilcos-organization-[a-z0-9]{8}$/);
+    expect(secondSlug).not.toBe(firstSlug);
+  });
+});
+
+describe("auth-fragment auto-create organization slug collisions", async () => {
+  const { fragments, test } = await buildDatabaseFragmentsTest()
+    .withTestAdapter({ type: "kysely-sqlite" })
+    .withFragment(
+      "auth",
+      instantiate(authFragmentDefinition)
+        .withConfig({
+          organizations: {
+            autoCreateOrganization: {
+              slug: () => "shared-workspace",
+            },
+          },
+        })
+        .withRoutes([userActionsRoutesFactory, sessionRoutesFactory]),
+    )
+    .build();
+
+  const fragment = fragments.auth;
+
+  afterAll(async () => {
+    await test.cleanup();
+  });
+
+  it("returns a typed error instead of surfacing a database constraint error", async () => {
+    const firstSignUpResponse = await fragment.callRoute("POST", "/sign-up", {
+      body: { email: "shared-one@test.com", password: "password" },
+    });
+    const secondSignUpResponse = await fragment.callRoute("POST", "/sign-up", {
+      body: { email: "shared-two@test.com", password: "password" },
+    });
+
+    assert(firstSignUpResponse.type === "json");
+    assert(secondSignUpResponse.type === "error");
+    assert(secondSignUpResponse.status === 400);
+    assert(secondSignUpResponse.error.code === "organization_slug_taken");
+  });
+});
+
 describe("auth-fragment beforeCreateUser hook", async () => {
   const blockedDomain = "blocked.test";
   const hookCalls: string[] = [];

--- a/packages/auth/src/organization/utils.ts
+++ b/packages/auth/src/organization/utils.ts
@@ -2,6 +2,9 @@ import type { AutoCreateOrganizationConfig, OrganizationRoleName } from "./types
 
 export const ORGANIZATION_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{2,62}$/;
 
+const ORGANIZATION_SLUG_MAX_LENGTH = 63;
+const AUTO_ORGANIZATION_USER_ID_SUFFIX_LENGTH = 8;
+
 export const DEFAULT_CREATOR_ROLES = ["owner"] as const;
 export const DEFAULT_MEMBER_ROLES = ["member"] as const;
 
@@ -41,6 +44,20 @@ export function buildDefaultOrganizationName(email: string): string {
   return `${safeLocalPart}'s Organization`;
 }
 
+function buildUserScopedOrganizationSlug(value: string, userId: string): string | null {
+  const suffix = slugifyOrganizationName(userId).slice(0, AUTO_ORGANIZATION_USER_ID_SUFFIX_LENGTH);
+  if (!suffix) {
+    return null;
+  }
+
+  const normalizedBase = slugifyOrganizationName(value) || "org";
+  const maxBaseLength = ORGANIZATION_SLUG_MAX_LENGTH - suffix.length - 1;
+  const base = normalizedBase.slice(0, maxBaseLength).replace(/-+$/g, "") || "org";
+  const slug = `${base}-${suffix}`;
+
+  return ORGANIZATION_SLUG_REGEX.test(slug) ? slug : normalizeOrganizationSlug(`org-${suffix}`);
+}
+
 export function buildAutoOrganizationInput(
   config: AutoCreateOrganizationConfig | undefined,
   ctx: { userId: string; email: string },
@@ -51,10 +68,12 @@ export function buildAutoOrganizationInput(
   metadata: Record<string, unknown> | null | undefined;
 } {
   const name = config?.name?.(ctx) ?? buildDefaultOrganizationName(ctx.email);
-  const rawSlug = config?.slug?.(ctx) ?? name;
+  const rawSlug = config?.slug?.(ctx);
   return {
     name,
-    slug: normalizeOrganizationSlug(rawSlug),
+    slug: rawSlug
+      ? (normalizeOrganizationSlug(rawSlug) ?? buildUserScopedOrganizationSlug(name, ctx.userId))
+      : buildUserScopedOrganizationSlug(name, ctx.userId),
     logoUrl: config?.logoUrl?.(ctx),
     metadata: config?.metadata?.(ctx),
   };

--- a/packages/auth/src/user/auto-organization.ts
+++ b/packages/auth/src/user/auto-organization.ts
@@ -9,7 +9,6 @@ import type {
 import {
   DEFAULT_CREATOR_ROLES,
   buildAutoOrganizationInput,
-  normalizeOrganizationSlug,
   normalizeRoleNames,
   toExternalId,
 } from "../organization/utils";
@@ -25,30 +24,27 @@ export type AutoCreateOrganizationResult = {
   member: OrganizationMember<string>;
 };
 
-type AuthUow = TypedUnitOfWork<typeof authSchema, unknown[], unknown, AuthHooksMap>;
-
-const resolveAutoOrganizationSlug = (name: string, userId: string): string => {
-  const normalized = normalizeOrganizationSlug(name);
-  if (normalized) {
-    return normalized;
-  }
-
-  const fallback = normalizeOrganizationSlug(`org-${userId.slice(0, 8)}`);
-  if (!fallback) {
-    throw new Error("Invalid auto organization slug");
-  }
-  return fallback;
+export type ResolvedAutoOrganizationInput = {
+  name: string;
+  slug: string;
+  logoUrl: string | null | undefined;
+  metadata: Record<string, unknown> | null | undefined;
 };
 
-export const createAutoOrganization = (
-  uow: AuthUow,
-  input: {
-    userId: string;
-    email: string;
-    now: Date;
-    options?: AutoCreateOrganizationOptions;
-  },
-): AutoCreateOrganizationResult | null => {
+type AuthUow = TypedUnitOfWork<typeof authSchema, unknown[], unknown, AuthHooksMap>;
+
+const resolveAutoOrganizationSlug = (slug: string | null): string => {
+  if (!slug) {
+    throw new Error("Invalid auto organization slug");
+  }
+  return slug;
+};
+
+export const resolveAutoOrganizationInput = (input: {
+  userId: string;
+  email: string;
+  options?: AutoCreateOrganizationOptions;
+}): ResolvedAutoOrganizationInput | null => {
   if (!input.options?.autoCreateOrganization) {
     return null;
   }
@@ -61,8 +57,34 @@ export const createAutoOrganization = (
     },
   );
 
-  const normalizedSlug = slug ?? resolveAutoOrganizationSlug(name, input.userId);
-  const creatorRoles = normalizeRoleNames(input.options.creatorRoles, DEFAULT_CREATOR_ROLES);
+  return {
+    name,
+    slug: resolveAutoOrganizationSlug(slug),
+    logoUrl,
+    metadata,
+  };
+};
+
+export const createAutoOrganization = (
+  uow: AuthUow,
+  input: {
+    userId: string;
+    email: string;
+    now: Date;
+    options?: AutoCreateOrganizationOptions;
+    autoOrganizationInput?: ResolvedAutoOrganizationInput | null;
+  },
+): AutoCreateOrganizationResult | null => {
+  const autoOrganizationInput =
+    "autoOrganizationInput" in input
+      ? input.autoOrganizationInput
+      : resolveAutoOrganizationInput(input);
+  if (!autoOrganizationInput) {
+    return null;
+  }
+
+  const { name, slug: normalizedSlug, logoUrl, metadata } = autoOrganizationInput;
+  const creatorRoles = normalizeRoleNames(input.options?.creatorRoles, DEFAULT_CREATOR_ROLES);
 
   const organizationId = uow.create("organization", {
     name,

--- a/packages/auth/src/user/user-actions.ts
+++ b/packages/auth/src/user/user-actions.ts
@@ -1,7 +1,8 @@
+import { generateId } from "@fragno-dev/db/schema";
 import { z } from "zod";
 
 import { defineRoutes } from "@fragno-dev/core";
-import type { DatabaseServiceContext } from "@fragno-dev/db";
+import { isUniqueConstraintError, type DatabaseServiceContext } from "@fragno-dev/db";
 
 import type { authFragmentDefinition } from "..";
 import { buildIssuedAuthResponse, issuedAuthSchema } from "../auth/response-auth";
@@ -14,7 +15,11 @@ import type { AuthActor } from "../auth/types";
 import type { AuthHooksMap, BeforeCreateUserHook } from "../hooks";
 import { authSchema } from "../schema";
 import { resolveCredentialSeedFromMembers, credentialSeedSchema } from "../session/session-seed";
-import { createAutoOrganization, type AutoCreateOrganizationOptions } from "./auto-organization";
+import {
+  createAutoOrganization,
+  resolveAutoOrganizationInput,
+  type AutoCreateOrganizationOptions,
+} from "./auto-organization";
 import { hashPassword, verifyPassword } from "./password";
 import { mapUserSummary } from "./summary";
 
@@ -218,21 +223,39 @@ export function createUserServices(
       const expiresAt = new Date();
       expiresAt.setDate(expiresAt.getDate() + 30); // 30 days from now
 
+      const userId = generateId(authSchema, "user");
+      const effectiveAutoCreateOptions = autoCreateOptions ?? options;
+      const autoOrganizationInput = resolveAutoOrganizationInput({
+        userId: userId.valueOf(),
+        email,
+        options: effectiveAutoCreateOptions,
+      });
+      const autoOrganizationSlug = autoOrganizationInput?.slug ?? "";
+
       return this.serviceTx(authSchema)
         .retrieve((uow) =>
-          uow.findFirst("user", (b) =>
-            b.whereIndex("idx_user_email", (eb) => eb("email", "=", email)),
-          ),
+          uow
+            .findFirst("user", (b) =>
+              b.whereIndex("idx_user_email", (eb) => eb("email", "=", email)),
+            )
+            .findFirst("organization", (b) =>
+              b.whereIndex("idx_organization_slug", (eb) => eb("slug", "=", autoOrganizationSlug)),
+            ),
         )
-        .mutate(({ uow, retrieveResult: [existingUser] }) => {
+        .mutate(({ uow, retrieveResult: [existingUser, existingAutoOrganization] }) => {
           if (existingUser) {
             return { ok: false as const, code: "email_already_exists" as const };
+          }
+
+          if (autoOrganizationInput && existingAutoOrganization) {
+            return { ok: false as const, code: "organization_slug_taken" as const };
           }
 
           const now = new Date();
           const role = resolveCreateUserRole(email, "user");
 
-          const userId = uow.create("user", {
+          uow.create("user", {
+            id: userId,
             email,
             passwordHash,
             role,
@@ -242,7 +265,8 @@ export function createUserServices(
             userId: userId.valueOf(),
             email,
             now,
-            options: autoCreateOptions ?? options,
+            options: effectiveAutoCreateOptions,
+            autoOrganizationInput,
           });
 
           const credentialId = uow.create("session", {
@@ -556,7 +580,12 @@ export const userActionsRoutesFactory = defineRoutes<typeof authFragmentDefiniti
           email: z.string(),
           role: z.enum(["user", "admin"]),
         }),
-        errorCodes: ["email_already_exists", "invalid_input", "email_password_disabled"],
+        errorCodes: [
+          "email_already_exists",
+          "invalid_input",
+          "email_password_disabled",
+          "organization_slug_taken",
+        ],
         handler: async function ({ input }, { error }) {
           if (!emailAndPasswordEnabled) {
             return error(
@@ -569,11 +598,33 @@ export const userActionsRoutesFactory = defineRoutes<typeof authFragmentDefiniti
 
           const passwordHash = await hashPassword(password);
 
-          const [result] = await this.handlerTx()
-            .withServiceCalls(() => [services.signUp(email, passwordHash)])
-            .execute();
+          const signUpTx = this.handlerTx().withServiceCalls(() => [
+            services.signUp(email, passwordHash),
+          ]);
+
+          let serviceResults: Awaited<ReturnType<typeof signUpTx.execute>>;
+          try {
+            serviceResults = await signUpTx.execute();
+          } catch (cause) {
+            if (isUniqueConstraintError(cause) && cause.constraint === "idx_organization_slug") {
+              return error(
+                { message: "Organization slug taken", code: "organization_slug_taken" },
+                400,
+              );
+            }
+            throw cause;
+          }
+
+          const [result] = serviceResults;
 
           if (!result.ok) {
+            if (result.code === "organization_slug_taken") {
+              return error(
+                { message: "Organization slug taken", code: "organization_slug_taken" },
+                400,
+              );
+            }
+
             return error({ message: "Email already exists", code: "email_already_exists" }, 400);
           }
 

--- a/packages/fragment-upload/src/client/clients.ts
+++ b/packages/fragment-upload/src/client/clients.ts
@@ -19,6 +19,8 @@ export function createUploadFragmentClients(config: FragnoPublicClientConfig = {
     useFile: builder.createHook("/files/by-key"),
     useCreateUpload: builder.createMutator("POST", "/uploads"),
     useUploadStatus: builder.createHook("/uploads/:uploadId"),
+    useSearchFiles: builder.createMutator("POST", "/files/search"),
+    useHydrateSearchMatches: builder.createMutator("POST", "/files/search/hydrate"),
     useCompleteUpload: builder.createMutator(
       "POST",
       "/uploads/:uploadId/complete",

--- a/packages/fragment-upload/src/client/helpers.test.ts
+++ b/packages/fragment-upload/src/client/helpers.test.ts
@@ -691,6 +691,86 @@ describe("upload client helpers", () => {
     ).rejects.toThrow(/Download provider is required/);
   });
 
+  it("searchFiles posts glob, query, provider, and options", async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    const helpers = createUploadHelpers({
+      buildUrl: (path) => `https://local${path}`,
+      fetcher: (async (input, init) => {
+        const url = typeof input === "string" ? input : input.toString();
+        calls.push({ url, body: JSON.parse(init?.body as string) });
+
+        if (url.endsWith("/files/search/hydrate")) {
+          return jsonResponse({
+            matches: [
+              {
+                path: "workspace/src/workflows.ts",
+                line: 1,
+                column: 14,
+                startOffset: 13,
+                endOffset: 27,
+                text: "createWorkflow",
+                contextBefore: [],
+                contextAfter: [],
+              },
+            ],
+            scannedFiles: 1,
+          });
+        }
+
+        return jsonResponse({
+          provider: TEST_PROVIDER,
+          candidates: [{ key: "workspace/src/workflows.ts", positions: [13], count: 1 }],
+          candidateFiles: 1,
+          hasMoreCandidates: false,
+        });
+      }) as typeof fetch,
+    });
+
+    const result = await helpers.searchFiles("/workspace/**/*.ts", "createWorkflow", {
+      provider: TEST_PROVIDER,
+      caseSensitive: false,
+      contextBefore: 2,
+      contextAfter: 2,
+      maxMatches: 50,
+      maxCandidateFiles: 100,
+    });
+
+    expect(calls).toEqual([
+      {
+        url: "https://local/files/search",
+        body: {
+          provider: TEST_PROVIDER,
+          glob: "/workspace/**/*.ts",
+          query: "createWorkflow",
+          maxCandidateFiles: 100,
+          options: {
+            caseSensitive: false,
+            contextBefore: 2,
+            contextAfter: 2,
+            maxMatches: 50,
+          },
+        },
+      },
+      {
+        url: "https://local/files/search/hydrate",
+        body: {
+          provider: TEST_PROVIDER,
+          glob: "/workspace/**/*.ts",
+          query: "createWorkflow",
+          maxCandidateFiles: 100,
+          options: {
+            caseSensitive: false,
+            contextBefore: 2,
+            contextAfter: 2,
+            maxMatches: 50,
+          },
+        },
+      },
+    ]);
+    assert(result.candidates[0]?.key === "workspace/src/workflows.ts");
+    assert(result.matches[0]?.path === "workspace/src/workflows.ts");
+  });
+
   it("requires callers to specify provider and file key when creating uploads", async () => {
     const helpers = createUploadHelpers({
       buildUrl: (path) => `https://local${path}`,

--- a/packages/fragment-upload/src/client/helpers.ts
+++ b/packages/fragment-upload/src/client/helpers.ts
@@ -1,4 +1,5 @@
 import type { UploadChecksum } from "../storage/types";
+import type { StateSearchOptions, StateTextMatch } from "../text-index";
 import type { FileMetadata, FileVisibility, UploadStrategy } from "../types";
 
 export type UploadProgress = {
@@ -27,6 +28,33 @@ export type DownloadFileOptions = {
   provider: string;
   method: DownloadMethod;
 };
+
+export type SearchFilesOptions = StateSearchOptions & {
+  provider: string;
+  maxCandidateFiles?: number;
+  cursor?: string;
+};
+
+export type SearchFileCandidate = {
+  key: string;
+  positions: number[];
+  count: number;
+};
+
+export type SearchFileCandidatesResult = {
+  provider: string;
+  candidates: SearchFileCandidate[];
+  candidateFiles: number;
+  cursor?: string;
+  hasMoreCandidates: boolean;
+};
+
+export type HydrateSearchMatchesResult = {
+  matches: StateTextMatch[];
+  scannedFiles: number;
+};
+
+export type SearchFilesResult = SearchFileCandidatesResult & HydrateSearchMatchesResult;
 
 export type UploadCreateResponse = {
   uploadId: string;
@@ -58,6 +86,21 @@ export type UploadHelpers = {
     options: CreateUploadAndTransferOptions,
   ) => Promise<{ upload: UploadCreateResponse; file: FileMetadata }>;
   downloadFile: (fileKey: string, options: DownloadFileOptions) => Promise<Response>;
+  searchFileCandidates: (
+    glob: string,
+    query: string,
+    options: SearchFilesOptions,
+  ) => Promise<SearchFileCandidatesResult>;
+  hydrateSearchMatches: (
+    glob: string,
+    query: string,
+    options: SearchFilesOptions,
+  ) => Promise<HydrateSearchMatchesResult>;
+  searchFiles: (
+    glob: string,
+    query: string,
+    options: SearchFilesOptions,
+  ) => Promise<SearchFilesResult>;
 };
 
 const DEFAULT_CONTENT_TYPE = "application/octet-stream";
@@ -584,6 +627,66 @@ export const createUploadHelpers = (input: {
     return { upload, file: proxyMetadata };
   };
 
+  const buildSearchPayload = (glob: string, query: string, options: SearchFilesOptions) => {
+    if (!hasText(glob)) {
+      throw new Error("Glob is required");
+    }
+
+    if (!hasText(query)) {
+      throw new Error("Search query is required");
+    }
+
+    if (!options || !hasText(options.provider)) {
+      throw new Error("Search provider is required");
+    }
+
+    const { provider, maxCandidateFiles, cursor, ...searchOptions } = options;
+    return {
+      provider,
+      glob,
+      query,
+      maxCandidateFiles,
+      cursor,
+      options: searchOptions,
+    };
+  };
+
+  const searchFileCandidates: UploadHelpers["searchFileCandidates"] = async (
+    glob,
+    query,
+    options,
+  ) => {
+    return await fetchJson<SearchFileCandidatesResult>("/files/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildSearchPayload(glob, query, options)),
+    });
+  };
+
+  const hydrateSearchMatches: UploadHelpers["hydrateSearchMatches"] = async (
+    glob,
+    query,
+    options,
+  ) => {
+    return await fetchJson<HydrateSearchMatchesResult>("/files/search/hydrate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildSearchPayload(glob, query, options)),
+    });
+  };
+
+  const searchFiles: UploadHelpers["searchFiles"] = async (glob, query, options) => {
+    const [candidates, hydrated] = await Promise.all([
+      searchFileCandidates(glob, query, options),
+      hydrateSearchMatches(glob, query, options),
+    ]);
+
+    return {
+      ...candidates,
+      ...hydrated,
+    };
+  };
+
   const downloadFile: UploadHelpers["downloadFile"] = async (fileKey, options) => {
     if (!hasText(fileKey)) {
       throw new Error("File key is required");
@@ -708,5 +811,8 @@ export const createUploadHelpers = (input: {
   return {
     createUploadAndTransfer,
     downloadFile,
+    hydrateSearchMatches,
+    searchFileCandidates,
+    searchFiles,
   };
 };

--- a/packages/fragment-upload/src/config.ts
+++ b/packages/fragment-upload/src/config.ts
@@ -4,6 +4,7 @@ import type {
   StorageAdapterLimits,
   StorageAdapterRecommendations,
 } from "./storage/types";
+import type { TextIndexOptions } from "./text-index";
 
 export type FileHookPayload = {
   provider: string;
@@ -31,6 +32,7 @@ export interface UploadFragmentConfig {
   signedUrlExpiresInSeconds?: number;
   maxSingleUploadBytes?: number;
   maxMultipartUploadBytes?: number;
+  textIndex?: TextIndexOptions;
 
   onFileReady?: (payload: FileHookPayload, idempotencyKey: string) => Promise<void>;
   onUploadFailed?: (payload: FileHookPayload, idempotencyKey: string) => Promise<void>;

--- a/packages/fragment-upload/src/definition.ts
+++ b/packages/fragment-upload/src/definition.ts
@@ -1,10 +1,11 @@
 import { defineFragment } from "@fragno-dev/core";
 import { withDatabase } from "@fragno-dev/db";
 
-import type { UploadFragmentConfig } from "./config";
+import type { FileHookPayload, UploadFragmentConfig, UploadTimeoutPayload } from "./config";
 import { resolveUploadFragmentConfig } from "./config";
 import { uploadSchema } from "./schema";
 import { createFileServices, createUploadServices } from "./services";
+import { buildTextIndex, shouldIndexContentType } from "./text-index";
 import type { UploadStatus } from "./types";
 
 const buildMissingDeletedFileObjectKeyError = (input: { provider: string; fileKey: string }) =>
@@ -22,13 +23,152 @@ export const uploadFragmentDefinition = defineFragment<UploadFragmentConfig>("up
     const resolvedConfig = resolveUploadFragmentConfig(config);
 
     return {
-      onFileReady: defineHook(async function (payload) {
+      onFileReady: defineHook(async function (payload: FileHookPayload) {
         await config.onFileReady?.(payload, this.idempotencyKey);
       }),
-      onUploadFailed: defineHook(async function (payload) {
+      onFileTextIndexRequested: defineHook(async function (payload: FileHookPayload) {
+        if (!resolvedConfig.textIndex?.enabled) {
+          return;
+        }
+
+        const objectKey =
+          typeof payload.objectKey === "string" && payload.objectKey.length > 0
+            ? payload.objectKey
+            : null;
+
+        if (!objectKey) {
+          return;
+        }
+
+        if (!shouldIndexContentType(payload.contentType)) {
+          await this.handlerTx()
+            .retrieve(({ forSchema }) => {
+              const uow = forSchema(uploadSchema);
+              return uow
+                .findFirst("file", (b) =>
+                  b.whereIndex("idx_file_provider_key", (eb) =>
+                    eb.and(eb("provider", "=", payload.provider), eb("key", "=", payload.fileKey)),
+                  ),
+                )
+                .findFirst("file_text_document", (b) =>
+                  b
+                    .whereIndex("idx_file_text_document_provider_key", (eb) =>
+                      eb.and(
+                        eb("provider", "=", payload.provider),
+                        eb("key", "=", payload.fileKey),
+                      ),
+                    )
+                    .joinMany("terms", "file_text_term", (term) =>
+                      term.onIndex("idx_file_text_term_document", (eb) =>
+                        eb("documentId", "=", eb.parent("id")),
+                      ),
+                    ),
+                );
+            })
+            .mutate(({ forSchema, retrieveResult: [file, document] }) => {
+              if (!file || file.status !== "ready" || file.objectKey !== objectKey || !document) {
+                return;
+              }
+
+              const uow = forSchema(uploadSchema);
+              for (const term of document.terms) {
+                uow.delete("file_text_term", term.id);
+              }
+              uow.delete("file_text_document", document.id);
+            })
+            .execute();
+          return;
+        }
+
+        const response = await resolvedConfig.storage.getDownloadStream?.({
+          storageKey: objectKey,
+        });
+        if (!response?.ok) {
+          return;
+        }
+
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        const index = buildTextIndex(bytes, resolvedConfig.textIndex);
+
+        await this.handlerTx()
+          .retrieve(({ forSchema }) => {
+            const uow = forSchema(uploadSchema);
+            return uow
+              .findFirst("file", (b) =>
+                b.whereIndex("idx_file_provider_key", (eb) =>
+                  eb.and(eb("provider", "=", payload.provider), eb("key", "=", payload.fileKey)),
+                ),
+              )
+              .findFirst("file_text_document", (b) =>
+                b
+                  .whereIndex("idx_file_text_document_provider_key", (eb) =>
+                    eb.and(eb("provider", "=", payload.provider), eb("key", "=", payload.fileKey)),
+                  )
+                  .joinMany("terms", "file_text_term", (term) =>
+                    term.onIndex("idx_file_text_term_document", (eb) =>
+                      eb("documentId", "=", eb.parent("id")),
+                    ),
+                  ),
+              );
+          })
+          .mutate(({ forSchema, retrieveResult: [file, document] }) => {
+            if (!file || file.status !== "ready" || file.objectKey !== objectKey) {
+              return;
+            }
+
+            if (document?.contentHash === index.contentHash) {
+              return;
+            }
+
+            const uow = forSchema(uploadSchema);
+            const now = new Date();
+            const documentId = document
+              ? document.id
+              : uow.create("file_text_document", {
+                  fileId: file.id,
+                  provider: file.provider,
+                  key: file.key,
+                  objectKey,
+                  contentHash: index.contentHash,
+                  byteLength: BigInt(index.byteLength),
+                  indexedAt: now,
+                  updatedAt: now,
+                });
+
+            if (document) {
+              uow.update("file_text_document", document.id, (b) =>
+                b.set({
+                  fileId: file.id,
+                  objectKey,
+                  contentHash: index.contentHash,
+                  byteLength: BigInt(index.byteLength),
+                  indexedAt: now,
+                  updatedAt: now,
+                }),
+              );
+
+              for (const term of document.terms) {
+                uow.delete("file_text_term", term.id);
+              }
+            }
+
+            for (const term of index.terms) {
+              uow.create("file_text_term", {
+                documentId,
+                provider: file.provider,
+                key: file.key,
+                term: term.term,
+                positions: term.positions,
+                count: term.count,
+              });
+            }
+          })
+          .execute();
+      }),
+      onUploadFailed: defineHook(async function (payload: FileHookPayload) {
         await config.onUploadFailed?.(payload, this.idempotencyKey);
       }),
-      cleanupStorageObject: defineHook(async function (payload) {
+      cleanupStorageObject: defineHook(async function (payload: FileHookPayload) {
         const objectKey =
           typeof payload.objectKey === "string" && payload.objectKey.length > 0
             ? payload.objectKey
@@ -45,43 +185,84 @@ export const uploadFragmentDefinition = defineFragment<UploadFragmentConfig>("up
 
         await resolvedConfig.storage.deleteObject({ storageKey: objectKey });
       }),
-      onFileDeleted: defineHook(async function (payload) {
+      onFileDeleted: defineHook(async function (payload: FileHookPayload) {
         const payloadObjectKey =
           typeof payload.objectKey === "string" && payload.objectKey.length > 0
             ? payload.objectKey
             : undefined;
-        const persistedObjectKey =
-          payloadObjectKey ??
-          (await this.handlerTx()
-            .retrieve(({ forSchema }) =>
-              forSchema(uploadSchema).findFirst("file", (b) =>
-                b.whereIndex("idx_file_provider_key", (eb) =>
-                  eb.and(eb("provider", "=", payload.provider), eb("key", "=", payload.fileKey)),
-                ),
-              ),
-            )
-            .transformRetrieve(([file]) => {
-              if (
-                file?.status === "deleted" &&
-                typeof file.objectKey === "string" &&
-                file.objectKey.length > 0
-              ) {
-                return file.objectKey;
-              }
-              return null;
-            })
-            .execute());
+        const resolvePersistedObjectKey = (
+          file: { status: string; objectKey?: string | null } | null | undefined,
+        ) => {
+          if (payloadObjectKey) {
+            return payloadObjectKey;
+          }
 
-        if (!persistedObjectKey) {
-          throw new Error(
+          if (
+            file?.status === "deleted" &&
+            typeof file.objectKey === "string" &&
+            file.objectKey.length > 0
+          ) {
+            return file.objectKey;
+          }
+
+          return null;
+        };
+
+        const missingPersistedObjectKeyError = () =>
+          new Error(
             buildMissingDeletedFileObjectKeyError({
               provider: payload.provider,
               fileKey: payload.fileKey,
             }),
           );
-        }
 
-        await resolvedConfig.storage.deleteObject({ storageKey: persistedObjectKey });
+        const { persistedObjectKey } = await this.handlerTx()
+          .retrieve(({ forSchema }) => {
+            const uow = forSchema(uploadSchema);
+            return uow
+              .findFirst("file", (b) =>
+                b.whereIndex("idx_file_provider_key", (eb) =>
+                  eb.and(eb("provider", "=", payload.provider), eb("key", "=", payload.fileKey)),
+                ),
+              )
+              .findFirst("file_text_document", (b) =>
+                b
+                  .whereIndex("idx_file_text_document_provider_key", (eb) =>
+                    eb.and(eb("provider", "=", payload.provider), eb("key", "=", payload.fileKey)),
+                  )
+                  .joinMany("terms", "file_text_term", (term) =>
+                    term.onIndex("idx_file_text_term_document", (eb) =>
+                      eb("documentId", "=", eb.parent("id")),
+                    ),
+                  ),
+              );
+          })
+          .afterRetrieve(async (_uow, [file]) => {
+            const persistedObjectKey = resolvePersistedObjectKey(file);
+            if (!persistedObjectKey) {
+              throw missingPersistedObjectKeyError();
+            }
+
+            await resolvedConfig.storage.deleteObject({ storageKey: persistedObjectKey });
+          })
+          .mutate(({ forSchema, retrieveResult: [file, document] }) => {
+            const persistedObjectKey = resolvePersistedObjectKey(file);
+            if (!persistedObjectKey) {
+              throw missingPersistedObjectKeyError();
+            }
+
+            if (document?.objectKey === persistedObjectKey) {
+              const uow = forSchema(uploadSchema);
+              for (const term of document.terms) {
+                uow.delete("file_text_term", term.id);
+              }
+              uow.delete("file_text_document", document.id);
+            }
+
+            return { persistedObjectKey };
+          })
+          .execute();
+
         await config.onFileDeleted?.(
           {
             ...payload,
@@ -90,7 +271,7 @@ export const uploadFragmentDefinition = defineFragment<UploadFragmentConfig>("up
           this.idempotencyKey,
         );
       }),
-      onUploadTimeout: defineHook(async function (payload) {
+      onUploadTimeout: defineHook(async function (payload: UploadTimeoutPayload) {
         const now = new Date();
 
         if (!payload.uploadId) {

--- a/packages/fragment-upload/src/index.ts
+++ b/packages/fragment-upload/src/index.ts
@@ -14,6 +14,13 @@ export type {
 } from "./config";
 export { resolveUploadFragmentConfig } from "./config";
 export { uploadSchema } from "./schema";
+export type {
+  BuiltTextIndex,
+  StateSearchOptions,
+  StateTextMatch,
+  TextIndexOptions,
+  TextIndexTerm,
+} from "./text-index";
 export type { FileKey, FileKeyValidationResult, ValidateFileKeyOptions } from "./file-key";
 export { assertFileKey, splitFileKey, validateFileKey } from "./file-key";
 export type {
@@ -43,6 +50,11 @@ export type {
   CreateUploadAndTransferOptions,
   DownloadFileOptions,
   DownloadMethod,
+  HydrateSearchMatchesResult,
+  SearchFileCandidate,
+  SearchFileCandidatesResult,
+  SearchFilesOptions,
+  SearchFilesResult,
   UploadHelpers,
   UploadProgress,
 } from "./client/helpers";

--- a/packages/fragment-upload/src/routes/files.ts
+++ b/packages/fragment-upload/src/routes/files.ts
@@ -5,8 +5,15 @@ import type { FragnoRouteConfig } from "@fragno-dev/core";
 
 import { resolveUploadFragmentConfig } from "../config";
 import { uploadFragmentDefinition } from "../definition";
+import { uploadSchema } from "../schema";
 import { resolveFileKeyInput } from "../services/helpers";
 import { buildStorageObjectVersionSegment } from "../storage/object-key";
+import {
+  extractTextIndexTerms,
+  getStaticGlobPrefix,
+  globToRegExp,
+  searchTextContent,
+} from "../text-index";
 import {
   checksumSchema,
   fileMetadataSchema,
@@ -47,6 +54,43 @@ const updateFileSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 
+const stateSearchOptionsSchema = z.object({
+  caseSensitive: z.boolean().optional(),
+  regex: z.boolean().optional(),
+  wholeWord: z.boolean().optional(),
+  contextBefore: z.number().int().min(0).max(20).optional(),
+  contextAfter: z.number().int().min(0).max(20).optional(),
+  maxMatches: z.number().int().min(1).max(500).optional(),
+});
+
+const searchFilesSchema = z.object({
+  provider: providerNamespaceSchema,
+  glob: z.string().min(1).max(512),
+  query: z.string().min(1).max(512),
+  options: stateSearchOptionsSchema.optional(),
+  maxCandidateFiles: z.number().int().min(1).max(500).optional(),
+  cursor: z.string().optional(),
+});
+
+const searchFileCandidateSchema = z.object({
+  key: z.string(),
+  positions: z.array(z.number()),
+  count: z.number(),
+});
+
+const hydrateSearchMatchesSchema = searchFilesSchema;
+
+const stateTextMatchSchema = z.object({
+  path: z.string(),
+  line: z.number(),
+  column: z.number(),
+  startOffset: z.number(),
+  endOffset: z.number(),
+  text: z.string(),
+  contextBefore: z.array(z.string()),
+  contextAfter: z.array(z.string()),
+});
+
 const errorCodes = [
   "UPLOAD_NOT_FOUND",
   "UPLOAD_ALREADY_ACTIVE",
@@ -60,6 +104,9 @@ const errorCodes = [
   "INVALID_FILE_KEY",
   "INVALID_CHECKSUM",
   "INVALID_REQUEST",
+  "TEXT_INDEX_DISABLED",
+  "TEXT_SEARCH_REGEX_UNSUPPORTED",
+  "TEXT_SEARCH_INVALID_QUERY",
 ] as const;
 
 type FileErrorCode = (typeof errorCodes)[number];
@@ -111,6 +158,21 @@ const handleServiceError = <Code extends FileErrorCode>(
       return error({ message: "Invalid request", code: "INVALID_REQUEST" as Code }, 400);
     case "STORAGE_ERROR":
       return error({ message: "Storage error", code: "STORAGE_ERROR" as Code }, 502);
+    case "TEXT_INDEX_DISABLED":
+      return error({ message: "Text index is disabled", code: "TEXT_INDEX_DISABLED" as Code }, 400);
+    case "TEXT_SEARCH_REGEX_UNSUPPORTED":
+      return error(
+        {
+          message: "Regex search is not supported by the text index",
+          code: "TEXT_SEARCH_REGEX_UNSUPPORTED" as Code,
+        },
+        400,
+      );
+    case "TEXT_SEARCH_INVALID_QUERY":
+      return error(
+        { message: "Invalid text search query", code: "TEXT_SEARCH_INVALID_QUERY" as Code },
+        400,
+      );
     default:
       throw err;
   }
@@ -157,6 +219,13 @@ const assertFileAvailable = <T extends { status: string }>(file: T) => {
     throw new Error("FILE_DELETED");
   }
   return file;
+};
+
+const toSearchPositions = (value: unknown): number[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((position): position is number => Number.isSafeInteger(position));
 };
 
 type DirectoryMetadata = z.infer<typeof directoryMetadataSchema>;
@@ -509,6 +578,185 @@ export const fileRoutesFactory = defineRoutes(uploadFragmentDefinition).create(
             cursor: result.cursor?.encode(),
             hasNextPage: result.hasNextPage,
           });
+        },
+      }),
+
+      // Complex read endpoints use POST so callers can send structured search options
+      // without query-string encoding or URL length limits.
+      defineRoute({
+        method: "POST",
+        path: "/files/search",
+        inputSchema: searchFilesSchema,
+        outputSchema: z.object({
+          provider: providerNamespaceSchema,
+          candidates: z.array(searchFileCandidateSchema),
+          candidateFiles: z.number(),
+          cursor: z.string().optional(),
+          hasMoreCandidates: z.boolean(),
+        }),
+        errorCodes,
+        handler: async function ({ input }, { json, error }) {
+          const resolvedConfig = getResolvedConfig();
+          const payload = await input.valid();
+          const options = payload.options ?? {};
+
+          if (!resolvedConfig.textIndex?.enabled) {
+            return handleServiceError(new Error("TEXT_INDEX_DISABLED"), error);
+          }
+
+          if (options.regex) {
+            return handleServiceError(new Error("TEXT_SEARCH_REGEX_UNSUPPORTED"), error);
+          }
+
+          const searchTerms = extractTextIndexTerms(payload.query, resolvedConfig.textIndex);
+          const searchTerm = searchTerms[0];
+          if (!searchTerm) {
+            return handleServiceError(new Error("TEXT_SEARCH_INVALID_QUERY"), error);
+          }
+
+          const globPrefix = getStaticGlobPrefix(payload.glob);
+          const globPattern = globToRegExp(payload.glob);
+          const maxCandidateFiles = payload.maxCandidateFiles ?? 200;
+
+          const [candidatePage] = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(uploadSchema).findWithCursor("file_text_term", (b) => {
+                const query = b
+                  .whereIndex("idx_file_text_term_provider_term_key", (eb) =>
+                    eb.and(
+                      eb("provider", "=", payload.provider),
+                      eb("term", "=", searchTerm),
+                      eb("key", "starts with", globPrefix),
+                    ),
+                  )
+                  .orderByIndex("idx_file_text_term_provider_term_key", "asc")
+                  .pageSize(maxCandidateFiles)
+                  .joinOne("document", "file_text_document", (document) =>
+                    document.onIndex("primary", (eb) => eb("id", "=", eb.parent("documentId"))),
+                  );
+
+                return payload.cursor ? query.after(payload.cursor) : query;
+              }),
+            )
+            .execute();
+
+          const candidates = candidatePage.items.flatMap((candidate) => {
+            const document = candidate.document;
+            if (!document || !globPattern.test(document.key)) {
+              return [];
+            }
+
+            return [
+              {
+                key: document.key,
+                positions: toSearchPositions(candidate.positions),
+                count: candidate.count,
+              },
+            ];
+          });
+
+          return json({
+            provider: payload.provider,
+            candidates,
+            candidateFiles: candidates.length,
+            cursor: candidatePage.cursor?.encode(),
+            hasMoreCandidates: candidatePage.hasNextPage,
+          });
+        },
+      }),
+
+      // Hydration is also read-only, but POST keeps the API compatible with richer
+      // payloads such as explicit candidate pages.
+      defineRoute({
+        method: "POST",
+        path: "/files/search/hydrate",
+        inputSchema: hydrateSearchMatchesSchema,
+        outputSchema: z.object({
+          matches: z.array(stateTextMatchSchema),
+          scannedFiles: z.number(),
+        }),
+        errorCodes,
+        handler: async function ({ input }, { json, error }) {
+          const resolvedConfig = getResolvedConfig();
+          const payload = await input.valid();
+          const options = payload.options ?? {};
+          const maxMatches = options.maxMatches ?? 50;
+
+          if (!resolvedConfig.textIndex?.enabled) {
+            return handleServiceError(new Error("TEXT_INDEX_DISABLED"), error);
+          }
+
+          if (options.regex) {
+            return handleServiceError(new Error("TEXT_SEARCH_REGEX_UNSUPPORTED"), error);
+          }
+
+          if (!resolvedConfig.storage.getDownloadStream) {
+            return handleServiceError(new Error("STORAGE_ERROR"), error);
+          }
+
+          const searchTerms = extractTextIndexTerms(payload.query, resolvedConfig.textIndex);
+          const searchTerm = searchTerms[0];
+          if (!searchTerm) {
+            return handleServiceError(new Error("TEXT_SEARCH_INVALID_QUERY"), error);
+          }
+
+          const globPrefix = getStaticGlobPrefix(payload.glob);
+          const globPattern = globToRegExp(payload.glob);
+          const maxCandidateFiles = payload.maxCandidateFiles ?? 200;
+
+          const [candidatePage] = await this.handlerTx()
+            .retrieve(({ forSchema }) =>
+              forSchema(uploadSchema).findWithCursor("file_text_term", (b) => {
+                const query = b
+                  .whereIndex("idx_file_text_term_provider_term_key", (eb) =>
+                    eb.and(
+                      eb("provider", "=", payload.provider),
+                      eb("term", "=", searchTerm),
+                      eb("key", "starts with", globPrefix),
+                    ),
+                  )
+                  .orderByIndex("idx_file_text_term_provider_term_key", "asc")
+                  .pageSize(maxCandidateFiles)
+                  .joinOne("document", "file_text_document", (document) =>
+                    document.onIndex("primary", (eb) => eb("id", "=", eb.parent("documentId"))),
+                  );
+
+                return payload.cursor ? query.after(payload.cursor) : query;
+              }),
+            )
+            .execute();
+
+          const matches = [];
+          let scannedFiles = 0;
+
+          for (const candidate of candidatePage.items) {
+            if (matches.length >= maxMatches) {
+              break;
+            }
+
+            const document = candidate.document;
+            if (!document || !globPattern.test(document.key)) {
+              continue;
+            }
+
+            const response = await resolvedConfig.storage.getDownloadStream({
+              storageKey: document.objectKey,
+            });
+            if (!response.ok) {
+              return handleServiceError(new Error("STORAGE_ERROR"), error);
+            }
+
+            scannedFiles += 1;
+            const text = await response.text();
+            matches.push(
+              ...searchTextContent(document.key, text, payload.query, {
+                ...options,
+                maxMatches: maxMatches - matches.length,
+              }),
+            );
+          }
+
+          return json({ matches, scannedFiles });
         },
       }),
 

--- a/packages/fragment-upload/src/schema.ts
+++ b/packages/fragment-upload/src/schema.ts
@@ -115,5 +115,40 @@ export const uploadSchema = schema("upload", (s) => {
           column("timestamp").defaultTo((b) => b.now()),
         )
         .createIndex("idx_storage_object_key", ["storageKey"], { unique: true });
+    })
+    .addTable("file_text_document", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("fileId", referenceColumn({ table: "file" }))
+        .addColumn("provider", column("string"))
+        .addColumn("key", column("string"))
+        .addColumn("objectKey", column("string"))
+        .addColumn("contentHash", column("string"))
+        .addColumn("byteLength", column("bigint"))
+        .addColumn(
+          "indexedAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .addColumn(
+          "updatedAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .createIndex("idx_file_text_document_provider_key", ["provider", "key"], {
+          unique: true,
+        })
+        .createIndex("idx_file_text_document_file", ["fileId"]);
+    })
+    .addTable("file_text_term", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("documentId", referenceColumn({ table: "file_text_document" }))
+        .addColumn("provider", column("string"))
+        .addColumn("key", column("string"))
+        .addColumn("term", column("string"))
+        .addColumn("positions", column("json"))
+        .addColumn("count", column("integer"))
+        .createIndex("idx_file_text_term_provider_term", ["provider", "term"])
+        .createIndex("idx_file_text_term_provider_term_key", ["provider", "term", "key"])
+        .createIndex("idx_file_text_term_document", ["documentId"]);
     });
 });

--- a/packages/fragment-upload/src/services/uploads.ts
+++ b/packages/fragment-upload/src/services/uploads.ts
@@ -68,6 +68,7 @@ const DEFAULT_VISIBILITY: FileVisibility = "private";
 
 type UploadHooks = {
   onFileReady: (payload: FileHookPayload) => void | Promise<void>;
+  onFileTextIndexRequested: (payload: FileHookPayload) => void | Promise<void>;
   onUploadFailed: (payload: FileHookPayload) => void | Promise<void>;
   onFileDeleted: (payload: FileHookPayload) => void | Promise<void>;
   cleanupStorageObject: (payload: FileHookPayload) => void | Promise<void>;
@@ -595,7 +596,9 @@ export const createUploadServices = (config: UploadFragmentResolvedConfig) => {
             errorMessage: null,
           } as UploadRow;
 
-          uow.triggerHook("onFileReady", buildUploadHookPayload(uploadRow, finalSizeBytes));
+          const fileReadyPayload = buildUploadHookPayload(uploadRow, finalSizeBytes);
+          uow.triggerHook("onFileReady", fileReadyPayload);
+          uow.triggerHook("onFileTextIndexRequested", fileReadyPayload);
 
           return {
             upload: uploadRow,
@@ -934,7 +937,9 @@ export const createUploadServices = (config: UploadFragmentResolvedConfig) => {
                 };
               })();
 
-          uow.triggerHook("onFileReady", buildUploadHookPayload(upload, finalSizeBytes));
+          const fileReadyPayload = buildUploadHookPayload(upload, finalSizeBytes);
+          uow.triggerHook("onFileReady", fileReadyPayload);
+          uow.triggerHook("onFileTextIndexRequested", fileReadyPayload);
 
           return {
             upload: updatedUpload,

--- a/packages/fragment-upload/src/storage/__tests__/db.test.ts
+++ b/packages/fragment-upload/src/storage/__tests__/db.test.ts
@@ -36,10 +36,10 @@ const createDatabaseStorageTestBuild = (setStorage: (storage: StorageAdapter) =>
         const storage = createDatabaseStorageAdapter({ databaseAdapter: adapter });
         setStorage(storage);
         return instantiate(uploadFragmentDefinition)
-          .withConfig({ storage })
+          .withConfig({ storage, textIndex: { enabled: true } })
           .withRoutes(uploadRoutes);
       },
-      { config: { storage: schemaExtractionStorage } },
+      { config: { storage: schemaExtractionStorage, textIndex: { enabled: true } } },
     )
     .build();
 };
@@ -103,6 +103,440 @@ describe("database storage adapter", () => {
     await objectUow.executeRetrieve();
     const storedObject = (await objectUow.retrievalPhase)[0];
     assert(Buffer.from(storedObject!.body).toString("utf8") === "database bytes");
+  });
+
+  it("indexes uploaded text and searches through the inverted index", async () => {
+    const { fragment } = build.fragments.upload;
+
+    const uploadTextFile = async (fileKey: string, content: string, contentType = "text/plain") => {
+      const form = new FormData();
+      form.set("provider", storage.name);
+      form.set("fileKey", fileKey);
+      form.set(
+        "file",
+        new File([content], fileKey.split("/").at(-1) ?? "file.txt", { type: contentType }),
+      );
+      const response = await fragment.callRoute("POST", "/files", { body: form });
+      assert(response.type === "json");
+      assert(response.data.status === "ready");
+    };
+
+    await uploadTextFile(
+      "workspace/src/workflows.ts",
+      [
+        "import { workflow } from './runtime';",
+        "export const createWorkflow = () => workflow();",
+        "createWorkflow();",
+      ].join("\n"),
+      "application/typescript",
+    );
+    await uploadTextFile(
+      "workspace/src/users.ts",
+      "export const createUser = () => {};",
+      "application/typescript",
+    );
+    await uploadTextFile(
+      "workspace/README.md",
+      "createWorkflow is documented here",
+      "text/markdown",
+    );
+
+    await drainDurableHooks(fragment);
+
+    const searchResponse = await fragment.callRoute("POST", "/files/search", {
+      body: {
+        provider: storage.name,
+        glob: "/workspace/**/*.ts",
+        query: "createWorkflow",
+        options: {
+          caseSensitive: false,
+          contextBefore: 1,
+          contextAfter: 1,
+          maxMatches: 50,
+        },
+      },
+    });
+
+    assert(searchResponse.type === "json");
+    expect(searchResponse.data).toMatchInlineSnapshot(`
+      {
+        "candidateFiles": 1,
+        "candidates": [
+          {
+            "count": 2,
+            "key": "workspace/src/workflows.ts",
+            "positions": [
+              51,
+              86,
+            ],
+          },
+        ],
+        "hasMoreCandidates": false,
+        "provider": "database",
+      }
+    `);
+
+    const hydrateResponse = await fragment.callRoute("POST", "/files/search/hydrate", {
+      body: {
+        provider: storage.name,
+        glob: "/workspace/**/*.ts",
+        query: "createWorkflow",
+        options: {
+          caseSensitive: false,
+          contextBefore: 1,
+          contextAfter: 1,
+          maxMatches: 50,
+        },
+      },
+    });
+
+    assert(hydrateResponse.type === "json");
+    expect(hydrateResponse.data).toMatchInlineSnapshot(`
+      {
+        "matches": [
+          {
+            "column": 14,
+            "contextAfter": [
+              "createWorkflow();",
+            ],
+            "contextBefore": [
+              "import { workflow } from './runtime';",
+            ],
+            "endOffset": 65,
+            "line": 2,
+            "path": "workspace/src/workflows.ts",
+            "startOffset": 51,
+            "text": "createWorkflow",
+          },
+          {
+            "column": 1,
+            "contextAfter": [],
+            "contextBefore": [
+              "export const createWorkflow = () => workflow();",
+            ],
+            "endOffset": 100,
+            "line": 3,
+            "path": "workspace/src/workflows.ts",
+            "startOffset": 86,
+            "text": "createWorkflow",
+          },
+        ],
+        "scannedFiles": 1,
+      }
+    `);
+  });
+
+  it("limits text search candidate files before downloading file contents", async () => {
+    const { fragment } = build.fragments.upload;
+
+    for (const fileKey of ["workspace/src/a.ts", "workspace/src/b.ts", "workspace/src/c.ts"]) {
+      const form = new FormData();
+      form.set("provider", storage.name);
+      form.set("fileKey", fileKey);
+      form.set(
+        "file",
+        new File([`export const createWorkflow = '${fileKey}';\n`], fileKey.split("/").at(-1)!, {
+          type: "application/typescript",
+        }),
+      );
+      const uploadResponse = await fragment.callRoute("POST", "/files", { body: form });
+      assert(uploadResponse.type === "json");
+    }
+
+    await drainDurableHooks(fragment);
+
+    const searchResponse = await fragment.callRoute("POST", "/files/search", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+        maxCandidateFiles: 2,
+      },
+    });
+
+    assert(searchResponse.type === "json");
+    expect(searchResponse.data).toMatchInlineSnapshot(`
+      {
+        "candidateFiles": 2,
+        "candidates": [
+          {
+            "count": 1,
+            "key": "workspace/src/a.ts",
+            "positions": [
+              13,
+            ],
+          },
+          {
+            "count": 1,
+            "key": "workspace/src/b.ts",
+            "positions": [
+              13,
+            ],
+          },
+        ],
+        "cursor": "eyJ2IjoxLCJpbmRleE5hbWUiOiJpZHhfZmlsZV90ZXh0X3Rlcm1fcHJvdmlkZXJfdGVybV9rZXkiLCJvcmRlckRpcmVjdGlvbiI6ImFzYyIsInBhZ2VTaXplIjoyLCJpbmRleFZhbHVlcyI6eyJwcm92aWRlciI6ImRhdGFiYXNlIiwidGVybSI6ImNyZWF0ZXdvcmtmbG93Iiwia2V5Ijoid29ya3NwYWNlL3NyYy9iLnRzIn19",
+        "hasMoreCandidates": true,
+        "provider": "database",
+      }
+    `);
+
+    const cursor = searchResponse.data.cursor;
+    assert(typeof cursor === "string");
+
+    const nextSearchResponse = await fragment.callRoute("POST", "/files/search", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+        maxCandidateFiles: 2,
+        cursor,
+      },
+    });
+
+    assert(nextSearchResponse.type === "json");
+    expect(nextSearchResponse.data).toMatchInlineSnapshot(`
+      {
+        "candidateFiles": 1,
+        "candidates": [
+          {
+            "count": 1,
+            "key": "workspace/src/c.ts",
+            "positions": [
+              13,
+            ],
+          },
+        ],
+        "hasMoreCandidates": false,
+        "provider": "database",
+      }
+    `);
+
+    const hydrateResponse = await fragment.callRoute("POST", "/files/search/hydrate", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+        maxCandidateFiles: 2,
+      },
+    });
+
+    assert(hydrateResponse.type === "json");
+    expect(hydrateResponse.data).toMatchInlineSnapshot(`
+      {
+        "matches": [
+          {
+            "column": 14,
+            "contextAfter": [],
+            "contextBefore": [],
+            "endOffset": 27,
+            "line": 1,
+            "path": "workspace/src/a.ts",
+            "startOffset": 13,
+            "text": "createWorkflow",
+          },
+          {
+            "column": 14,
+            "contextAfter": [],
+            "contextBefore": [],
+            "endOffset": 27,
+            "line": 1,
+            "path": "workspace/src/b.ts",
+            "startOffset": 13,
+            "text": "createWorkflow",
+          },
+        ],
+        "scannedFiles": 2,
+      }
+    `);
+
+    const nextHydrateResponse = await fragment.callRoute("POST", "/files/search/hydrate", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+        maxCandidateFiles: 2,
+        cursor,
+      },
+    });
+
+    assert(nextHydrateResponse.type === "json");
+    expect(nextHydrateResponse.data).toMatchInlineSnapshot(`
+      {
+        "matches": [
+          {
+            "column": 14,
+            "contextAfter": [],
+            "contextBefore": [],
+            "endOffset": 27,
+            "line": 1,
+            "path": "workspace/src/c.ts",
+            "startOffset": 13,
+            "text": "createWorkflow",
+          },
+        ],
+        "scannedFiles": 1,
+      }
+    `);
+  });
+
+  it("replaces stale text index terms when a file is re-uploaded", async () => {
+    const { fragment } = build.fragments.upload;
+    const uploadTextFile = async (content: string) => {
+      const form = new FormData();
+      form.set("provider", storage.name);
+      form.set("fileKey", "workspace/src/stale.ts");
+      form.set("file", new File([content], "stale.ts", { type: "application/typescript" }));
+      const response = await fragment.callRoute("POST", "/files", { body: form });
+      assert(response.type === "json");
+    };
+
+    await uploadTextFile("export const createWorkflow = () => {};\n");
+    await drainDurableHooks(fragment);
+
+    const before = await fragment.callRoute("POST", "/files/search/hydrate", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+      },
+    });
+    assert(before.type === "json");
+    expect(before.data).toMatchInlineSnapshot(`
+      {
+        "matches": [
+          {
+            "column": 14,
+            "contextAfter": [],
+            "contextBefore": [],
+            "endOffset": 27,
+            "line": 1,
+            "path": "workspace/src/stale.ts",
+            "startOffset": 13,
+            "text": "createWorkflow",
+          },
+        ],
+        "scannedFiles": 1,
+      }
+    `);
+
+    await uploadTextFile("export const createUser = () => {};\n");
+    await drainDurableHooks(fragment);
+
+    const after = await fragment.callRoute("POST", "/files/search/hydrate", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+      },
+    });
+    assert(after.type === "json");
+    expect(after.data).toMatchInlineSnapshot(`
+      {
+        "matches": [],
+        "scannedFiles": 0,
+      }
+    `);
+  });
+
+  it("clears the text index when a file is replaced by non-indexable content", async () => {
+    const { fragment } = build.fragments.upload;
+    const uploadFile = async (content: string, contentType: string) => {
+      const form = new FormData();
+      form.set("provider", storage.name);
+      form.set("fileKey", "workspace/src/replaced.ts");
+      form.set("file", new File([content], "replaced.ts", { type: contentType }));
+      const response = await fragment.callRoute("POST", "/files", { body: form });
+      assert(response.type === "json");
+    };
+
+    await uploadFile("export const createWorkflow = () => {};\n", "application/typescript");
+    await drainDurableHooks(fragment);
+
+    await uploadFile("binary-ish replacement", "application/octet-stream");
+    await drainDurableHooks(fragment);
+
+    const searchResponse = await fragment.callRoute("POST", "/files/search/hydrate", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+      },
+    });
+
+    assert(searchResponse.type === "json");
+    expect(searchResponse.data).toEqual({ matches: [], scannedFiles: 0 });
+  });
+
+  it("clears the text index idempotently when a file is deleted", async () => {
+    const { fragment, db } = build.fragments.upload;
+    const form = new FormData();
+    form.set("provider", storage.name);
+    form.set("fileKey", "workspace/src/deleted.ts");
+    form.set(
+      "file",
+      new File(["export const createWorkflow = () => {};\n"], "deleted.ts", {
+        type: "application/typescript",
+      }),
+    );
+
+    const uploadResponse = await fragment.callRoute("POST", "/files", { body: form });
+    assert(uploadResponse.type === "json");
+    await drainDurableHooks(fragment);
+
+    const fileUow = db
+      .createUnitOfWork("read-file-before-delete")
+      .forSchema(uploadSchema)
+      .findFirst("file", (b) =>
+        b.whereIndex("idx_file_provider_key", (eb) =>
+          eb.and(eb("provider", "=", storage.name), eb("key", "=", "workspace/src/deleted.ts")),
+        ),
+      );
+    await fileUow.executeRetrieve();
+    const fileBeforeDelete = (await fileUow.retrievalPhase)[0];
+    assert(fileBeforeDelete?.objectKey);
+
+    const deleteResponse = await fragment.callRoute("DELETE", "/files/by-key", {
+      query: { provider: storage.name, key: "workspace/src/deleted.ts" },
+    });
+    assert(deleteResponse.type === "json");
+    await drainDurableHooks(fragment);
+
+    const searchResponse = await fragment.callRoute("POST", "/files/search/hydrate", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+      },
+    });
+
+    assert(searchResponse.type === "json");
+    expect(searchResponse.data).toEqual({ matches: [], scannedFiles: 0 });
+
+    await fragment.inContext(async function () {
+      await this.handlerTx()
+        .mutate(({ forSchema }) => {
+          forSchema(uploadSchema).triggerHook("onFileDeleted", {
+            provider: storage.name,
+            fileKey: "workspace/src/deleted.ts",
+            objectKey: fileBeforeDelete.objectKey,
+            sizeBytes: Number(fileBeforeDelete.sizeBytes),
+            contentType: fileBeforeDelete.contentType,
+          });
+        })
+        .execute();
+    });
+    await drainDurableHooks(fragment);
+
+    const repeatedSearchResponse = await fragment.callRoute("POST", "/files/search/hydrate", {
+      body: {
+        provider: storage.name,
+        glob: "workspace/**/*.ts",
+        query: "createWorkflow",
+      },
+    });
+
+    assert(repeatedSearchResponse.type === "json");
+    expect(repeatedSearchResponse.data).toEqual({ matches: [], scannedFiles: 0 });
   });
 
   it("removes database bytes when the file deletion hook runs", async () => {

--- a/packages/fragment-upload/src/text-index.ts
+++ b/packages/fragment-upload/src/text-index.ts
@@ -1,0 +1,258 @@
+export type TextIndexOptions = {
+  enabled?: boolean;
+  minTermLength?: number;
+  maxTermLength?: number;
+};
+
+export type TextIndexTerm = {
+  term: string;
+  positions: number[];
+  count: number;
+};
+
+export type BuiltTextIndex = {
+  contentHash: string;
+  byteLength: number;
+  terms: TextIndexTerm[];
+};
+
+export type StateSearchOptions = {
+  caseSensitive?: boolean;
+  regex?: boolean;
+  wholeWord?: boolean;
+  contextBefore?: number;
+  contextAfter?: number;
+  maxMatches?: number;
+};
+
+export type StateTextMatch = {
+  path: string;
+  line: number;
+  column: number;
+  startOffset: number;
+  endOffset: number;
+  text: string;
+  contextBefore: string[];
+  contextAfter: string[];
+};
+
+const DEFAULT_MIN_TERM_LENGTH = 2;
+const DEFAULT_MAX_TERM_LENGTH = 128;
+const TEXT_CONTENT_TYPES = [
+  "application/javascript",
+  "application/json",
+  "application/typescript",
+  "application/xml",
+  "application/x-javascript",
+  "application/x-typescript",
+  "image/svg+xml",
+];
+
+const tokenPattern = /[\p{L}\p{N}_$]+/gu;
+
+export const normalizeTextIndexTerm = (term: string) => term.normalize("NFKC").toLowerCase();
+
+export const extractTextIndexTerms = (
+  text: string,
+  options: Pick<TextIndexOptions, "minTermLength" | "maxTermLength"> = {},
+): string[] => {
+  const minTermLength = options.minTermLength ?? DEFAULT_MIN_TERM_LENGTH;
+  const maxTermLength = options.maxTermLength ?? DEFAULT_MAX_TERM_LENGTH;
+  const terms: string[] = [];
+
+  for (const match of text.matchAll(tokenPattern)) {
+    const rawTerm = match[0];
+    if (rawTerm.length < minTermLength || rawTerm.length > maxTermLength) {
+      continue;
+    }
+    terms.push(normalizeTextIndexTerm(rawTerm));
+  }
+
+  return terms;
+};
+
+export const shouldIndexContentType = (contentType: string): boolean => {
+  const normalized = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  return normalized.startsWith("text/") || TEXT_CONTENT_TYPES.includes(normalized);
+};
+
+const hashBytes = (bytes: Uint8Array) => {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+
+  for (const byte of bytes) {
+    hash ^= BigInt(byte);
+    hash = (hash * prime) & mask;
+  }
+
+  return hash.toString(16).padStart(16, "0");
+};
+
+export const buildTextIndex = (
+  bytes: Uint8Array,
+  options: TextIndexOptions = {},
+): BuiltTextIndex => {
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  const minTermLength = options.minTermLength ?? DEFAULT_MIN_TERM_LENGTH;
+  const maxTermLength = options.maxTermLength ?? DEFAULT_MAX_TERM_LENGTH;
+  const terms = new Map<string, number[]>();
+
+  for (const match of text.matchAll(tokenPattern)) {
+    const rawTerm = match[0];
+    if (rawTerm.length < minTermLength || rawTerm.length > maxTermLength) {
+      continue;
+    }
+
+    const term = normalizeTextIndexTerm(rawTerm);
+    const positions = terms.get(term);
+    if (positions) {
+      positions.push(match.index ?? 0);
+      continue;
+    }
+
+    terms.set(term, [match.index ?? 0]);
+  }
+
+  return {
+    contentHash: hashBytes(bytes),
+    byteLength: bytes.byteLength,
+    terms: Array.from(terms.entries()).map(([term, positions]) => ({
+      term,
+      positions,
+      count: positions.length,
+    })),
+  };
+};
+
+const isWordCharacter = (value: string) => /[\p{L}\p{N}_$]/u.test(value);
+
+const isWholeWordMatch = (text: string, startOffset: number, endOffset: number) => {
+  const before = startOffset > 0 ? text[startOffset - 1] : undefined;
+  const after = endOffset < text.length ? text[endOffset] : undefined;
+  return (!before || !isWordCharacter(before)) && (!after || !isWordCharacter(after));
+};
+
+const getLineStarts = (text: string): number[] => {
+  const starts = [0];
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] === "\n") {
+      starts.push(index + 1);
+    }
+  }
+  return starts;
+};
+
+const getLineForOffset = (lineStarts: number[], offset: number) => {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const start = lineStarts[middle] ?? 0;
+    const next = lineStarts[middle + 1] ?? Number.POSITIVE_INFINITY;
+    if (offset >= start && offset < next) {
+      return middle;
+    }
+    if (offset < start) {
+      high = middle - 1;
+    } else {
+      low = middle + 1;
+    }
+  }
+  return lineStarts.length - 1;
+};
+
+const getLines = (text: string) => text.split(/\r?\n/);
+
+export const searchTextContent = (
+  path: string,
+  text: string,
+  query: string,
+  options: StateSearchOptions = {},
+): StateTextMatch[] => {
+  const maxMatches = options.maxMatches ?? 50;
+  if (maxMatches <= 0 || query.length === 0) {
+    return [];
+  }
+
+  if (options.regex) {
+    throw new Error("TEXT_SEARCH_REGEX_UNSUPPORTED");
+  }
+
+  const haystack = options.caseSensitive ? text : text.toLocaleLowerCase();
+  const needle = options.caseSensitive ? query : query.toLocaleLowerCase();
+  const lineStarts = getLineStarts(text);
+  const lines = getLines(text);
+  const matches: StateTextMatch[] = [];
+  let searchOffset = 0;
+
+  while (matches.length < maxMatches) {
+    const startOffset = haystack.indexOf(needle, searchOffset);
+    if (startOffset === -1) {
+      break;
+    }
+
+    const endOffset = startOffset + needle.length;
+    searchOffset = Math.max(endOffset, startOffset + 1);
+
+    if (options.wholeWord && !isWholeWordMatch(text, startOffset, endOffset)) {
+      continue;
+    }
+
+    const lineIndex = getLineForOffset(lineStarts, startOffset);
+    const lineStart = lineStarts[lineIndex] ?? 0;
+    const contextBefore = Math.max(0, options.contextBefore ?? 0);
+    const contextAfter = Math.max(0, options.contextAfter ?? 0);
+
+    matches.push({
+      path,
+      line: lineIndex + 1,
+      column: startOffset - lineStart + 1,
+      startOffset,
+      endOffset,
+      text: text.slice(startOffset, endOffset),
+      contextBefore: lines.slice(Math.max(0, lineIndex - contextBefore), lineIndex),
+      contextAfter: lines.slice(lineIndex + 1, lineIndex + 1 + contextAfter),
+    });
+  }
+
+  return matches;
+};
+
+export const getStaticGlobPrefix = (glob: string) => {
+  const normalized = glob.replace(/^\/+/, "");
+  const wildcardIndex = normalized.search(/[!*?[{]/);
+  const staticPart = wildcardIndex === -1 ? normalized : normalized.slice(0, wildcardIndex);
+  const slashIndex = staticPart.lastIndexOf("/");
+  if (wildcardIndex === -1) {
+    return staticPart;
+  }
+  return slashIndex === -1 ? "" : staticPart.slice(0, slashIndex + 1);
+};
+
+const escapeRegex = (value: string) => value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+
+export const globToRegExp = (glob: string) => {
+  const normalized = glob.replace(/^\/+/, "");
+  let pattern = "^";
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+    if (char === "*" && next === "*") {
+      pattern += ".*";
+      index += 1;
+      continue;
+    }
+    if (char === "*") {
+      pattern += "[^/]*";
+      continue;
+    }
+    if (char === "?") {
+      pattern += "[^/]";
+      continue;
+    }
+    pattern += escapeRegex(char ?? "");
+  }
+  pattern += "$";
+  return new RegExp(pattern);
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text-index-powered file search with hydrated match results.
  * Introduced a clearer `/static` vs `/system` split across the file browser, terminal guidance, and automation/script views, including updated starter and documentation surfaces under `/static` (e.g., `SYSTEM.md`).
  * Added support for `/static`-scoped codemode artifacts on demand.
* **Bug Fixes**
  * Fixed default auto-created organization slug scoping to the correct user.
  * Improved behavior when an organization slug is already taken (now returns a clear `organization_slug_taken` error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->