### PR TITLE
feat(backoffice): add scoped automation integrations

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,7 +6,8 @@
     "./packages-private/oxlint-plugins/fragment-dev-browser-exports.js",
     "./packages-private/oxlint-plugins/docs-icons-sync.js",
     "./packages-private/oxlint-plugins/vitest-assert-json-response.js",
-    "./packages-private/oxlint-plugins/zod-inline-schema-definitions.js"
+    "./packages-private/oxlint-plugins/zod-inline-schema-definitions.js",
+    "./packages-private/oxlint-plugins/zod-v4-object-factories.js"
   ],
   "env": {
     "builtin": true
@@ -92,6 +93,7 @@
     "docs-icons-sync/used-icons": "error",
     "vitest-assert-json-response/assert-json-response": "error",
     "zod-inline-schema-definitions/inline-one-line": "error",
+    "zod-v4-object-factories/prefer-object-factories": "error",
     "for-direction": "error",
     "no-async-promise-executor": "error",
     "no-case-declarations": "error",

--- a/apps/backoffice/app/backoffice-runtime/object-registry.test.ts
+++ b/apps/backoffice/app/backoffice-runtime/object-registry.test.ts
@@ -93,9 +93,9 @@ describe("backoffice object scope policy", () => {
       API: ["org", "user", "project"],
       AUTH: ["singleton"],
       AUTOMATIONS: ["singleton", "org", "user", "project"],
-      TELEGRAM: ["singleton", "org", "user"],
+      TELEGRAM: ["singleton", "org", "user", "project"],
       OTP: ["org"],
-      RESEND: ["org"],
+      RESEND: ["singleton", "org"],
       RESON8: ["org"],
       MCP: ["org", "user", "project"],
       UPLOAD: ["org", "user", "project"],
@@ -115,6 +115,8 @@ describe("backoffice object scope policy", () => {
     assertBackofficeObjectAddressAllowed(address("MCP", "project"));
     assertBackofficeObjectAddressAllowed(address("TELEGRAM", "singleton"));
     assertBackofficeObjectAddressAllowed(address("TELEGRAM", "user"));
+    assertBackofficeObjectAddressAllowed(address("TELEGRAM", "project"));
+    assertBackofficeObjectAddressAllowed(address("RESEND", "singleton"));
     assertBackofficeObjectAddressAllowed(address("PI", "org"));
   });
 

--- a/apps/backoffice/app/backoffice-runtime/object-registry.ts
+++ b/apps/backoffice/app/backoffice-runtime/object-registry.ts
@@ -241,9 +241,9 @@ export const backofficeObjectScopePolicy = {
 
   AUTOMATIONS: ["singleton", "org", "user", "project"],
 
-  TELEGRAM: ["singleton", "org", "user"],
+  TELEGRAM: ["singleton", "org", "user", "project"],
   OTP: ["org"],
-  RESEND: ["org"],
+  RESEND: ["singleton", "org"],
   RESON8: ["org"],
   MCP: ["org", "user", "project"],
   UPLOAD: ["org", "user", "project"],

--- a/apps/backoffice/app/components/backoffice/breadcrumbs.tsx
+++ b/apps/backoffice/app/components/backoffice/breadcrumbs.tsx
@@ -1,9 +1,10 @@
 import { Drawer } from "@base-ui/react/drawer";
 import { Separator } from "@base-ui/react/separator";
+import type { ReactNode } from "react";
 import { Link } from "react-router";
 
 export type BreadcrumbItem = {
-  label: string;
+  label: ReactNode;
   to?: string;
 };
 
@@ -32,7 +33,7 @@ export function BackofficeBreadcrumbs({
         {items.map((item, index) => {
           const isLast = index === items.length - 1;
           return (
-            <li key={`${item.label}-${index}`} className="flex items-center gap-2">
+            <li key={`${String(item.label)}-${index}`} className="flex items-center gap-2">
               {item.to && !isLast ? (
                 <Link to={item.to} className="transition-colors hover:text-[var(--bo-fg)]">
                   {item.label}

--- a/apps/backoffice/app/components/backoffice/sidebar.tsx
+++ b/apps/backoffice/app/components/backoffice/sidebar.tsx
@@ -22,9 +22,9 @@ const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/gu, "\
 
 const projectAutomationBasePathPattern = (automationBasePath: string) => {
   const match = /^\/backoffice\/automations\/org\/([^/]+)$/u.exec(automationBasePath);
-  const orgId = match?.[1];
-  return orgId
-    ? `/backoffice/automations/project/${escapeRegExp(encodeURIComponent(orgId))}:[^/]+`
+  const organizationId = match?.[1];
+  return organizationId
+    ? `/backoffice/automations/project/${escapeRegExp(encodeURIComponent(organizationId))}:[^/]+`
     : null;
 };
 
@@ -54,9 +54,6 @@ const isAutomationTabPath = (
 };
 
 function createNavItems(activeOrganizationId?: string | null): NavItem[] {
-  const githubPath = activeOrganizationId
-    ? `/backoffice/connections/github/${activeOrganizationId}`
-    : "/backoffice/connections/github";
   const automationBasePath = activeOrganizationId
     ? `/backoffice/automations/org/${activeOrganizationId}`
     : "/backoffice/automations";
@@ -102,6 +99,14 @@ function createNavItems(activeOrganizationId?: string | null): NavItem[] {
           isActive: isAutomationTabPath("events-catalog"),
         },
         { label: "API", to: `${automationBasePath}/api`, isActive: isAutomationTabPath("api") },
+        {
+          label: "Integrations",
+          to: `${automationBasePath}/integrations`,
+          isActive: isAutomationTabPath("integrations", {
+            automationBasePath,
+            includeProjectScope: true,
+          }),
+        },
         { label: "MCP", to: `${automationBasePath}/mcp`, isActive: isAutomationTabPath("mcp") },
         {
           label: "Sandboxes",
@@ -120,17 +125,6 @@ function createNavItems(activeOrganizationId?: string | null): NavItem[] {
     { label: "Sessions", to: "/backoffice/sessions" },
     { label: "Files", to: "/backoffice/files" },
     {
-      label: "Connections",
-      to: "/backoffice/connections",
-      children: [
-        { label: "Telegram", to: "/backoffice/connections/telegram" },
-        { label: "Resend", to: "/backoffice/connections/resend" },
-        { label: "Reson8", to: "/backoffice/connections/reson8" },
-        { label: "GitHub", to: githubPath },
-        { label: "Upload", to: "/backoffice/connections/upload" },
-      ],
-    },
-    {
       label: "Environments",
       to: "/backoffice/environments",
       children: [{ label: "Workers", to: toWorkersPath({}) }],
@@ -140,6 +134,20 @@ function createNavItems(activeOrganizationId?: string | null): NavItem[] {
       to: "/backoffice/internals",
       children: [
         { label: "GitHub", to: "/backoffice/internals/github" },
+        {
+          label: "Upload",
+          to: activeOrganizationId
+            ? `/backoffice/connections/upload/${activeOrganizationId}`
+            : "/backoffice/connections/upload",
+          isActive: (pathname) => pathname.startsWith("/backoffice/connections/upload"),
+        },
+        {
+          label: "Reson8",
+          to: activeOrganizationId
+            ? `/backoffice/connections/reson8/${activeOrganizationId}`
+            : "/backoffice/connections/reson8",
+          isActive: (pathname) => pathname.startsWith("/backoffice/connections/reson8"),
+        },
         { label: "Durable hooks", to: "/backoffice/internals/durable-hooks" },
         { label: "Workflows", to: "/backoffice/internals/workflows" },
       ],

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api.ts
@@ -50,7 +50,7 @@ const apiConnectionAvailablePayloadSchema = z.object({
 });
 
 const apiScopeSubjectSchema = z.object({
-  scope: z.object({ kind: z.string().min(1) }).passthrough(),
+  scope: z.looseObject({ kind: z.string().min(1) }),
   orgId: z.string().min(1).optional(),
 });
 

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/github.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/github.ts
@@ -2,6 +2,50 @@ import { z } from "zod";
 
 import type { BackofficeCapability } from "@/fragno/backoffice-capabilities/backoffice-capabilities";
 
+const githubUserSchema = z.looseObject({
+  id: z.union([z.number(), z.string()]),
+  login: z.string().min(1),
+  type: z.string().optional(),
+  html_url: z.string().optional(),
+});
+
+const githubRepositorySchema = z.looseObject({
+  id: z.union([z.number(), z.string()]),
+  name: z.string().min(1),
+  full_name: z.string().min(1),
+  private: z.boolean(),
+  html_url: z.string().optional(),
+  default_branch: z.string().nullable().optional(),
+  owner: githubUserSchema.nullable().optional(),
+});
+
+const githubIssueSchema = z.looseObject({
+  id: z.union([z.number(), z.string()]),
+  number: z.number(),
+  title: z.string(),
+  state: z.string().min(1),
+  html_url: z.string().optional(),
+  user: githubUserSchema.nullable().optional(),
+});
+
+const githubPullRequestRefSchema = z.looseObject({
+  ref: z.string().min(1),
+  sha: z.string().min(1),
+});
+
+const githubPullRequestSchema = z.looseObject({
+  id: z.union([z.number(), z.string()]),
+  number: z.number(),
+  title: z.string(),
+  state: z.string().min(1),
+  draft: z.boolean().optional(),
+  merged: z.boolean().optional(),
+  html_url: z.string().optional(),
+  user: githubUserSchema.nullable().optional(),
+  head: githubPullRequestRefSchema.optional(),
+  base: githubPullRequestRefSchema.optional(),
+});
+
 const githubActorSchema = z.object({
   scope: z.literal("external"),
   source: z.literal("github"),
@@ -27,10 +71,10 @@ const githubPayloadSchema = z.object({
   githubEvent: z.string().min(1),
   action: z.string().nullable(),
   installationId: z.string().min(1),
-  sender: z.unknown().nullable().optional(),
-  repository: z.unknown().nullable().optional(),
-  issue: z.unknown().nullable().optional(),
-  pullRequest: z.unknown().nullable().optional(),
+  sender: githubUserSchema.nullable().optional(),
+  repository: githubRepositorySchema.nullable().optional(),
+  issue: githubIssueSchema.nullable().optional(),
+  pullRequest: githubPullRequestSchema.nullable().optional(),
   raw: z.record(z.string(), z.unknown()),
 });
 
@@ -75,7 +119,8 @@ export const githubCapability: BackofficeCapability = {
         githubEvent: "pull_request",
         action: "opened",
         installationId: "123456",
-        repository: { id: 1, full_name: "acme/project" },
+        repository: { id: 1, name: "project", full_name: "acme/project", private: false },
+        pullRequest: { id: 10, number: 7, title: "Add webhook support", state: "open" },
         sender: { id: 42, login: "octocat" },
         raw: {},
       },

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/pi.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/pi.ts
@@ -22,12 +22,10 @@ const piApiKeysSchema = z.object({
   gemini: apiKeyValueSchema,
 });
 
-export const piConfigureInputSchema = z
-  .object({
-    apiKeys: piApiKeysSchema.optional(),
-    harnesses: z.unknown().optional(),
-  })
-  .passthrough();
+export const piConfigureInputSchema = z.looseObject({
+  apiKeys: piApiKeysSchema.optional(),
+  harnesses: z.unknown().optional(),
+});
 
 const piCapabilityConfiguredPayloadSchema = z.object({
   capabilityId: z.literal("pi"),

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/upload.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/upload.ts
@@ -9,12 +9,10 @@ import { createUploadCapabilityFiles } from "@/fragno/backoffice-capabilities/ca
 
 const uploadProviderSchema = z.enum(["database", "r2", "r2-binding"]);
 
-export const uploadConfigureInputSchema = z
-  .object({
-    provider: uploadProviderSchema.optional(),
-    defaultProvider: uploadProviderSchema.optional(),
-  })
-  .passthrough();
+export const uploadConfigureInputSchema = z.looseObject({
+  provider: uploadProviderSchema.optional(),
+  defaultProvider: uploadProviderSchema.optional(),
+});
 
 const uploadCapabilityConfiguredPayloadSchema = z.object({
   capabilityId: z.literal("upload"),

--- a/apps/backoffice/app/routes.ts
+++ b/apps/backoffice/app/routes.ts
@@ -45,6 +45,131 @@ export default [
         "automations/:orgId/claims/complete",
         "routes/backoffice/automations/claims-complete.tsx",
       ),
+      route(
+        "automations/:scopeKind/:scopeId/integrations/telegram/attachment-download",
+        "routes/backoffice/connections/telegram/attachment-download.ts",
+        { id: "scoped-integrations/telegram/attachment-download" },
+      ),
+      route(
+        "automations/:scopeKind/:scopeId/integrations/telegram",
+        "routes/backoffice/connections/telegram/organisation-layout.tsx",
+        { id: "scoped-integrations/telegram/layout" },
+        [
+          index("routes/backoffice/connections/telegram/organisation-index.tsx", {
+            id: "scoped-integrations/telegram/index",
+          }),
+          route("configuration", "routes/backoffice/connections/telegram/configuration.tsx", {
+            id: "scoped-integrations/telegram/configuration",
+          }),
+          route(
+            "messages",
+            "routes/backoffice/connections/telegram/messages.tsx",
+            { id: "scoped-integrations/telegram/messages" },
+            [
+              index("routes/backoffice/connections/telegram/messages-index.tsx", {
+                id: "scoped-integrations/telegram/messages-index",
+              }),
+              route(":chatId", "routes/backoffice/connections/telegram/message-thread.tsx", {
+                id: "scoped-integrations/telegram/message-thread",
+              }),
+            ],
+          ),
+        ],
+      ),
+      route(
+        "automations/:scopeKind/:scopeId/integrations/resend",
+        "routes/backoffice/connections/resend/organisation-layout.tsx",
+        { id: "scoped-integrations/resend/layout" },
+        [
+          route("configuration", "routes/backoffice/connections/resend/configuration.tsx", {
+            id: "scoped-integrations/resend/configuration",
+          }),
+          route(
+            "domains",
+            "routes/backoffice/connections/resend/domains.tsx",
+            { id: "scoped-integrations/resend/domains" },
+            [
+              index("routes/backoffice/connections/resend/domains-index.tsx", {
+                id: "scoped-integrations/resend/domains-index",
+              }),
+              route(":domainId", "routes/backoffice/connections/resend/domain-detail.tsx", {
+                id: "scoped-integrations/resend/domain-detail",
+              }),
+            ],
+          ),
+          route(
+            "threads",
+            "routes/backoffice/connections/resend/threads.tsx",
+            { id: "scoped-integrations/resend/threads" },
+            [
+              index("routes/backoffice/connections/resend/threads-index.tsx", {
+                id: "scoped-integrations/resend/threads-index",
+              }),
+              route("start", "routes/backoffice/connections/resend/thread-start.tsx", {
+                id: "scoped-integrations/resend/thread-start",
+              }),
+              route(":threadId", "routes/backoffice/connections/resend/thread-detail.tsx", {
+                id: "scoped-integrations/resend/thread-detail",
+              }),
+            ],
+          ),
+          route(
+            "incoming",
+            "routes/backoffice/connections/resend/incoming.tsx",
+            { id: "scoped-integrations/resend/incoming" },
+            [
+              index("routes/backoffice/connections/resend/incoming-index.tsx", {
+                id: "scoped-integrations/resend/incoming-index",
+              }),
+              route(":emailId", "routes/backoffice/connections/resend/incoming-detail.tsx", {
+                id: "scoped-integrations/resend/incoming-detail",
+              }),
+            ],
+          ),
+          route(
+            "outgoing",
+            "routes/backoffice/connections/resend/outbox.tsx",
+            { id: "scoped-integrations/resend/outbox" },
+            [
+              index("routes/backoffice/connections/resend/outbox-index.tsx", {
+                id: "scoped-integrations/resend/outbox-index",
+              }),
+              route("send", "routes/backoffice/connections/resend/send.tsx", {
+                id: "scoped-integrations/resend/send",
+              }),
+              route(":emailId", "routes/backoffice/connections/resend/outbox-detail.tsx", {
+                id: "scoped-integrations/resend/outbox-detail",
+              }),
+            ],
+          ),
+        ],
+      ),
+      route(
+        "automations/:scopeKind/:scopeId/integrations/github",
+        "routes/backoffice/connections/github/organisation-layout.tsx",
+        { id: "scoped-integrations/github/layout" },
+        [
+          index("routes/backoffice/connections/github/organisation-index.tsx", {
+            id: "scoped-integrations/github/index",
+          }),
+          route("configuration", "routes/backoffice/connections/github/configuration.tsx", {
+            id: "scoped-integrations/github/configuration",
+          }),
+          route(
+            "repositories",
+            "routes/backoffice/connections/github/repositories.tsx",
+            { id: "scoped-integrations/github/repositories" },
+            [
+              index("routes/backoffice/connections/github/repositories-index.tsx", {
+                id: "scoped-integrations/github/repositories-index",
+              }),
+              route(":repoId", "routes/backoffice/connections/github/repository-detail.tsx", {
+                id: "scoped-integrations/github/repository-detail",
+              }),
+            ],
+          ),
+        ],
+      ),
       route("automations/:scopeKind/:scopeId", "routes/backoffice/automations/scope-layout.tsx", [
         index("routes/backoffice/automations/scope-index.tsx"),
         route("terminal", "routes/backoffice/automations/terminal.tsx"),
@@ -52,6 +177,7 @@ export default [
         route("router", "routes/backoffice/automations/router.tsx"),
         route("store", "routes/backoffice/automations/store.tsx"),
         route("api", "routes/backoffice/automations/api.tsx"),
+        route("integrations", "routes/backoffice/automations/integrations.tsx"),
         route("events", "routes/backoffice/automations/events.tsx"),
         route("events-catalog", "routes/backoffice/automations/events-catalog.tsx"),
         route("mcp", "routes/backoffice/automations/mcp.tsx"),
@@ -60,31 +186,6 @@ export default [
 
       route("environments", "routes/backoffice/environments/index.tsx"),
       route("environments/workers", "routes/backoffice/environments/workers.tsx"),
-      route(
-        "connections/resend/:orgId",
-        "routes/backoffice/connections/resend/organisation-layout.tsx",
-        [
-          route("configuration", "routes/backoffice/connections/resend/configuration.tsx"),
-          route("domains", "routes/backoffice/connections/resend/domains.tsx", [
-            index("routes/backoffice/connections/resend/domains-index.tsx"),
-            route(":domainId", "routes/backoffice/connections/resend/domain-detail.tsx"),
-          ]),
-          route("threads", "routes/backoffice/connections/resend/threads.tsx", [
-            index("routes/backoffice/connections/resend/threads-index.tsx"),
-            route("start", "routes/backoffice/connections/resend/thread-start.tsx"),
-            route(":threadId", "routes/backoffice/connections/resend/thread-detail.tsx"),
-          ]),
-          route("incoming", "routes/backoffice/connections/resend/incoming.tsx", [
-            index("routes/backoffice/connections/resend/incoming-index.tsx"),
-            route(":emailId", "routes/backoffice/connections/resend/incoming-detail.tsx"),
-          ]),
-          route("outgoing", "routes/backoffice/connections/resend/outbox.tsx", [
-            index("routes/backoffice/connections/resend/outbox-index.tsx"),
-            route("send", "routes/backoffice/connections/resend/send.tsx"),
-            route(":emailId", "routes/backoffice/connections/resend/outbox-detail.tsx"),
-          ]),
-        ],
-      ),
       route(
         "connections/reson8/:orgId",
         "routes/backoffice/connections/reson8/organisation-layout.tsx",
@@ -100,34 +201,6 @@ export default [
         route("configuration", "routes/backoffice/connections/mcp/configuration.tsx"),
         route("oauth-complete", "routes/backoffice/connections/mcp/oauth-complete.tsx"),
       ]),
-      route(
-        "connections/telegram/:orgId/attachment-download",
-        "routes/backoffice/connections/telegram/attachment-download.ts",
-      ),
-      route(
-        "connections/telegram/:orgId",
-        "routes/backoffice/connections/telegram/organisation-layout.tsx",
-        [
-          index("routes/backoffice/connections/telegram/organisation-index.tsx"),
-          route("configuration", "routes/backoffice/connections/telegram/configuration.tsx"),
-          route("messages", "routes/backoffice/connections/telegram/messages.tsx", [
-            index("routes/backoffice/connections/telegram/messages-index.tsx"),
-            route(":chatId", "routes/backoffice/connections/telegram/message-thread.tsx"),
-          ]),
-        ],
-      ),
-      route(
-        "connections/github/:orgId",
-        "routes/backoffice/connections/github/organisation-layout.tsx",
-        [
-          index("routes/backoffice/connections/github/organisation-index.tsx"),
-          route("configuration", "routes/backoffice/connections/github/configuration.tsx"),
-          route("repositories", "routes/backoffice/connections/github/repositories.tsx", [
-            index("routes/backoffice/connections/github/repositories-index.tsx"),
-            route(":repoId", "routes/backoffice/connections/github/repository-detail.tsx"),
-          ]),
-        ],
-      ),
       route(
         "connections/upload/:orgId",
         "routes/backoffice/connections/upload/organisation-layout.tsx",
@@ -211,7 +284,7 @@ export default [
   ...prefix("api", [
     route("auth/*", "routes/api/auth.ts"),
     route("cloudflare/:orgId/*", "routes/api/cloudflare.ts"),
-    route("resend/:orgId/*", "routes/api/resend.ts"),
+    route("resend/:scopeSegment/*", "routes/api/resend.ts"),
     route("reson8/:orgId/*", "routes/api/reson8.ts"),
     route("mcp/:scopeSegment/*", "routes/api/mcp.ts"),
     route("http/:scopeSegment/*", "routes/api/api.ts"),

--- a/apps/backoffice/app/routes/api/resend.ts
+++ b/apps/backoffice/app/routes/api/resend.ts
@@ -1,37 +1,58 @@
-import { getResendDurableObject } from "@/worker-runtime/durable-objects";
+import { backofficeContextScopeFromSinglePathSegment } from "@/backoffice-runtime/scope-codec";
+import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
 import type { Route } from "./+types/resend";
 
 const forwardToResend = async (
   request: Request,
   context: Route.LoaderArgs["context"],
-  orgId: string | undefined,
+  scopeSegment: string | undefined,
 ) => {
-  if (!orgId) {
-    return new Response("Missing organisation id", { status: 400 });
+  if (!scopeSegment) {
+    return new Response("Missing Resend scope", { status: 400 });
   }
 
-  const resendDo = getResendDurableObject(context, orgId);
+  let scope: { kind: "system" } | { kind: "org"; orgId: string };
+  if (scopeSegment === "admin") {
+    scope = { kind: "system" };
+  } else {
+    try {
+      const resolvedScope = backofficeContextScopeFromSinglePathSegment(scopeSegment);
+      if (resolvedScope.kind !== "org") {
+        return new Response("Invalid Resend scope", { status: 404 });
+      }
+      scope = resolvedScope;
+    } catch {
+      return new Response("Invalid Resend scope", { status: 404 });
+    }
+  }
+
+  const objects = context.get(BackofficeWorkerContext).runtime.objects;
+  const resendStorageScope = scope.kind === "system" ? "admin" : scope.orgId;
+  const resendDo =
+    scope.kind === "system"
+      ? objects.resend.singleton()
+      : objects.resend.forOrg(resendStorageScope);
   const url = new URL(request.url);
-  const prefix = `/api/resend/${orgId}`;
+  const prefix = `/api/resend/${scopeSegment}`;
   if (url.pathname.startsWith(prefix)) {
     const suffix = url.pathname.slice(prefix.length);
     url.pathname = `/api/resend${suffix}`;
   }
-  url.searchParams.set("orgId", orgId);
+  url.searchParams.set("orgId", resendStorageScope);
 
   const proxyRequest = new Request(url.toString(), request);
   return resendDo.fetch(proxyRequest);
 };
 
 /**
- * Catch-all route that forwards all /api/resend/:orgId/* requests to the Resend Durable Object.
- * The org-specific prefix is stripped before the request reaches the fragment.
+ * Catch-all route that forwards all /api/resend/:scopeSegment/* requests to the Resend Durable Object.
+ * The scope-specific prefix is stripped before the request reaches the fragment.
  */
 export async function loader({ request, context, params }: Route.LoaderArgs) {
-  return forwardToResend(request, context, params.orgId);
+  return forwardToResend(request, context, params.scopeSegment);
 }
 
 export async function action({ request, context, params }: Route.ActionArgs) {
-  return forwardToResend(request, context, params.orgId);
+  return forwardToResend(request, context, params.scopeSegment);
 }

--- a/apps/backoffice/app/routes/backoffice/automations/integrations.tsx
+++ b/apps/backoffice/app/routes/backoffice/automations/integrations.tsx
@@ -1,0 +1,97 @@
+import { Link, useOutletContext } from "react-router";
+
+import { backofficeConnectionCatalog } from "@/fragno/backoffice-capabilities/backoffice-capabilities";
+
+import { integrationBasePath } from "../integrations/scope";
+import type { AutomationLayoutContext } from "./shared";
+
+const SCOPED_INTEGRATION_IDS = ["telegram", "resend", "github"] as const;
+
+type ScopedIntegrationId = (typeof SCOPED_INTEGRATION_IDS)[number];
+
+const SCOPE_SUPPORT: Record<
+  ScopedIntegrationId,
+  readonly AutomationLayoutContext["selectedScope"]["kind"][]
+> = {
+  telegram: ["system", "org", "project", "user"],
+  resend: ["system", "org"],
+  github: ["org"],
+};
+
+export function meta() {
+  return [
+    { title: "Integrations" },
+    { name: "description", content: "Manage scoped backoffice integrations." },
+  ];
+}
+
+export default function BackofficeAutomationIntegrations() {
+  const { selectedScope } = useOutletContext<AutomationLayoutContext>();
+  const integrations = backofficeConnectionCatalog.filter((connection) =>
+    SCOPED_INTEGRATION_IDS.includes(connection.id as ScopedIntegrationId),
+  );
+
+  return (
+    <div className="space-y-4">
+      <section className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-4">
+        <p className="text-[10px] tracking-[0.24em] text-[var(--bo-muted-2)] uppercase">
+          Integrations
+        </p>
+        <h2 className="mt-2 text-2xl font-semibold text-[var(--bo-fg)]">
+          Available for {selectedScope.label}
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm text-[var(--bo-muted)]">
+          Configure the channels available to this scope. GitHub is intentionally limited to
+          organisation scopes; Resend is available for organisations and the admin singleton;
+          Telegram can be configured on any scope.
+        </p>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-2">
+        {integrations.map((integration) => {
+          const id = integration.id as ScopedIntegrationId;
+          const supported = SCOPE_SUPPORT[id].includes(selectedScope.kind);
+          const managePath = supported
+            ? integrationBasePath(selectedScope, integration.routeSegment ?? id)
+            : null;
+
+          return (
+            <div
+              key={integration.id}
+              className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-4"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-[10px] tracking-[0.24em] text-[var(--bo-muted-2)] uppercase">
+                    {integration.configurable ? "Configurable" : "Environment"}
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold text-[var(--bo-fg)]">
+                    {integration.label}
+                  </h3>
+                </div>
+                <span className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-2 py-1 text-[10px] tracking-[0.22em] text-[var(--bo-muted)] uppercase">
+                  {supported ? "Available" : "Unavailable"}
+                </span>
+              </div>
+              <p className="mt-4 text-sm text-[var(--bo-muted)]">{integration.description}</p>
+              <div className="mt-4">
+                {managePath ? (
+                  <Link
+                    to={managePath}
+                    className="inline-flex border border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-accent-fg)] uppercase transition-colors hover:border-[color:var(--bo-accent-strong)]"
+                  >
+                    Manage
+                  </Link>
+                ) : (
+                  <span className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted-2)] uppercase">
+                    Not on this scope
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/apps/backoffice/app/routes/backoffice/automations/scope-layout.tsx
+++ b/apps/backoffice/app/routes/backoffice/automations/scope-layout.tsx
@@ -156,6 +156,9 @@ const currentTabFromPath = (pathname: string): AutomationTab => {
   if (segments.includes("mcp")) {
     return "mcp";
   }
+  if (segments.includes("integrations")) {
+    return "integrations";
+  }
   if (segments.includes("router")) {
     return "router";
   }

--- a/apps/backoffice/app/routes/backoffice/automations/scope.ts
+++ b/apps/backoffice/app/routes/backoffice/automations/scope.ts
@@ -69,6 +69,7 @@ export type AutomationScopeTab =
   | "api"
   | "events"
   | "events-catalog"
+  | "integrations"
   | "mcp"
   | "sandboxes";
 

--- a/apps/backoffice/app/routes/backoffice/automations/shared.tsx
+++ b/apps/backoffice/app/routes/backoffice/automations/shared.tsx
@@ -154,6 +154,7 @@ export type AutomationTab =
   | "api"
   | "events"
   | "events-catalog"
+  | "integrations"
   | "mcp"
   | "sandboxes";
 
@@ -337,6 +338,11 @@ export function AutomationTabs({
       id: "api" as const,
       label: "API",
       to: automationScopeTabPath(selectedScope, "api"),
+    },
+    {
+      id: "integrations" as const,
+      label: "Integrations",
+      to: automationScopeTabPath(selectedScope, "integrations"),
     },
     {
       id: "mcp" as const,

--- a/apps/backoffice/app/routes/backoffice/connections/github/configuration.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/github/configuration.tsx
@@ -17,6 +17,10 @@ import {
 } from "@/worker-runtime/durable-objects";
 
 import { buildBackofficeLoginPath } from "../../auth-navigation";
+import {
+  resolveAuthenticatedIntegrationContext,
+  resolveOrganizationScopeFromRouteParams,
+} from "../../integrations/scope";
 import type { Route } from "./+types/configuration";
 import {
   fetchGitHubAdminConfig,
@@ -159,9 +163,8 @@ const readInstallNotice = (requestUrl: URL): InstallFlowNotice => {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const organizationScope = resolveOrganizationScopeFromRouteParams(params);
+  const organizationId = organizationScope.organizationId;
 
   const requestUrl = new URL(request.url);
   const origin = requestUrl.origin;
@@ -176,7 +179,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   if (callbackState || callbackInstallationId || setupAction) {
     if (!callbackState || !callbackInstallationId) {
       console.warn("GitHub install callback missing required parameters", {
-        orgId: params.orgId,
+        organizationId: organizationId,
         setupAction,
         hasState: Boolean(callbackState),
         hasInstallationId: Boolean(callbackInstallationId),
@@ -186,7 +189,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
     if (!isValidInstallationId(callbackInstallationId)) {
       console.warn("GitHub install callback provided invalid installation id", {
-        orgId: params.orgId,
+        organizationId: organizationId,
         installationId: callbackInstallationId,
         state: toStatePreview(callbackState),
       });
@@ -198,7 +201,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       const url = new URL(request.url);
       return redirect(buildBackofficeLoginPath(`${url.pathname}${url.search}`));
     }
-    const memberEntry = me.organizations.find((entry) => entry.organization.id === params.orgId);
+    const memberEntry = me.organizations.find((entry) => entry.organization.id === organizationId);
     if (!memberEntry) {
       throw new Response("Not Found", { status: 404 });
     }
@@ -213,7 +216,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
       if (!consumed.ok) {
         console.warn("GitHub install callback state validation failed", {
-          orgId: params.orgId,
+          organizationId: organizationId,
           code: consumed.code,
           message: consumed.message,
           installationId: callbackInstallationId,
@@ -229,9 +232,9 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
         return redirect(buildConfigurationRedirect(request.url, "invalid_state"));
       }
 
-      if (consumed.orgId !== params.orgId) {
+      if (consumed.orgId !== organizationId) {
         console.warn("GitHub install callback resolved to a different organisation", {
-          requestedOrgId: params.orgId,
+          requestedOrgId: organizationId,
           resolvedOrgId: consumed.orgId,
           installationId: callbackInstallationId,
           state: toStatePreview(callbackState),
@@ -242,11 +245,11 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
       const mappingResult = await githubWebhookRouterDo.setInstallationOrg(
         callbackInstallationId,
-        params.orgId,
+        organizationId,
       );
       if (!mappingResult.ok) {
         console.error("GitHub install callback failed to map installation to organisation", {
-          orgId: params.orgId,
+          organizationId: organizationId,
           installationId: callbackInstallationId,
           state: toStatePreview(callbackState),
           userId: me.user.id,
@@ -260,17 +263,17 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       const syncResult = await syncGitHubInstallation(
         request,
         context,
-        params.orgId,
+        organizationId,
         callbackInstallationId,
       );
       if (syncResult.error || !syncResult.result) {
         console.warn("GitHub install callback mapped installation but sync failed", {
-          orgId: params.orgId,
+          organizationId: organizationId,
           installationId: callbackInstallationId,
           error: syncResult.error,
         });
 
-        const githubDo = getGitHubDurableObject(context, params.orgId);
+        const githubDo = getGitHubDurableObject(context, organizationId);
         await githubDo.redeliverFailedInstallationWebhooks(callbackInstallationId);
 
         return redirect(buildConfigurationRedirect(request.url, "installed_pending_webhook"));
@@ -279,7 +282,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       return redirect(buildConfigurationRedirect(request.url, "installed_synced"));
     } catch (error) {
       console.error("GitHub install callback processing threw", {
-        orgId: params.orgId,
+        organizationId: organizationId,
         installationId: callbackInstallationId,
         state: toStatePreview(callbackState),
         error,
@@ -289,7 +292,11 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   const installNotice = readInstallNotice(requestUrl);
-  const { configState, configError } = await fetchGitHubAdminConfig(context, params.orgId, origin);
+  const { configState, configError } = await fetchGitHubAdminConfig(
+    context,
+    organizationId,
+    origin,
+  );
   if (configError) {
     return {
       configState,
@@ -313,7 +320,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const { installations, installationsError } = await fetchGitHubInstallations(
     request,
     context,
-    params.orgId,
+    organizationId,
     "active",
   );
   if (installationsError) {
@@ -331,7 +338,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       const reposResult = await fetchGitHubInstallationRepos(
         request,
         context,
-        params.orgId!,
+        organizationId,
         installation.id,
       );
 
@@ -359,31 +366,31 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params, context }: Route.ActionArgs) {
-  if (!params.orgId) {
+  const integration = await resolveAuthenticatedIntegrationContext({
+    request,
+    context,
+    params,
+    integration: "github",
+    allowedScopes: ["org"],
+  });
+  if (integration.scope.kind !== "org") {
     throw new Response("Not Found", { status: 404 });
   }
+  const organizationId = integration.scope.orgId;
+  const { me } = integration;
 
   const formData = await request.formData();
   const intent = getStringValue(formData, "intent");
 
   if (intent === "start-installation") {
-    const me = await getAuthMe(request, context);
-    if (!me?.user) {
-      return {
-        ok: false,
-        message: "You must be signed in before starting installation.",
-      } satisfies GitHubConfigurationActionData;
-    }
-    const memberEntry = me.organizations.find((entry) => entry.organization.id === params.orgId);
-    if (!memberEntry) {
-      throw new Response("Not Found", { status: 404 });
-    }
-
     const githubWebhookRouterDo = getGitHubWebhookRouterDurableObject(context);
-    const install = await githubWebhookRouterDo.createInstallStatefulUrl(me.user.id, params.orgId);
+    const install = await githubWebhookRouterDo.createInstallStatefulUrl(
+      me.user.id,
+      organizationId,
+    );
     if (!install.ok) {
       console.error("Failed to create GitHub install stateful URL", {
-        orgId: params.orgId,
+        organizationId: organizationId,
         userId: me.user.id,
         message: install.message,
         missing: install.missing,
@@ -401,21 +408,9 @@ export async function action({ request, params, context }: Route.ActionArgs) {
   }
 
   if (intent === "connect-existing-installation") {
-    const me = await getAuthMe(request, context);
-    if (!me?.user) {
-      return {
-        ok: false,
-        message: "You must be signed in before restoring an installation.",
-      } satisfies GitHubConfigurationActionData;
-    }
-    const memberEntry = me.organizations.find((entry) => entry.organization.id === params.orgId);
-    if (!memberEntry) {
-      throw new Response("Not Found", { status: 404 });
-    }
-
     const requestUrl = new URL(request.url);
     const returnTo = `${requestUrl.pathname}${requestUrl.search}`;
-    const claim = await startGitHubOAuth(request, context, params.orgId, {
+    const claim = await startGitHubOAuth(request, context, organizationId, {
       subjectId: me.user.id,
       returnTo,
     });
@@ -431,13 +426,13 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       await githubWebhookRouterDo.storeInstallationClaimState({
         state: claim.result.state,
         userId: me.user.id,
-        orgId: params.orgId,
+        orgId: integration.scope.orgId,
         returnTo,
         expiresAt: new Date(claim.result.expiresAt).getTime(),
       });
     } catch (error) {
       console.warn("Failed to store GitHub installation claim state", {
-        orgId: params.orgId,
+        organizationId: organizationId,
         userId: me.user.id,
         state: toStatePreview(claim.result.state),
         error,
@@ -461,13 +456,13 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       } satisfies GitHubConfigurationActionData;
     }
 
-    const result = await linkGitHubRepository(request, context, params.orgId, {
+    const result = await linkGitHubRepository(request, context, organizationId, {
       installationId,
       repoId,
     });
     if (result.error || !result.result) {
       console.warn("Failed to link GitHub repository", {
-        orgId: params.orgId,
+        organizationId: organizationId,
         installationId,
         repoId,
         error: result.error ?? "Failed to link repository.",
@@ -493,12 +488,12 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       } satisfies GitHubConfigurationActionData;
     }
 
-    const result = await unlinkGitHubRepository(request, context, params.orgId, {
+    const result = await unlinkGitHubRepository(request, context, organizationId, {
       repoId,
     });
     if (result.error || !result.ok) {
       console.warn("Failed to unlink GitHub repository", {
-        orgId: params.orgId,
+        organizationId: organizationId,
         repoId,
         error: result.error ?? "Failed to unlink repository.",
       });

--- a/apps/backoffice/app/routes/backoffice/connections/github/data.ts
+++ b/apps/backoffice/app/routes/backoffice/connections/github/data.ts
@@ -133,17 +133,17 @@ type GitHubOAuthCompleteResult = {
 const createGitHubRouteCaller = (
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
 ) => {
-  const githubDo = getGitHubDurableObject(context, orgId);
+  const githubDo = getGitHubDurableObject(context, organizationId);
   return createRouteCaller<GitHubFragment>({
     baseUrl: request.url,
     mountRoute: "/api/github",
     baseHeaders: request.headers,
     fetch: async (outboundRequest) => {
-      await githubDo.ensureAdminConfig(orgId);
+      await githubDo.ensureAdminConfig(organizationId);
       const url = new URL(outboundRequest.url);
-      url.searchParams.set("orgId", orgId);
+      url.searchParams.set("orgId", organizationId);
       return await githubDo.fetch(new Request(url.toString(), outboundRequest));
     },
   });
@@ -193,11 +193,11 @@ export async function fetchGitHubAdminConfig(
 export async function fetchGitHubInstallations(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
   status?: "active" | "suspended" | "deleted",
 ): Promise<GitHubInstallationsResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const query = status ? { status } : undefined;
     const response = await callRoute("GET", "/installations", { query });
 
@@ -230,12 +230,12 @@ export async function fetchGitHubInstallations(
 export async function fetchGitHubInstallationRepos(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
   installationId: string,
   options: { linkedOnly?: boolean } = {},
 ): Promise<GitHubReposResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const query: Record<string, string> = {};
     if (options.linkedOnly) {
       query.linkedOnly = "true";
@@ -255,10 +255,10 @@ export async function fetchGitHubInstallationRepos(
 export async function fetchGitHubLinkedRepositories(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
 ): Promise<GitHubReposResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const response = await callRoute("GET", "/repositories/linked");
 
     return gitHubReposResultFromRouteResponse(response, "Failed to fetch linked repositories");
@@ -270,7 +270,7 @@ export async function fetchGitHubLinkedRepositories(
 export async function fetchGitHubPulls(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
   options: {
     owner: string;
     repo: string;
@@ -280,7 +280,7 @@ export async function fetchGitHubPulls(
   },
 ): Promise<GitHubPullsResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const query: Record<string, string> = {};
     if (options.state) {
       query.state = options.state;
@@ -331,11 +331,11 @@ export async function fetchGitHubPulls(
 export async function linkGitHubRepository(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
   payload: { installationId: string; repoId: string; linkKey?: string },
 ): Promise<GitHubLinkResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const response = await callRoute("POST", "/repositories/link", { body: payload });
 
     return nullableDataActionResultFromRouteResponse<GitHubLinkResponse>({
@@ -350,11 +350,11 @@ export async function linkGitHubRepository(
 export async function syncGitHubInstallation(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
   installationId: string,
 ): Promise<GitHubSyncResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const response = await callRoute("POST", "/installations/:installationId/sync", {
       pathParams: { installationId },
     });
@@ -375,11 +375,11 @@ export async function syncGitHubInstallation(
 export async function startGitHubOAuth(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
   payload: { subjectId: string; returnTo?: string },
 ): Promise<GitHubOAuthStartResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const response = await callRoute("POST", "/oauth/start", { body: payload });
     return nullableDataActionResultFromRouteResponse({
       response,
@@ -393,11 +393,11 @@ export async function startGitHubOAuth(
 export async function completeGitHubOAuth(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
   payload: { subjectId: string; state: string; code: string },
 ): Promise<GitHubOAuthCompleteResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const response = await callRoute("POST", "/oauth/complete", { body: payload });
     return nullableDataActionResultFromRouteResponse<GitHubOAuthComplete>({
       response,
@@ -411,11 +411,11 @@ export async function completeGitHubOAuth(
 export async function unlinkGitHubRepository(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  organizationId: string,
   payload: { repoId: string; linkKey?: string },
 ): Promise<GitHubUnlinkResult> {
   try {
-    const callRoute = createGitHubRouteCaller(request, context, orgId);
+    const callRoute = createGitHubRouteCaller(request, context, organizationId);
     const response = await callRoute("POST", "/repositories/unlink", { body: payload });
 
     return booleanActionResultFromRouteResponse({

--- a/apps/backoffice/app/routes/backoffice/connections/github/index.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/github/index.tsx
@@ -21,13 +21,15 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
   const activeOrganizationId = me.activeOrganization?.organization.id;
   const fallbackOrganizationId = me.organizations[0]?.organization.id;
-  const orgId = activeOrganizationId ?? fallbackOrganizationId;
+  const organizationId = activeOrganizationId ?? fallbackOrganizationId;
 
-  if (!orgId) {
+  if (!organizationId) {
     return redirect("/backoffice/connections");
   }
 
-  return redirect(`/backoffice/connections/github/${encodeURIComponent(orgId)}`);
+  return redirect(
+    `/backoffice/automations/org/${encodeURIComponent(organizationId)}/integrations/github`,
+  );
 }
 
 export default function BackofficeConnectionsGitHub() {

--- a/apps/backoffice/app/routes/backoffice/connections/github/organisation-index.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/github/organisation-index.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "react-router";
 
+import { resolveOrganizationScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/organisation-index";
 import {
   fetchGitHubAdminConfig,
@@ -8,20 +9,19 @@ import {
 } from "./data";
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const organizationScope = resolveOrganizationScopeFromRouteParams(params);
+  const organizationId = organizationScope.organizationId;
 
   const origin = new URL(request.url).origin;
-  const { configState } = await fetchGitHubAdminConfig(context, params.orgId, origin);
+  const { configState } = await fetchGitHubAdminConfig(context, organizationId, origin);
   const linkedRepositories = configState?.configured
-    ? await fetchGitHubLinkedRepositories(request, context, params.orgId)
+    ? await fetchGitHubLinkedRepositories(request, context, organizationId)
     : null;
   const target =
     linkedRepositories && gitHubRepositoriesRouteAvailable(linkedRepositories)
       ? "repositories"
       : "configuration";
-  return redirect(`/backoffice/connections/github/${params.orgId}/${target}`);
+  return redirect(`${new URL(request.url).pathname.replace(/\/+$/u, "")}/${target}`);
 }
 
 export default function BackofficeOrganisationGitHubIndex() {

--- a/apps/backoffice/app/routes/backoffice/connections/github/organisation-layout.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/github/organisation-layout.tsx
@@ -4,7 +4,11 @@ import { Outlet } from "react-router";
 import { getAuthMe } from "@/fragno/auth/auth-server";
 
 import { buildBackofficeLoginPath } from "../../auth-navigation";
-import { throwOrganisationNotFound } from "../../route-errors";
+import {
+  createIntegrationScopeSwitchOptions,
+  organizationIdFromScope,
+  resolveIntegrationContext,
+} from "../../integrations/scope";
 import type { Route } from "./+types/organisation-layout";
 import {
   fetchGitHubAdminConfig,
@@ -20,10 +24,6 @@ import {
 } from "./shared";
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const me = await getAuthMe(request, context);
   if (!me?.user) {
     const url = new URL(request.url);
@@ -33,25 +33,51 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     );
   }
 
-  const organisation =
-    me.organizations.find((entry) => entry.organization.id === params.orgId)?.organization ?? null;
-  if (!organisation) {
-    throwOrganisationNotFound(params.orgId);
+  const integration = resolveIntegrationContext({
+    params,
+    me,
+    integration: "github",
+    allowedScopes: ["org"],
+  });
+  const organizationId = organizationIdFromScope(integration.scope);
+  if (!organizationId) {
+    throw new Response("Not Found", { status: 404 });
   }
+  const organisation =
+    me.organizations.find((entry) => entry.organization.id === organizationId)?.organization ??
+    null;
+
+  const projectOrgId =
+    organizationId ??
+    me.activeOrganization?.organization.id ??
+    me.organizations[0]?.organization.id;
+  const scopeOptions = createIntegrationScopeSwitchOptions({
+    me,
+    projects: [],
+    projectOrgId: projectOrgId ?? "",
+    integration: "github",
+    allowedScopes: ["org"],
+  });
 
   const origin = new URL(request.url).origin;
-  const { configState, configError } = await fetchGitHubAdminConfig(context, params.orgId, origin);
+  const { configState, configError } = await fetchGitHubAdminConfig(
+    context,
+    organizationId,
+    origin,
+  );
   const linkedRepositories = configState?.configured
-    ? await fetchGitHubLinkedRepositories(request, context, params.orgId)
+    ? await fetchGitHubLinkedRepositories(request, context, organizationId)
     : null;
   const repositoriesEnabled = linkedRepositories
     ? gitHubRepositoriesRouteAvailable(linkedRepositories)
     : false;
 
   return {
-    orgId: params.orgId,
+    ...integration,
+    organizationId,
     origin,
     organisation,
+    scopeOptions,
     configState,
     configError,
     repositoriesEnabled,
@@ -59,8 +85,8 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 }
 
 export function meta({ data }: Route.MetaArgs) {
-  const orgId = data?.orgId ?? "organisation";
-  return [{ title: `GitHub Setup · ${orgId}` }];
+  const label = data?.label ?? "organisation";
+  return [{ title: `GitHub Setup · ${label}` }];
 }
 
 export function ErrorBoundary({ error, params }: Route.ErrorBoundaryProps) {
@@ -72,9 +98,14 @@ export default function BackofficeOrganisationGitHubLayout({
   matches,
 }: Route.ComponentProps) {
   const {
-    orgId,
+    organizationId,
     origin,
     organisation,
+    label,
+    basePath,
+    integrationsPath,
+    scopeSegment,
+    scopeOptions,
     configState: initialConfigState,
     configError: initialConfigError,
     repositoriesEnabled,
@@ -86,7 +117,7 @@ export default function BackofficeOrganisationGitHubLayout({
   useEffect(() => {
     setConfigState(initialConfigState);
     setConfigError(initialConfigError);
-  }, [initialConfigError, initialConfigState, orgId]);
+  }, [initialConfigError, initialConfigState, scopeSegment]);
 
   let activeTab: GitHubTab = "configuration";
   const currentPath = (matches[matches.length - 1]?.pathname || "").replace(/\/+$/, "");
@@ -99,13 +130,24 @@ export default function BackofficeOrganisationGitHubLayout({
 
   return (
     <div className="space-y-4">
-      <GitHubHeader orgId={orgId} organisationName={organisation?.name ?? orgId} />
-      <GitHubTabs orgId={orgId} activeTab={activeTab} repositoriesEnabled={repositoriesEnabled} />
+      <GitHubHeader
+        organisationName={organisation?.name ?? label}
+        integrationsPath={integrationsPath}
+        scopeOptions={scopeOptions}
+      />
+      <GitHubTabs
+        basePath={basePath}
+        activeTab={activeTab}
+        repositoriesEnabled={repositoriesEnabled}
+      />
       <Outlet
         context={{
-          orgId,
+          organizationId,
           origin,
           organisation,
+          basePath,
+          integrationsPath,
+          scopeOptions,
           configState,
           configLoading,
           configError,

--- a/apps/backoffice/app/routes/backoffice/connections/github/repositories.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/github/repositories.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet, redirect, useLoaderData, useOutletContext, useParams } from "react-router";
 
+import { resolveOrganizationScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/repositories";
 import {
   fetchGitHubAdminConfig,
@@ -21,12 +22,15 @@ export type GitHubRepositoriesOutletContext = {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const organizationScope = resolveOrganizationScopeFromRouteParams(params);
+  const organizationId = organizationScope.organizationId;
 
   const origin = new URL(request.url).origin;
-  const { configState, configError } = await fetchGitHubAdminConfig(context, params.orgId, origin);
+  const { configState, configError } = await fetchGitHubAdminConfig(
+    context,
+    organizationId,
+    origin,
+  );
   if (configError) {
     return {
       configError,
@@ -36,12 +40,20 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   if (!configState?.configured) {
-    return redirect(`/backoffice/connections/github/${params.orgId}/configuration`);
+    return redirect(
+      `${new URL(request.url).pathname.replace(/\/(?:repositories)(?:\/.*)?$/u, "")}/configuration`,
+    );
   }
 
-  const { repos, reposError } = await fetchGitHubLinkedRepositories(request, context, params.orgId);
+  const { repos, reposError } = await fetchGitHubLinkedRepositories(
+    request,
+    context,
+    organizationId,
+  );
   if (!reposError && repos.length === 0) {
-    return redirect(`/backoffice/connections/github/${params.orgId}/configuration`);
+    return redirect(
+      `${new URL(request.url).pathname.replace(/\/(?:repositories)(?:\/.*)?$/u, "")}/configuration`,
+    );
   }
 
   return {
@@ -53,10 +65,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
 export default function BackofficeOrganisationGitHubRepositories() {
   const { repos, configError, reposError } = useLoaderData<typeof loader>();
-  const { orgId } = useOutletContext<GitHubLayoutContext>();
+  const { basePath: integrationBasePath } = useOutletContext<GitHubLayoutContext>();
   const { repoId } = useParams();
   const selectedRepoId = repoId ?? null;
-  const basePath = `/backoffice/connections/github/${orgId}/repositories`;
+  const basePath = `${integrationBasePath}/repositories`;
   const isDetailRoute = Boolean(selectedRepoId);
 
   if (configError) {

--- a/apps/backoffice/app/routes/backoffice/connections/github/repository-detail.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/github/repository-detail.tsx
@@ -1,5 +1,6 @@
 import { Link, useLoaderData, useOutletContext, useParams } from "react-router";
 
+import { resolveOrganizationScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/repository-detail";
 import {
   fetchGitHubLinkedRepositories,
@@ -29,11 +30,13 @@ const asNumber = (value: unknown) =>
 const asBoolean = (value: unknown) => (typeof value === "boolean" ? value : null);
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId || !params.repoId) {
+  if (!params.repoId) {
     throw new Response("Not Found", { status: 404 });
   }
+  const organizationScope = resolveOrganizationScopeFromRouteParams(params);
+  const organizationId = organizationScope.organizationId;
 
-  const linkedResult = await fetchGitHubLinkedRepositories(request, context, params.orgId);
+  const linkedResult = await fetchGitHubLinkedRepositories(request, context, organizationId);
   if (linkedResult.reposError) {
     return {
       repo: null,
@@ -55,7 +58,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     } satisfies GitHubRepositoryDetailLoaderData;
   }
 
-  const pullsResult = await fetchGitHubPulls(request, context, params.orgId, {
+  const pullsResult = await fetchGitHubPulls(request, context, organizationId, {
     owner: repo.ownerLogin,
     repo: repo.name,
     state: "open",

--- a/apps/backoffice/app/routes/backoffice/connections/github/setup-callback.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/github/setup-callback.tsx
@@ -4,6 +4,7 @@ import { getAuthMe } from "@/fragno/auth/auth-server";
 import { getGitHubWebhookRouterDurableObject } from "@/worker-runtime/durable-objects";
 
 import { buildBackofficeLoginPath } from "../../auth-navigation";
+import { integrationBasePath, scopeToAutomationUiScope } from "../../integrations/scope";
 import type { Route } from "./+types/setup-callback";
 
 const CONNECTIONS_INDEX_PATH = "/backoffice/connections/github";
@@ -40,7 +41,8 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     return redirect(CONNECTIONS_INDEX_PATH);
   }
 
-  const targetPath = `/backoffice/connections/github/${encodeURIComponent(resolved.orgId)}/configuration`;
+  const scope = { kind: "org" as const, orgId: resolved.orgId };
+  const targetPath = `${integrationBasePath(scopeToAutomationUiScope(scope, me), "github")}/configuration`;
   const search = url.searchParams.toString();
   return redirect(search ? `${targetPath}?${search}` : targetPath);
 }

--- a/apps/backoffice/app/routes/backoffice/connections/github/shared.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/github/shared.tsx
@@ -4,6 +4,8 @@ import { Link, isRouteErrorResponse } from "react-router";
 import { BackofficePageHeader } from "@/components/backoffice";
 import type { AuthMeData } from "@/fragno/auth/auth-client";
 
+import type { IntegrationScopeSwitchOption } from "../../integrations/scope";
+import { IntegrationScopeBreadcrumbSelector } from "../../integrations/scope-selector";
 import { getRouteErrorMessage, isOrganisationNotFoundError } from "../../route-errors";
 
 type BackofficeOrganisation = AuthMeData["organizations"][number]["organization"];
@@ -24,12 +26,14 @@ export type GitHubAdminConfigState = {
 };
 
 export type GitHubLayoutContext = {
-  orgId: string;
   origin: string;
-  organisation: BackofficeOrganisation;
+  organisation: BackofficeOrganisation | null;
+  basePath: string;
+  integrationsPath: string;
   configState: GitHubAdminConfigState | null;
   configLoading: boolean;
   configError: string | null;
+  scopeOptions: IntegrationScopeSwitchOption[];
   setConfigState: Dispatch<SetStateAction<GitHubAdminConfigState | null>>;
   setConfigError: Dispatch<SetStateAction<string | null>>;
 };
@@ -48,29 +52,36 @@ export const formatTimestamp = (value?: string | Date | null) => {
 };
 
 export function GitHubHeader({
-  orgId,
   organisationName,
+  integrationsPath,
+  scopeOptions,
 }: {
-  orgId: string;
   organisationName?: string | null;
+  integrationsPath: string;
+  scopeOptions: IntegrationScopeSwitchOption[];
 }) {
+  const scopeLabel = organisationName ?? "Organisation";
+
   return (
     <BackofficePageHeader
       breadcrumbs={[
         { label: "Backoffice", to: "/backoffice" },
-        { label: "Connections", to: "/backoffice/connections" },
+        { label: "Automations", to: "/backoffice/automations" },
+        {
+          label: <IntegrationScopeBreadcrumbSelector label={scopeLabel} options={scopeOptions} />,
+        },
+        { label: "Integrations", to: integrationsPath },
         { label: "GitHub" },
-        { label: organisationName ?? orgId },
       ]}
       eyebrow="Integrations"
-      title={`GitHub for ${organisationName ?? orgId}`}
+      title={`GitHub for ${scopeLabel}`}
       description="Connect your GitHub App installation, link repositories, and inspect pull requests."
       actions={
         <Link
-          to="/backoffice/connections"
+          to={integrationsPath}
           className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
         >
-          Back to connections
+          Back to integrations
         </Link>
       }
     />
@@ -78,15 +89,14 @@ export function GitHubHeader({
 }
 
 export function GitHubTabs({
-  orgId,
+  basePath,
   activeTab,
   repositoriesEnabled,
 }: {
-  orgId: string;
+  basePath: string;
   activeTab: GitHubTab;
   repositoriesEnabled: boolean;
 }) {
-  const basePath = `/backoffice/connections/github/${orgId}`;
   const tabs = [
     {
       id: "repositories" as const,
@@ -142,10 +152,9 @@ export function GitHubTabs({
 
 export function GitHubErrorBoundary({
   error,
-  params,
 }: {
   error: unknown;
-  params: { orgId?: string };
+  params: { scopeKind?: string; scopeId?: string };
 }) {
   let statusCode = 500;
   let message = "An unexpected error occurred.";
@@ -158,13 +167,17 @@ export function GitHubErrorBoundary({
 
   message = getRouteErrorMessage(error, message);
 
-  if (statusCode === 404 && params.orgId && isOrganisationNotFoundError(error)) {
-    message = `Organisation '${params.orgId}' could not be found.`;
+  if (statusCode === 404 && isOrganisationNotFoundError(error)) {
+    message = "Organisation for this scope could not be found.";
   }
 
   return (
     <div className="space-y-4">
-      <GitHubHeader orgId={params.orgId ?? "organisation"} organisationName="Error" />
+      <GitHubHeader
+        integrationsPath="/backoffice/automations"
+        organisationName="Error"
+        scopeOptions={[]}
+      />
       <div className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-4 text-sm text-[var(--bo-muted)]">
         <p className="text-[10px] tracking-[0.22em] text-[var(--bo-muted-2)] uppercase">
           {statusCode} · {statusText}

--- a/apps/backoffice/app/routes/backoffice/connections/index.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/index.tsx
@@ -36,7 +36,9 @@ export default function BackofficeConnections() {
         {CONNECTIONS.map((connection) => {
           const connectionLink =
             activeOrganizationId && connection.routeSegment
-              ? `/backoffice/connections/${connection.routeSegment}/${activeOrganizationId}`
+              ? ["telegram", "resend", "github"].includes(connection.routeSegment)
+                ? `/backoffice/automations/org/${activeOrganizationId}/integrations/${connection.routeSegment}`
+                : `/backoffice/connections/${connection.routeSegment}/${activeOrganizationId}`
               : null;
           const isAvailable = Boolean(connectionLink);
           return (

--- a/apps/backoffice/app/routes/backoffice/connections/resend/configuration.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/configuration.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 import { Form, useActionData, useNavigation, useOutletContext } from "react-router";
 
+import { backofficeContextScopeSinglePathSegment } from "@/backoffice-runtime/scope-codec";
 import { FormContainer, FormField, WizardStepper } from "@/components/backoffice";
-import { getResendDurableObject } from "@/worker-runtime/durable-objects";
+import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
+import { resolveAuthenticatedIntegrationContext } from "../../integrations/scope";
 import type { Route } from "./+types/configuration";
 import { formatTimestamp, type ResendConfigState, type ResendLayoutContext } from "./shared";
 
@@ -91,9 +93,14 @@ const normalizeResendConfigInput = (input: ResendConfigForm): ResendConfigValida
 };
 
 export async function action({ request, context, params }: Route.ActionArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const integration = await resolveAuthenticatedIntegrationContext({
+    request,
+    context,
+    params,
+    integration: "resend",
+    allowedScopes: ["org", "system"],
+  });
+  const scope = integration.scope;
 
   const formData = await request.formData();
   const getValue = (key: string) => {
@@ -117,10 +124,21 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   }
 
   const origin = new URL(request.url).origin;
-  const resendDo = getResendDurableObject(context, params.orgId);
+  if (scope.kind !== "system" && scope.kind !== "org") {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  const resendObjects = context.get(BackofficeWorkerContext).runtime.objects.resend;
+  const resendStorageScope = scope.kind === "system" ? "admin" : scope.orgId;
+  const resendDo =
+    scope.kind === "system" ? resendObjects.singleton() : resendObjects.forOrg(resendStorageScope);
 
   try {
-    const configState = await resendDo.setAdminConfig(validation.payload, params.orgId, origin);
+    const configState = await resendDo.setAdminConfig(
+      validation.payload,
+      resendStorageScope,
+      origin,
+    );
     const webhook = configState.webhook;
     if (webhook && !webhook.ok) {
       return {
@@ -144,7 +162,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 }
 
 export default function BackofficeOrganisationResendConfiguration() {
-  const { orgId, origin, configState, configLoading, configError, setConfigState, setConfigError } =
+  const { origin, scope, configState, configLoading, configError, setConfigState, setConfigError } =
     useOutletContext<ResendLayoutContext>();
   const [currentStep, setCurrentStep] = useState(0);
   const actionData = useActionData<typeof action>();
@@ -159,7 +177,9 @@ export default function BackofficeOrganisationResendConfiguration() {
 
   const isConfigured = Boolean(configState?.configured);
   const webhookBaseUrl = formState.webhookBaseUrl.trim();
-  const webhookUrl = `${webhookBaseUrl.replace(/\/+$/, "")}/api/resend/${orgId}/webhook`;
+  const resendScopeSegment =
+    scope.kind === "system" ? "admin" : backofficeContextScopeSinglePathSegment(scope);
+  const webhookUrl = `${webhookBaseUrl.replace(/\/+$/, "")}/api/resend/${resendScopeSegment}/webhook`;
   const webhookBaseUrlError = validateRequiredUrl(
     formState.webhookBaseUrl.trim(),
     "Webhook base URL",

--- a/apps/backoffice/app/routes/backoffice/connections/resend/data.ts
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/data.ts
@@ -22,8 +22,9 @@ import type {
   ResendThreadSummary,
 } from "@fragno-dev/resend-fragment";
 
+import type { BackofficeContextScope } from "@/backoffice-runtime/context";
 import type { ResendFragment } from "@/fragno/resend";
-import { getResendDurableObject } from "@/worker-runtime/durable-objects";
+import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
 import type { ResendConfigState } from "./shared";
 
@@ -124,12 +125,28 @@ interface ResendRouteCaller {
   ): Promise<FragnoResponse<ResendThreadMutationOutput>>;
 }
 
+type ResendTarget = string | BackofficeContextScope;
+
+const getResendObject = (context: Readonly<RouterContextProvider>, target: ResendTarget) => {
+  const objects = context.get(BackofficeWorkerContext).runtime.objects;
+  if (typeof target === "string") {
+    return objects.resend.forOrg(target);
+  }
+  if (target.kind === "system") {
+    return objects.resend.singleton();
+  }
+  if (target.kind === "org" || target.kind === "project") {
+    return objects.resend.forOrg(target.orgId);
+  }
+  return objects.resend.forOrg(target.userId);
+};
+
 const createResendRouteCaller = (
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
 ): ResendRouteCaller => {
-  const resendDo = getResendDurableObject(context, orgId);
+  const resendDo = getResendObject(context, target);
   return createRouteCaller<ResendFragment>({
     baseUrl: request.url,
     mountRoute: "/api/resend",
@@ -210,10 +227,10 @@ type ResendReplyToThreadResult = {
 
 export async function fetchResendConfig(
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
 ): Promise<ResendConfigResult> {
   try {
-    const resendDo = getResendDurableObject(context, orgId);
+    const resendDo = getResendObject(context, target);
     const configState = await resendDo.getAdminConfig();
     return { configState, configError: null };
   } catch (error) {
@@ -227,10 +244,10 @@ export async function fetchResendConfig(
 export async function fetchResendDomains(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
 ): Promise<ResendDomainsResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const response = await callRoute("GET", "/domains");
 
     if (response.type === "json") {
@@ -274,11 +291,11 @@ export async function fetchResendDomains(
 export async function fetchResendDomainDetail(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   domainId: string,
 ): Promise<ResendDomainDetailResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const response = await callRoute("GET", "/domains/:domainId", {
       pathParams: { domainId },
     });
@@ -306,11 +323,11 @@ export async function fetchResendDomainDetail(
 export async function sendResendEmail(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   payload: ResendSendEmailInput,
 ): Promise<ResendSendEmailResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const response = await callRoute("POST", "/emails", { body: payload });
 
     if (response.type === "json") {
@@ -336,11 +353,11 @@ export async function sendResendEmail(
 export async function fetchResendEmailDetail(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   emailId: string,
 ): Promise<ResendEmailDetailResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const response = await callRoute("GET", "/emails/:emailId", {
       pathParams: { emailId },
     });
@@ -368,7 +385,7 @@ export async function fetchResendEmailDetail(
 export async function fetchResendOutbox(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   options: {
     order?: "asc" | "desc";
     pageSize?: number;
@@ -377,7 +394,7 @@ export async function fetchResendOutbox(
   } = {},
 ): Promise<ResendOutboxResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const requestedPageSize =
       typeof options.pageSize === "number" && Number.isFinite(options.pageSize)
         ? options.pageSize
@@ -433,7 +450,7 @@ export async function fetchResendOutbox(
 export async function fetchResendReceivedEmails(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   options: {
     order?: "asc" | "desc";
     pageSize?: number;
@@ -441,7 +458,7 @@ export async function fetchResendReceivedEmails(
   } = {},
 ): Promise<ResendReceivedEmailsResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const requestedPageSize =
       typeof options.pageSize === "number" && Number.isFinite(options.pageSize)
         ? options.pageSize
@@ -495,11 +512,11 @@ export async function fetchResendReceivedEmails(
 export async function fetchResendReceivedEmailDetail(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   emailId: string,
 ): Promise<ResendReceivedEmailDetailResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const response = await callRoute("GET", "/received-emails/:emailId", {
       pathParams: { emailId },
     });
@@ -527,7 +544,7 @@ export async function fetchResendReceivedEmailDetail(
 export async function fetchResendThreads(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   options: {
     order?: "asc" | "desc";
     pageSize?: number;
@@ -535,7 +552,7 @@ export async function fetchResendThreads(
   } = {},
 ): Promise<ResendThreadsResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const requestedPageSize =
       typeof options.pageSize === "number" && Number.isFinite(options.pageSize)
         ? options.pageSize
@@ -589,7 +606,7 @@ export async function fetchResendThreads(
 export async function fetchResendThreadDetail(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   threadId: string,
   options: {
     order?: "asc" | "desc";
@@ -598,7 +615,7 @@ export async function fetchResendThreadDetail(
   } = {},
 ): Promise<ResendThreadDetailResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const requestedPageSize =
       typeof options.pageSize === "number" && Number.isFinite(options.pageSize)
         ? options.pageSize
@@ -688,11 +705,11 @@ export async function fetchResendThreadDetail(
 export async function createResendThread(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   payload: ResendSendEmailInput,
 ): Promise<ResendCreateThreadResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const response = await callRoute("POST", "/threads", { body: payload });
 
     if (response.type === "json") {
@@ -724,12 +741,12 @@ export async function createResendThread(
 export async function replyToResendThread(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: ResendTarget,
   threadId: string,
   payload: ResendThreadReplyInput,
 ): Promise<ResendReplyToThreadResult> {
   try {
-    const callRoute = createResendRouteCaller(request, context, orgId);
+    const callRoute = createResendRouteCaller(request, context, target);
     const response = await callRoute("POST", "/threads/:threadId/reply", {
       pathParams: { threadId },
       body: payload,

--- a/apps/backoffice/app/routes/backoffice/connections/resend/domain-detail.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/domain-detail.tsx
@@ -2,6 +2,7 @@ import { Link, useLoaderData, useOutletContext, useParams } from "react-router";
 
 import type { ResendDomainRecord } from "@fragno-dev/resend-fragment";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/domain-detail";
 import { fetchResendDomainDetail } from "./data";
 import type { ResendDomainsOutletContext } from "./domains";
@@ -25,11 +26,12 @@ const recordLabel = (record: ResendDomainRecord) => {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId || !params.domainId) {
+  if (!params.domainId) {
     throw new Response("Not Found", { status: 404 });
   }
+  const scope = resolveScopeFromRouteParams(params);
 
-  const result = await fetchResendDomainDetail(request, context, params.orgId, params.domainId);
+  const result = await fetchResendDomainDetail(request, context, scope, params.domainId);
   return {
     domain: result.domain,
     error: result.error,

--- a/apps/backoffice/app/routes/backoffice/connections/resend/domains.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/domains.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet, redirect, useLoaderData, useOutletContext, useParams } fr
 
 import type { ResendDomain } from "@fragno-dev/resend-fragment";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/domains";
 import { fetchResendConfig, fetchResendDomains } from "./data";
 import {
@@ -26,11 +27,9 @@ export type ResendDomainsOutletContext = {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const scope = resolveScopeFromRouteParams(params);
 
-  const { configState, configError } = await fetchResendConfig(context, params.orgId);
+  const { configState, configError } = await fetchResendConfig(context, scope);
   if (configError) {
     return {
       configError,
@@ -41,14 +40,12 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   if (!configState?.configured) {
-    return redirect(`/backoffice/connections/resend/${params.orgId}/configuration`);
+    return redirect(
+      `${new URL(request.url).pathname.replace(/\/(?:domains|threads|incoming|outgoing)(?:\/.*)?$/u, "")}/configuration`,
+    );
   }
 
-  const { domains, hasMore, domainsError } = await fetchResendDomains(
-    request,
-    context,
-    params.orgId,
-  );
+  const { domains, hasMore, domainsError } = await fetchResendDomains(request, context, scope);
   return {
     configError: null,
     domainsError,
@@ -59,10 +56,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
 export default function BackofficeOrganisationResendDomains() {
   const { domains, hasMore, configError, domainsError } = useLoaderData<typeof loader>();
-  const { orgId } = useOutletContext<ResendLayoutContext>();
+  const { basePath: integrationBasePath } = useOutletContext<ResendLayoutContext>();
   const { domainId } = useParams();
   const selectedDomainId = domainId ?? null;
-  const basePath = `/backoffice/connections/resend/${orgId}/domains`;
+  const basePath = `${integrationBasePath}/domains`;
   const isDetailRoute = Boolean(selectedDomainId);
 
   if (configError) {

--- a/apps/backoffice/app/routes/backoffice/connections/resend/incoming-detail.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/incoming-detail.tsx
@@ -1,5 +1,6 @@
 import { Link, useLoaderData, useOutletContext, useParams } from "react-router";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/incoming-detail";
 import { fetchResendReceivedEmailDetail } from "./data";
 import type { ResendIncomingOutletContext } from "./incoming";
@@ -18,16 +19,12 @@ const formatAddressList = (value?: string[] | null) => {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId || !params.emailId) {
+  if (!params.emailId) {
     throw new Response("Not Found", { status: 404 });
   }
+  const scope = resolveScopeFromRouteParams(params);
 
-  const result = await fetchResendReceivedEmailDetail(
-    request,
-    context,
-    params.orgId,
-    params.emailId,
-  );
+  const result = await fetchResendReceivedEmailDetail(request, context, scope, params.emailId);
   return {
     email: result.email,
     error: result.error,

--- a/apps/backoffice/app/routes/backoffice/connections/resend/incoming.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/incoming.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet, redirect, useLoaderData, useOutletContext, useParams } fr
 
 import type { ResendReceivedEmailSummary } from "@fragno-dev/resend-fragment";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/incoming";
 import { fetchResendConfig, fetchResendReceivedEmails } from "./data";
 import { formatTimestamp, type ResendLayoutContext } from "./shared";
@@ -21,11 +22,9 @@ export type ResendIncomingOutletContext = {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const scope = resolveScopeFromRouteParams(params);
 
-  const { configState, configError } = await fetchResendConfig(context, params.orgId);
+  const { configState, configError } = await fetchResendConfig(context, scope);
   if (configError) {
     return {
       configError,
@@ -37,13 +36,15 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   if (!configState?.configured) {
-    return redirect(`/backoffice/connections/resend/${params.orgId}/configuration`);
+    return redirect(
+      `${new URL(request.url).pathname.replace(/\/(?:domains|threads|incoming|outgoing)(?:\/.*)?$/u, "")}/configuration`,
+    );
   }
 
   const { emails, cursor, hasNextPage, incomingError } = await fetchResendReceivedEmails(
     request,
     context,
-    params.orgId,
+    scope,
     { order: "desc", pageSize: 50 },
   );
 
@@ -58,10 +59,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
 export default function BackofficeOrganisationResendIncoming() {
   const { emails, configError, incomingError, hasNextPage } = useLoaderData<typeof loader>();
-  const { orgId } = useOutletContext<ResendLayoutContext>();
+  const { basePath: integrationBasePath } = useOutletContext<ResendLayoutContext>();
   const { emailId } = useParams();
   const selectedEmailId = emailId ?? null;
-  const basePath = `/backoffice/connections/resend/${orgId}/incoming`;
+  const basePath = `${integrationBasePath}/incoming`;
   const isDetailRoute = Boolean(selectedEmailId);
 
   if (configError) {

--- a/apps/backoffice/app/routes/backoffice/connections/resend/index.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/index.tsx
@@ -17,7 +17,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
   const activeOrganizationId = me.activeOrganization?.organization.id ?? null;
   if (activeOrganizationId) {
-    return redirect(`/backoffice/connections/resend/${activeOrganizationId}`);
+    return redirect(`/backoffice/automations/org/${activeOrganizationId}/integrations/resend`);
   }
 
   return null;
@@ -100,7 +100,7 @@ export default function BackofficeConnectionsResend() {
 
               <div className="mt-4">
                 <Link
-                  to={`/backoffice/connections/resend/${organization.id}`}
+                  to={`/backoffice/automations/org/${organization.id}/integrations/resend`}
                   className="inline-flex border border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-accent-fg)] uppercase transition-colors hover:border-[color:var(--bo-accent-strong)]"
                 >
                   Manage Resend

--- a/apps/backoffice/app/routes/backoffice/connections/resend/organisation-layout.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/organisation-layout.tsx
@@ -4,7 +4,11 @@ import { Outlet, redirect } from "react-router";
 import { getAuthMe } from "@/fragno/auth/auth-server";
 
 import { buildBackofficeLoginPath } from "../../auth-navigation";
-import { throwOrganisationNotFound } from "../../route-errors";
+import {
+  createIntegrationScopeSwitchOptions,
+  organizationIdFromScope,
+  resolveIntegrationContext,
+} from "../../integrations/scope";
 import type { Route } from "./+types/organisation-layout";
 import { fetchResendConfig } from "./data";
 import {
@@ -16,10 +20,6 @@ import {
 } from "./shared";
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const me = await getAuthMe(request, context);
   if (!me?.user) {
     const url = new URL(request.url);
@@ -29,33 +29,52 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     );
   }
 
-  const organisation =
-    me.organizations.find((entry) => entry.organization.id === params.orgId)?.organization ?? null;
-  if (!organisation) {
-    throwOrganisationNotFound(params.orgId);
-  }
+  const integration = resolveIntegrationContext({
+    params,
+    me,
+    integration: "resend",
+    allowedScopes: ["org", "system"],
+  });
+  const organizationForScope = organizationIdFromScope(integration.scope);
+  const organisation = organizationForScope
+    ? (me.organizations.find((entry) => entry.organization.id === organizationForScope)
+        ?.organization ?? null)
+    : null;
 
-  const { configState, configError } = await fetchResendConfig(context, params.orgId);
+  const projectOrgId =
+    organizationForScope ??
+    me.activeOrganization?.organization.id ??
+    me.organizations[0]?.organization.id;
+  const scopeOptions = createIntegrationScopeSwitchOptions({
+    me,
+    projects: [],
+    projectOrgId: projectOrgId ?? "",
+    integration: "resend",
+    allowedScopes: ["org", "system"],
+  });
+
+  const { configState, configError } = await fetchResendConfig(context, integration.scope);
   const url = new URL(request.url);
   const currentPath = url.pathname.replace(/\/+$/, "");
-  const basePath = `/backoffice/connections/resend/${params.orgId}`;
+  const basePath = integration.basePath;
   if (currentPath === basePath) {
     const target = configState?.configured ? "threads" : "configuration";
     return redirect(`${basePath}/${target}`);
   }
 
   return {
-    orgId: params.orgId,
+    ...integration,
     origin: new URL(request.url).origin,
     organisation,
+    scopeOptions,
     configState,
     configError,
   };
 }
 
 export function meta({ loaderData }: Route.MetaArgs) {
-  const orgId = loaderData?.orgId ?? "organisation";
-  return [{ title: `Resend Setup · ${orgId}` }];
+  const label = loaderData?.label ?? "scope";
+  return [{ title: `Resend Setup · ${label}` }];
 }
 
 export function ErrorBoundary({ error, params }: Route.ErrorBoundaryProps) {
@@ -67,9 +86,14 @@ export default function BackofficeOrganisationResendLayout({
   matches,
 }: Route.ComponentProps) {
   const {
-    orgId,
     origin,
     organisation,
+    scope,
+    label,
+    basePath,
+    integrationsPath,
+    scopeSegment,
+    scopeOptions,
     configState: initialConfigState,
     configError: initialConfigError,
   } = loaderData;
@@ -80,49 +104,48 @@ export default function BackofficeOrganisationResendLayout({
   useEffect(() => {
     setConfigState(initialConfigState);
     setConfigError(initialConfigError);
-  }, [initialConfigError, initialConfigState, orgId]);
+  }, [initialConfigError, initialConfigState, scopeSegment]);
 
   const currentPath = (matches[matches.length - 1]?.pathname || "").replace(/\/+$/, "");
   const pathSegments = currentPath.split("/").filter(Boolean);
-  const resendIndex = pathSegments.lastIndexOf("resend");
-  const activeSegment = resendIndex >= 0 ? pathSegments[resendIndex + 2] : undefined;
 
   let activeTab: ResendTab = "configuration";
-  switch (activeSegment) {
-    case "threads":
-      activeTab = "threads";
-      break;
-    case "incoming":
-      activeTab = "incoming";
-      break;
-    case "outgoing":
-    case "outgoings":
-    case "outbox":
-      activeTab = "outgoing";
-      break;
-    case "domains":
-      activeTab = "domains";
-      break;
-    case "configuration":
-      activeTab = "configuration";
-      break;
-    default:
-      break;
+  if (pathSegments.includes("threads")) {
+    activeTab = "threads";
+  } else if (pathSegments.includes("incoming")) {
+    activeTab = "incoming";
+  } else if (
+    pathSegments.includes("outgoing") ||
+    pathSegments.includes("outgoings") ||
+    pathSegments.includes("outbox")
+  ) {
+    activeTab = "outgoing";
+  } else if (pathSegments.includes("domains")) {
+    activeTab = "domains";
   }
 
   return (
     <div className="space-y-4">
-      <ResendHeader orgId={orgId} organisationName={organisation?.name ?? orgId} />
+      <ResendHeader
+        organisationName={organisation?.name ?? label}
+        integrationsPath={integrationsPath}
+        scopeOptions={scopeOptions}
+      />
       <ResendTabs
-        orgId={orgId}
+        basePath={basePath}
         activeTab={activeTab}
         isConfigured={Boolean(configState?.configured)}
       />
       <Outlet
         context={{
-          orgId,
           origin,
           organisation,
+          scope,
+          scopeSegment,
+          label,
+          basePath,
+          integrationsPath,
+          scopeOptions,
           configState,
           configLoading,
           configError,

--- a/apps/backoffice/app/routes/backoffice/connections/resend/outbox-detail.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/outbox-detail.tsx
@@ -2,6 +2,7 @@ import { Link, useLoaderData, useOutletContext, useParams } from "react-router";
 
 import type { ResendEmailInput } from "@fragno-dev/resend-fragment";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/outbox-detail";
 import { fetchResendEmailDetail } from "./data";
 import type { ResendOutgoingOutletContext } from "./outbox";
@@ -20,11 +21,12 @@ const normalizeAddressList = (value?: string | string[] | null) => {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId || !params.emailId) {
+  if (!params.emailId) {
     throw new Response("Not Found", { status: 404 });
   }
+  const scope = resolveScopeFromRouteParams(params);
 
-  const result = await fetchResendEmailDetail(request, context, params.orgId, params.emailId);
+  const result = await fetchResendEmailDetail(request, context, scope, params.emailId);
   return {
     email: result.email,
     error: result.error,

--- a/apps/backoffice/app/routes/backoffice/connections/resend/outbox-index.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/outbox-index.tsx
@@ -1,19 +1,20 @@
 import { redirect } from "react-router";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/outbox-index";
 import { fetchResendConfig } from "./data";
 
-export async function loader({ params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const scope = resolveScopeFromRouteParams(params);
 
-  const { configState } = await fetchResendConfig(context, params.orgId);
+  const { configState } = await fetchResendConfig(context, scope);
   if (!configState?.configured) {
-    return redirect(`/backoffice/connections/resend/${params.orgId}/configuration`);
+    return redirect(
+      `${new URL(request.url).pathname.replace(/\/(?:domains|threads|incoming|outgoing)(?:\/.*)?$/u, "")}/configuration`,
+    );
   }
 
-  return redirect(`/backoffice/connections/resend/${params.orgId}/outgoing/send`);
+  return redirect(`${new URL(request.url).pathname.replace(/\/+$/u, "")}/send`);
 }
 
 export default function BackofficeOrganisationResendOutboxIndex() {

--- a/apps/backoffice/app/routes/backoffice/connections/resend/outbox.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/outbox.tsx
@@ -10,6 +10,7 @@ import {
 
 import type { ResendEmailSummary } from "@fragno-dev/resend-fragment";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/outbox";
 import { fetchResendConfig, fetchResendOutbox } from "./data";
 import { formatTimestamp, type ResendConfigState, type ResendLayoutContext } from "./shared";
@@ -27,16 +28,13 @@ export type ResendOutgoingOutletContext = {
   selectedEmailId: string | null;
   isSendRoute: boolean;
   basePath: string;
-  orgId: string;
   configState: ResendConfigState | null;
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const scope = resolveScopeFromRouteParams(params);
 
-  const { configState, configError } = await fetchResendConfig(context, params.orgId);
+  const { configState, configError } = await fetchResendConfig(context, scope);
   if (configError) {
     return {
       configError,
@@ -48,13 +46,15 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   if (!configState?.configured) {
-    return redirect(`/backoffice/connections/resend/${params.orgId}/configuration`);
+    return redirect(
+      `${new URL(request.url).pathname.replace(/\/(?:domains|threads|incoming|outgoing)(?:\/.*)?$/u, "")}/configuration`,
+    );
   }
 
   const { emails, cursor, hasNextPage, outboxError } = await fetchResendOutbox(
     request,
     context,
-    params.orgId,
+    scope,
     { order: "desc", pageSize: 50 },
   );
 
@@ -69,11 +69,11 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
 export default function BackofficeOrganisationResendOutbox() {
   const { emails, configError, outboxError, hasNextPage } = useLoaderData<typeof loader>();
-  const { orgId, configState } = useOutletContext<ResendLayoutContext>();
+  const { basePath: integrationBasePath, configState } = useOutletContext<ResendLayoutContext>();
   const { emailId } = useParams();
   const location = useLocation();
   const selectedEmailId = emailId ?? null;
-  const basePath = `/backoffice/connections/resend/${orgId}/outgoing`;
+  const basePath = `${integrationBasePath}/outgoing`;
   const isSendRoute = location.pathname.replace(/\/+$/, "").endsWith("/send");
   const isDetailRoute = Boolean(selectedEmailId || isSendRoute);
 
@@ -213,7 +213,6 @@ export default function BackofficeOrganisationResendOutbox() {
             selectedEmailId,
             isSendRoute,
             basePath,
-            orgId,
             configState,
           }}
         />

--- a/apps/backoffice/app/routes/backoffice/connections/resend/send.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/send.tsx
@@ -5,6 +5,7 @@ import type { ResendEmailRecord, ResendSendEmailInput } from "@fragno-dev/resend
 
 import { FormContainer, FormField } from "@/components/backoffice";
 
+import { resolveAuthenticatedIntegrationContext } from "../../integrations/scope";
 import type { Route } from "./+types/send";
 import { sendResendEmail } from "./data";
 import type { ResendOutgoingOutletContext } from "./outbox";
@@ -32,9 +33,14 @@ const parseOptionalValue = (value: string) => {
 };
 
 export async function action({ request, params, context }: Route.ActionArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const integration = await resolveAuthenticatedIntegrationContext({
+    request,
+    context,
+    params,
+    integration: "resend",
+    allowedScopes: ["org", "system"],
+  });
+  const scope = integration.scope;
 
   const formData = await request.formData();
   const getValue = (key: string) => {
@@ -98,7 +104,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     scheduledIn,
   };
 
-  const result = await sendResendEmail(request, context, params.orgId, payload);
+  const result = await sendResendEmail(request, context, scope, payload);
   if (result.error || !result.record) {
     return {
       ok: false,

--- a/apps/backoffice/app/routes/backoffice/connections/resend/shared.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/shared.tsx
@@ -3,9 +3,12 @@ import { Link, isRouteErrorResponse } from "react-router";
 
 import type { ResendDomain } from "@fragno-dev/resend-fragment";
 
+import type { BackofficeContextScope } from "@/backoffice-runtime/context";
 import { BackofficePageHeader } from "@/components/backoffice";
 import type { AuthMeData } from "@/fragno/auth/auth-client";
 
+import type { IntegrationScopeSwitchOption } from "../../integrations/scope";
+import { IntegrationScopeBreadcrumbSelector } from "../../integrations/scope-selector";
 import { getRouteErrorMessage, isOrganisationNotFoundError } from "../../route-errors";
 
 type BackofficeOrganisation = AuthMeData["organizations"][number]["organization"];
@@ -29,12 +32,17 @@ export type ResendConfigState = {
 };
 
 export type ResendLayoutContext = {
-  orgId: string;
   origin: string;
-  organisation: BackofficeOrganisation;
+  organisation: BackofficeOrganisation | null;
+  scope: BackofficeContextScope;
+  scopeSegment: string;
+  label: string;
+  basePath: string;
+  integrationsPath: string;
   configState: ResendConfigState | null;
   configLoading: boolean;
   configError: string | null;
+  scopeOptions: IntegrationScopeSwitchOption[];
   setConfigState: Dispatch<SetStateAction<ResendConfigState | null>>;
   setConfigError: Dispatch<SetStateAction<string | null>>;
 };
@@ -71,29 +79,36 @@ export const formatResendCapability = (value: ResendDomain["capabilities"]["send
   value === "enabled" ? "Enabled" : "Disabled";
 
 export function ResendHeader({
-  orgId,
   organisationName,
+  integrationsPath,
+  scopeOptions,
 }: {
-  orgId: string;
   organisationName?: string | null;
+  integrationsPath: string;
+  scopeOptions: IntegrationScopeSwitchOption[];
 }) {
+  const scopeLabel = organisationName ?? "Scope";
+
   return (
     <BackofficePageHeader
       breadcrumbs={[
         { label: "Backoffice", to: "/backoffice" },
-        { label: "Connections", to: "/backoffice/connections" },
-        { label: "Resend", to: "/backoffice/connections/resend" },
-        { label: organisationName ?? orgId },
+        { label: "Automations", to: "/backoffice/automations" },
+        {
+          label: <IntegrationScopeBreadcrumbSelector label={scopeLabel} options={scopeOptions} />,
+        },
+        { label: "Integrations", to: integrationsPath },
+        { label: "Resend" },
       ]}
       eyebrow="Integrations"
-      title={`Resend for ${organisationName ?? orgId}`}
+      title={`Resend for ${scopeLabel}`}
       description="Connect Resend to send and receive email, inspect domains, manage threads, and monitor delivery state."
       actions={
         <Link
-          to="/backoffice/connections/resend"
+          to={integrationsPath}
           className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
         >
-          Back to Resend
+          Back to integrations
         </Link>
       }
     />
@@ -101,15 +116,14 @@ export function ResendHeader({
 }
 
 export function ResendTabs({
-  orgId,
+  basePath,
   activeTab,
   isConfigured,
 }: {
-  orgId: string;
+  basePath: string;
   activeTab: ResendTab;
   isConfigured: boolean;
 }) {
-  const basePath = `/backoffice/connections/resend/${orgId}`;
   const tabs = [
     {
       id: "threads" as const,
@@ -177,10 +191,9 @@ export function ResendTabs({
 
 export function ResendErrorBoundary({
   error,
-  params,
 }: {
   error: unknown;
-  params: { orgId?: string };
+  params: { scopeKind?: string; scopeId?: string };
 }) {
   let statusCode = 500;
   let message = "An unexpected error occurred.";
@@ -195,13 +208,17 @@ export function ResendErrorBoundary({
 
   message = getRouteErrorMessage(error, message);
 
-  if (statusCode === 404 && params.orgId && isOrganisationNotFoundError(error)) {
-    message = `Organisation '${params.orgId}' could not be found.`;
+  if (statusCode === 404 && isOrganisationNotFoundError(error)) {
+    message = "Organisation for this scope could not be found.";
   }
 
   return (
     <div className="space-y-4">
-      <ResendHeader orgId={params.orgId ?? "organisation"} organisationName="Error" />
+      <ResendHeader
+        integrationsPath="/backoffice/automations"
+        organisationName="Error"
+        scopeOptions={[]}
+      />
       <div className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-4 text-sm text-[var(--bo-muted)]">
         <p className="text-[10px] tracking-[0.22em] text-[var(--bo-muted-2)] uppercase">
           {statusCode} · {statusText}

--- a/apps/backoffice/app/routes/backoffice/connections/resend/thread-detail.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/thread-detail.tsx
@@ -6,6 +6,10 @@ import type { ResendThreadMessage, ResendThreadReplyInput } from "@fragno-dev/re
 
 import { FormField } from "@/components/backoffice";
 
+import {
+  resolveAuthenticatedIntegrationContext,
+  resolveScopeFromRouteParams,
+} from "../../integrations/scope";
 import type { Route } from "./+types/thread-detail";
 import { fetchResendThreadDetail, replyToResendThread } from "./data";
 import { formatTimestamp } from "./shared";
@@ -49,11 +53,12 @@ const formatAddressList = (value?: string[] | null) => {
 const getMessageBody = (message: ResendThreadMessage) => message.text ?? message.html ?? "—";
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId || !params.threadId) {
+  if (!params.threadId) {
     throw new Response("Not Found", { status: 404 });
   }
+  const scope = resolveScopeFromRouteParams(params);
 
-  const result = await fetchResendThreadDetail(request, context, params.orgId, params.threadId, {
+  const result = await fetchResendThreadDetail(request, context, scope, params.threadId, {
     order: "desc",
     pageSize: 100,
   });
@@ -67,9 +72,17 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params, context }: Route.ActionArgs) {
-  if (!params.orgId || !params.threadId) {
+  if (!params.threadId) {
     throw new Response("Not Found", { status: 404 });
   }
+  const integration = await resolveAuthenticatedIntegrationContext({
+    request,
+    context,
+    params,
+    integration: "resend",
+    allowedScopes: ["org", "system"],
+  });
+  const scope = integration.scope;
 
   const formData = await request.formData();
   const getValue = (key: string) => {
@@ -104,13 +117,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     html: html || undefined,
   };
 
-  const result = await replyToResendThread(
-    request,
-    context,
-    params.orgId,
-    params.threadId,
-    payload,
-  );
+  const result = await replyToResendThread(request, context, scope, params.threadId, payload);
   if (result.error) {
     return {
       ok: false,

--- a/apps/backoffice/app/routes/backoffice/connections/resend/thread-start.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/thread-start.tsx
@@ -5,6 +5,7 @@ import type { ResendSendEmailInput, ResendThreadMutationOutput } from "@fragno-d
 
 import { FormContainer, FormField } from "@/components/backoffice";
 
+import { resolveAuthenticatedIntegrationContext } from "../../integrations/scope";
 import type { Route } from "./+types/thread-start";
 import { createResendThread } from "./data";
 import type { ResendThreadsOutletContext } from "./threads";
@@ -38,9 +39,14 @@ const parseOptionalValue = (value: string) => {
 };
 
 export async function action({ request, params, context }: Route.ActionArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const integration = await resolveAuthenticatedIntegrationContext({
+    request,
+    context,
+    params,
+    integration: "resend",
+    allowedScopes: ["org", "system"],
+  });
+  const scope = integration.scope;
 
   const formData = await request.formData();
   const getValue = (key: string) => {
@@ -116,7 +122,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     scheduledIn,
   };
 
-  const result = await createResendThread(request, context, params.orgId, payload);
+  const result = await createResendThread(request, context, scope, payload);
   if (result.error || !result.result || !result.result.thread.id) {
     return {
       ok: false,

--- a/apps/backoffice/app/routes/backoffice/connections/resend/threads-index.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/threads-index.tsx
@@ -1,13 +1,12 @@
 import { redirect } from "react-router";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/threads-index";
 
-export async function loader({ params }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+export async function loader({ request, params }: Route.LoaderArgs) {
+  resolveScopeFromRouteParams(params);
 
-  return redirect(`/backoffice/connections/resend/${params.orgId}/threads/start`);
+  return redirect(`${new URL(request.url).pathname.replace(/\/+$/u, "")}/start`);
 }
 
 export default function BackofficeOrganisationResendThreadsIndex() {

--- a/apps/backoffice/app/routes/backoffice/connections/resend/threads.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/resend/threads.tsx
@@ -10,6 +10,7 @@ import {
 
 import type { ResendThreadSummary } from "@fragno-dev/resend-fragment";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/threads";
 import { fetchResendConfig, fetchResendThreads } from "./data";
 import { formatTimestamp, type ResendConfigState, type ResendLayoutContext } from "./shared";
@@ -27,16 +28,13 @@ export type ResendThreadsOutletContext = {
   selectedThreadId: string | null;
   isStartRoute: boolean;
   basePath: string;
-  orgId: string;
   configState: ResendConfigState | null;
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const scope = resolveScopeFromRouteParams(params);
 
-  const { configState, configError } = await fetchResendConfig(context, params.orgId);
+  const { configState, configError } = await fetchResendConfig(context, scope);
   if (configError) {
     return {
       configError,
@@ -48,13 +46,15 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   if (!configState?.configured) {
-    return redirect(`/backoffice/connections/resend/${params.orgId}/configuration`);
+    return redirect(
+      `${new URL(request.url).pathname.replace(/\/(?:domains|threads|incoming|outgoing)(?:\/.*)?$/u, "")}/configuration`,
+    );
   }
 
   const { threads, cursor, hasNextPage, threadsError } = await fetchResendThreads(
     request,
     context,
-    params.orgId,
+    scope,
     { order: "desc", pageSize: 50 },
   );
 
@@ -69,11 +69,11 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
 export default function BackofficeOrganisationResendThreads() {
   const { threads, configError, threadsError, hasNextPage } = useLoaderData<typeof loader>();
-  const { orgId, configState } = useOutletContext<ResendLayoutContext>();
+  const { basePath: integrationBasePath, configState } = useOutletContext<ResendLayoutContext>();
   const { threadId } = useParams();
   const location = useLocation();
   const selectedThreadId = threadId ?? null;
-  const basePath = `/backoffice/connections/resend/${orgId}/threads`;
+  const basePath = `${integrationBasePath}/threads`;
   const isStartRoute = location.pathname.replace(/\/+$/, "").endsWith("/start");
   const isDetailRoute = Boolean(selectedThreadId || isStartRoute);
 
@@ -194,7 +194,6 @@ export default function BackofficeOrganisationResendThreads() {
             selectedThreadId,
             isStartRoute,
             basePath,
-            orgId,
             configState,
           }}
         />

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/attachment-download.test.ts
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/attachment-download.test.ts
@@ -32,14 +32,14 @@ describe("telegram attachment download route", () => {
 
     const response = await loader(
       createLoaderArgs(
-        "https://example.com/backoffice/connections/telegram/org_123/attachment-download?fileId=file-1&kind=voice",
+        "https://example.com/backoffice/automations/org/org_123/integrations/telegram/attachment-download?fileId=file-1&kind=voice",
       ),
     );
 
     expect(response).toBeInstanceOf(Response);
     assert(response.status === 302);
     expect(response.headers.get("Location")).toBe(
-      `https://example.com${buildBackofficeLoginPath("/backoffice/connections/telegram/org_123/attachment-download?fileId=file-1&kind=voice")}`,
+      `https://example.com${buildBackofficeLoginPath("/backoffice/automations/org/org_123/integrations/telegram/attachment-download?fileId=file-1&kind=voice")}`,
     );
   });
 
@@ -57,7 +57,7 @@ describe("telegram attachment download route", () => {
 
     const response = await loader(
       createLoaderArgs(
-        "https://example.com/backoffice/connections/telegram/org_123/attachment-download?fileId=file-1&kind=voice",
+        "https://example.com/backoffice/automations/org/org_123/integrations/telegram/attachment-download?fileId=file-1&kind=voice",
       ),
     );
 
@@ -84,7 +84,7 @@ describe("telegram attachment download route", () => {
 
     const response = await loader(
       createLoaderArgs(
-        "https://example.com/backoffice/connections/telegram/org_123/attachment-download?fileId=file-1&kind=document&filename=Quarterly%20Report.pdf",
+        "https://example.com/backoffice/automations/org/org_123/integrations/telegram/attachment-download?fileId=file-1&kind=document&filename=Quarterly%20Report.pdf",
       ),
     );
 
@@ -109,7 +109,7 @@ describe("telegram attachment download route", () => {
 
     const response = await loader(
       createLoaderArgs(
-        "https://example.com/backoffice/connections/telegram/org_123/attachment-download?fileId=file%2Fwith%20spaces&kind=voice",
+        "https://example.com/backoffice/automations/org/org_123/integrations/telegram/attachment-download?fileId=file%2Fwith%20spaces&kind=voice",
       ),
     );
 
@@ -134,7 +134,7 @@ describe("telegram attachment download route", () => {
 
     const response = await loader(
       createLoaderArgs(
-        "https://example.com/backoffice/connections/telegram/org_123/attachment-download?fileId=file-1&kind=photo&disposition=inline",
+        "https://example.com/backoffice/automations/org/org_123/integrations/telegram/attachment-download?fileId=file-1&kind=photo&disposition=inline",
       ),
     );
 
@@ -152,7 +152,7 @@ describe("telegram attachment download route", () => {
     await expect(
       loader(
         createLoaderArgs(
-          "https://example.com/backoffice/connections/telegram/org_123/attachment-download?fileId=file-1&kind=voice",
+          "https://example.com/backoffice/automations/org/org_123/integrations/telegram/attachment-download?fileId=file-1&kind=voice",
         ),
       ),
     ).rejects.toMatchObject({
@@ -180,8 +180,18 @@ describe("telegram attachment download route", () => {
 const createLoaderArgs = (url: string) =>
   ({
     request: new Request(url),
-    context: {} as never,
-    params: { orgId: "org_123" },
+    context: {
+      get: () => ({
+        runtime: {
+          objects: {
+            telegram: {
+              for: () => getTelegramDurableObjectMock(),
+            },
+          },
+        },
+      }),
+    } as never,
+    params: { scopeKind: "org", scopeId: "org_123" },
   }) as Parameters<typeof loader>[0];
 
 const createAuthMe = () => ({

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/attachment-download.ts
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/attachment-download.ts
@@ -1,9 +1,10 @@
 import type { RouterContextProvider } from "react-router";
 
 import { getAuthMe } from "@/fragno/auth/auth-server";
-import { getTelegramDurableObject } from "@/worker-runtime/durable-objects";
+import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
 import { buildBackofficeLoginPath } from "../../auth-navigation";
+import { resolveIntegrationContext } from "../../integrations/scope";
 
 const DEFAULT_DOWNLOAD_NAME = "telegram-attachment";
 
@@ -13,13 +14,9 @@ export async function loader({
   context,
 }: {
   request: Request;
-  params: { orgId?: string };
+  params: { scopeKind?: string; scopeId?: string };
   context: Readonly<RouterContextProvider>;
 }) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const requestUrl = new URL(request.url);
   const fileId = requestUrl.searchParams.get("fileId")?.trim() ?? "";
   const attachmentKind = requestUrl.searchParams.get("kind")?.trim() ?? "";
@@ -36,13 +33,10 @@ export async function loader({
     return Response.redirect(new URL(buildBackofficeLoginPath(returnTo), request.url), 302);
   }
 
-  const organisation =
-    me.organizations.find((entry) => entry.organization.id === params.orgId)?.organization ?? null;
-  if (!organisation) {
-    throw new Response("Not Found", { status: 404 });
-  }
-
-  const telegramDo = getTelegramDurableObject(context, params.orgId);
+  const integration = resolveIntegrationContext({ params, me, integration: "telegram" });
+  const telegramDo = context
+    .get(BackofficeWorkerContext)
+    .runtime.objects.telegram.for(integration.scope);
   const metadata = await telegramDo.getAutomationFile({ fileId });
   const downloadResponse = await telegramDo.downloadAutomationFile({ fileId });
   const filename = buildDownloadFilename(

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/attachment-paths.ts
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/attachment-paths.ts
@@ -36,14 +36,16 @@ export const getTelegramAttachmentOriginalFilename = (
   }
 };
 
-export const buildTelegramAttachmentPath = (
-  orgId: string,
-  input: {
-    fileId: string;
-    kind: TelegramAttachment["kind"];
-    filename?: string;
-    disposition?: "inline" | "attachment";
-  },
+type TelegramAttachmentPathInput = {
+  fileId: string;
+  kind: TelegramAttachment["kind"];
+  filename?: string;
+  disposition?: "inline" | "attachment";
+};
+
+export const buildTelegramAttachmentPathForBase = (
+  basePath: string,
+  input: TelegramAttachmentPathInput,
 ): string => {
   const params = new URLSearchParams({
     fileId: input.fileId,
@@ -56,24 +58,26 @@ export const buildTelegramAttachmentPath = (
     params.set("filename", filename);
   }
 
-  return `/backoffice/connections/telegram/${orgId}/attachment-download?${params.toString()}`;
+  return `${basePath.replace(/\/+$/u, "")}/attachment-download?${params.toString()}`;
 };
 
+export const buildTelegramAttachmentPath = buildTelegramAttachmentPathForBase;
+
 export const buildTelegramAttachmentDownloadPath = (
-  orgId: string,
+  basePath: string,
   attachment: TelegramAttachment,
 ): string =>
-  buildTelegramAttachmentPath(orgId, {
+  buildTelegramAttachmentPathForBase(basePath, {
     fileId: getTelegramAttachmentDownloadFileId(attachment),
     kind: attachment.kind,
     filename: getTelegramAttachmentOriginalFilename(attachment),
   });
 
 export const buildTelegramAttachmentInlinePath = (
-  orgId: string,
+  basePath: string,
   attachment: TelegramAttachment,
 ): string =>
-  buildTelegramAttachmentPath(orgId, {
+  buildTelegramAttachmentPathForBase(basePath, {
     fileId: attachment.fileId,
     kind: attachment.kind,
     filename: getTelegramAttachmentOriginalFilename(attachment),

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/configuration.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/configuration.tsx
@@ -3,9 +3,9 @@ import { Form, useActionData, useNavigation, useOutletContext } from "react-rout
 
 import { backofficeContextScopeSinglePathSegment } from "@/backoffice-runtime/scope-codec";
 import { FormContainer, FormField, WizardStepper } from "@/components/backoffice";
-import { telegramCapability } from "@/fragno/backoffice-capabilities/capabilities/telegram";
 import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
+import { resolveAuthenticatedIntegrationContext } from "../../integrations/scope";
 import type { Route } from "./+types/configuration";
 import {
   formatTimestamp,
@@ -119,9 +119,13 @@ const normalizeTelegramConfigInput = (
 };
 
 export async function action({ request, context, params }: Route.ActionArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const integration = await resolveAuthenticatedIntegrationContext({
+    request,
+    context,
+    params,
+    integration: "telegram",
+  });
+  const scope = integration.scope;
 
   const formData = await request.formData();
   const getValue = (key: string) => {
@@ -151,27 +155,21 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const { runtime } = context.get(BackofficeWorkerContext);
 
   try {
-    const status = await telegramCapability.connection.configure({
-      objects: runtime.objects,
-      config: runtime.config,
-      scope: { kind: "org", orgId: params.orgId },
-      orgId: params.orgId,
-      origin,
-      payload: validation.payload,
-    });
+    const telegramDo = runtime.objects.telegram.for(scope);
+    const status = await telegramDo.setAdminConfig(validation.payload, origin);
 
-    if (status.verification && !status.verification.ok) {
+    if (status.webhook && !status.webhook.ok) {
       return {
         ok: false,
         intent,
-        message: status.verification.message,
+        message: status.webhook.message,
       } satisfies TelegramConfigActionData;
     }
 
     return {
       ok: true,
       intent,
-      message: status.verification?.message ?? "Telegram credentials saved.",
+      message: status.webhook?.message ?? "Telegram credentials saved.",
     } satisfies TelegramConfigActionData;
   } catch (error) {
     return {
@@ -183,7 +181,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 }
 
 export default function BackofficeOrganisationTelegramConfiguration() {
-  const { orgId, origin, configState, configLoading, configError, setConfigError } =
+  const { origin, scope, configState, configLoading, configError, setConfigError } =
     useOutletContext<TelegramLayoutContext>();
   const [currentStep, setCurrentStep] = useState(0);
   const actionData = useActionData<typeof action>();
@@ -199,7 +197,7 @@ export default function BackofficeOrganisationTelegramConfiguration() {
   });
 
   const webhookBaseUrl = formState.webhookBaseUrl.trim();
-  const telegramScopeSegment = backofficeContextScopeSinglePathSegment({ kind: "org", orgId });
+  const telegramScopeSegment = backofficeContextScopeSinglePathSegment(scope);
   const webhookUrl = `${webhookBaseUrl.replace(/\/+$/, "")}/api/telegram/${telegramScopeSegment}/telegram/webhook`;
   const apiBaseUrlError = validateOptionalUrl(formState.apiBaseUrl.trim(), "API base URL");
   const webhookBaseUrlError = validateRequiredUrl(

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/data.ts
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/data.ts
@@ -3,20 +3,30 @@ import type { RouterContextProvider } from "react-router";
 
 import type { TelegramChatSummary, TelegramMessageSummary } from "@fragno-dev/telegram-fragment";
 
+import type { BackofficeContextScope } from "@/backoffice-runtime/context";
 import type { TelegramFragment } from "@/fragno/telegram";
-import { getTelegramDurableObject } from "@/worker-runtime/durable-objects";
+import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
 import type { TelegramConfigState } from "./shared";
 
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_PAGE_SIZE = 200;
 
+type TelegramTarget = string | BackofficeContextScope;
+
+const getTelegramObject = (context: Readonly<RouterContextProvider>, target: TelegramTarget) => {
+  const objects = context.get(BackofficeWorkerContext).runtime.objects;
+  return typeof target === "string"
+    ? objects.telegram.forOrg(target)
+    : objects.telegram.for(target);
+};
+
 const createTelegramRouteCaller = (
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: TelegramTarget,
 ) => {
-  const telegramDo = getTelegramDurableObject(context, orgId);
+  const telegramDo = getTelegramObject(context, target);
   return createRouteCaller<TelegramFragment>({
     baseUrl: request.url,
     mountRoute: "/api/telegram",
@@ -54,10 +64,10 @@ type TelegramSendMessageResult = {
 
 export async function fetchTelegramConfig(
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: TelegramTarget,
 ): Promise<TelegramConfigResult> {
   try {
-    const telegramDo = getTelegramDurableObject(context, orgId);
+    const telegramDo = getTelegramObject(context, target);
     const configState = await telegramDo.getAdminConfig();
     return { configState, configError: null };
   } catch (error) {
@@ -71,10 +81,10 @@ export async function fetchTelegramConfig(
 export async function fetchTelegramChats(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: TelegramTarget,
 ): Promise<TelegramChatsResult> {
   try {
-    const callRoute = createTelegramRouteCaller(request, context, orgId);
+    const callRoute = createTelegramRouteCaller(request, context, target);
     const response = await callRoute("GET", "/chats");
 
     if (response.type === "json") {
@@ -103,12 +113,12 @@ export async function fetchTelegramChats(
 export async function fetchTelegramChatMessages(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: TelegramTarget,
   chatId: string,
   options: { order?: "asc" | "desc"; pageSize?: number; cursor?: string } = {},
 ): Promise<TelegramChatMessagesResult> {
   try {
-    const callRoute = createTelegramRouteCaller(request, context, orgId);
+    const callRoute = createTelegramRouteCaller(request, context, target);
     const requestedPageSize =
       typeof options.pageSize === "number" && Number.isFinite(options.pageSize)
         ? options.pageSize
@@ -164,7 +174,7 @@ export async function fetchTelegramChatMessages(
 export async function sendTelegramChatMessage(
   request: Request,
   context: Readonly<RouterContextProvider>,
-  orgId: string,
+  target: TelegramTarget,
   chatId: string,
   payload: {
     text: string;
@@ -174,7 +184,7 @@ export async function sendTelegramChatMessage(
   },
 ): Promise<TelegramSendMessageResult> {
   try {
-    const callRoute = createTelegramRouteCaller(request, context, orgId);
+    const callRoute = createTelegramRouteCaller(request, context, target);
     const response = await callRoute("POST", "/chats/:chatId/send", {
       pathParams: { chatId },
       body: payload,

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/index.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/index.tsx
@@ -82,7 +82,7 @@ export default function BackofficeConnectionsTelegram() {
 
               <div className="mt-4">
                 <Link
-                  to={`/backoffice/connections/telegram/${organization.id}`}
+                  to={`/backoffice/automations/org/${organization.id}/integrations/telegram`}
                   className="inline-flex border border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-accent-fg)] uppercase transition-colors hover:border-[color:var(--bo-accent-strong)]"
                 >
                   Manage Telegram

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/message-thread.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/message-thread.tsx
@@ -12,11 +12,15 @@ import {
 
 import type { TelegramAttachment, TelegramMessageSummary } from "@fragno-dev/telegram-fragment";
 
+import {
+  resolveAuthenticatedIntegrationContext,
+  resolveScopeFromRouteParams,
+} from "../../integrations/scope";
 import type { Route } from "./+types/message-thread";
 import {
   buildTelegramAttachmentDownloadPath,
   buildTelegramAttachmentInlinePath,
-  buildTelegramAttachmentPath,
+  buildTelegramAttachmentPathForBase,
 } from "./attachment-paths";
 import { fetchTelegramChatMessages, sendTelegramChatMessage } from "./data";
 import type { TelegramMessagesOutletContext } from "./messages";
@@ -33,17 +37,15 @@ type TelegramSendMessageActionData = {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId || !params.chatId) {
+  if (!params.chatId) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  const messageResult = await fetchTelegramChatMessages(
-    request,
-    context,
-    params.orgId,
-    params.chatId,
-    { order: "desc", pageSize: 50 },
-  );
+  const scope = resolveScopeFromRouteParams(params);
+  const messageResult = await fetchTelegramChatMessages(request, context, scope, params.chatId, {
+    order: "desc",
+    pageSize: 50,
+  });
 
   return {
     messages: [...messageResult.messages].reverse(),
@@ -52,10 +54,17 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params, context }: Route.ActionArgs) {
-  if (!params.orgId || !params.chatId) {
+  if (!params.chatId) {
     throw new Response("Not Found", { status: 404 });
   }
 
+  const integration = await resolveAuthenticatedIntegrationContext({
+    request,
+    context,
+    params,
+    integration: "telegram",
+  });
+  const scope = integration.scope;
   const formData = await request.formData();
   const text = formData.get("text");
 
@@ -66,7 +75,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     } satisfies TelegramSendMessageActionData;
   }
 
-  const result = await sendTelegramChatMessage(request, context, params.orgId, params.chatId, {
+  const result = await sendTelegramChatMessage(request, context, scope, params.chatId, {
     text: text.trim(),
   });
 
@@ -87,7 +96,7 @@ export default function BackofficeOrganisationTelegramMessageThread() {
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const { chats, basePath } = useOutletContext<TelegramMessagesOutletContext>();
-  const { chatId, orgId } = useParams();
+  const { chatId } = useParams();
   const isSending = navigation.state === "submitting";
   const selectedChat = chats.find((chat) => chat.id === chatId) ?? null;
   const chatTitle =
@@ -95,7 +104,7 @@ export default function BackofficeOrganisationTelegramMessageThread() {
 
   return (
     <ChatMessages
-      orgId={orgId ?? ""}
+      attachmentBasePath={basePath.replace(/\/messages$/u, "")}
       chatId={chatId ?? ""}
       chatTitle={chatTitle}
       messages={messages}
@@ -108,11 +117,11 @@ export default function BackofficeOrganisationTelegramMessageThread() {
 }
 
 const buildTelegramInlineFilePath = (
-  orgId: string,
+  attachmentBasePath: string,
   fileId: string,
   kind: TelegramAttachment["kind"],
 ): string =>
-  buildTelegramAttachmentPath(orgId, {
+  buildTelegramAttachmentPathForBase(attachmentBasePath, {
     fileId,
     kind,
     disposition: "inline",
@@ -286,22 +295,22 @@ const getAttachmentThumbnail = (attachment: TelegramAttachment) => {
 };
 
 function TelegramAttachmentCard({
-  orgId,
+  attachmentBasePath,
   messageId,
   attachment,
 }: {
-  orgId: string;
+  attachmentBasePath: string;
   messageId: string;
   attachment: TelegramAttachment;
 }) {
   const details = describeAttachment(attachment);
   const thumbnail = getAttachmentThumbnail(attachment);
   const thumbnailUrl = thumbnail
-    ? buildTelegramInlineFilePath(orgId, thumbnail.fileId, "photo")
+    ? buildTelegramInlineFilePath(attachmentBasePath, thumbnail.fileId, "photo")
     : null;
   const audioUrl =
     attachment.kind === "audio" || attachment.kind === "voice"
-      ? buildTelegramAttachmentInlinePath(orgId, attachment)
+      ? buildTelegramAttachmentInlinePath(attachmentBasePath, attachment)
       : null;
 
   return (
@@ -320,7 +329,7 @@ function TelegramAttachmentCard({
           <p className="text-[11px] break-all text-[var(--bo-muted-2)]">{attachment.fileId}</p>
         </div>
         <a
-          href={buildTelegramAttachmentDownloadPath(orgId, attachment)}
+          href={buildTelegramAttachmentDownloadPath(attachmentBasePath, attachment)}
           download
           className="inline-flex border border-[color:var(--bo-border)] bg-[var(--bo-panel)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
         >
@@ -349,7 +358,7 @@ function TelegramAttachmentCard({
 }
 
 function ChatMessages({
-  orgId,
+  attachmentBasePath,
   chatId,
   chatTitle,
   messages,
@@ -358,7 +367,7 @@ function ChatMessages({
   actionData,
   isSending,
 }: {
-  orgId: string;
+  attachmentBasePath: string;
   chatId: string;
   chatTitle: string;
   messages: TelegramMessageSummary[];
@@ -462,7 +471,7 @@ function ChatMessages({
                           {message.attachments.map((attachment) => (
                             <TelegramAttachmentCard
                               key={`${message.id}:${attachment.fileId}`}
-                              orgId={orgId}
+                              attachmentBasePath={attachmentBasePath}
                               messageId={message.id}
                               attachment={attachment}
                             />

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/messages.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/messages.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet, redirect, useLoaderData, useOutletContext, useParams } fr
 
 import type { TelegramChatSummary } from "@fragno-dev/telegram-fragment";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/messages";
 import { fetchTelegramChats, fetchTelegramConfig } from "./data";
 import type { TelegramLayoutContext } from "./shared";
@@ -19,11 +20,10 @@ export type TelegramMessagesOutletContext = {
 };
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+  const scope = resolveScopeFromRouteParams(params);
+  const basePath = new URL(request.url).pathname.replace(/\/messages(?:\/.*)?$/u, "");
 
-  const { configState, configError } = await fetchTelegramConfig(context, params.orgId);
+  const { configState, configError } = await fetchTelegramConfig(context, scope);
   if (configError) {
     return {
       configError,
@@ -33,10 +33,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   if (!configState?.configured) {
-    return redirect(`/backoffice/connections/telegram/${params.orgId}/configuration`);
+    return redirect(`${basePath}/configuration`);
   }
 
-  const { chats, chatsError } = await fetchTelegramChats(request, context, params.orgId);
+  const { chats, chatsError } = await fetchTelegramChats(request, context, scope);
   if (chatsError) {
     return {
       configError: null,
@@ -54,10 +54,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
 export default function BackofficeOrganisationTelegramMessagesLayout() {
   const { chats, configError, chatsError } = useLoaderData<typeof loader>();
-  const { orgId } = useOutletContext<TelegramLayoutContext>();
+  const { basePath: integrationBasePath } = useOutletContext<TelegramLayoutContext>();
   const { chatId } = useParams();
   const selectedChatId = chatId ?? null;
-  const basePath = `/backoffice/connections/telegram/${orgId}/messages`;
+  const basePath = `${integrationBasePath}/messages`;
   const isDetailRoute = Boolean(selectedChatId);
 
   if (configError) {

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/organisation-index.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/organisation-index.tsx
@@ -1,16 +1,14 @@
 import { redirect } from "react-router";
 
+import { resolveScopeFromRouteParams } from "../../integrations/scope";
 import type { Route } from "./+types/organisation-index";
 import { fetchTelegramConfig } from "./data";
 
-export async function loader({ params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
-
-  const { configState } = await fetchTelegramConfig(context, params.orgId);
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const scope = resolveScopeFromRouteParams(params);
+  const { configState } = await fetchTelegramConfig(context, scope);
   const target = configState?.configured ? "messages" : "configuration";
-  return redirect(`/backoffice/connections/telegram/${params.orgId}/${target}`);
+  return redirect(`${new URL(request.url).pathname.replace(/\/+$/u, "")}/${target}`);
 }
 
 export default function BackofficeOrganisationTelegramIndex() {

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/organisation-layout.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/organisation-layout.tsx
@@ -4,7 +4,12 @@ import { Outlet } from "react-router";
 import { getAuthMe } from "@/fragno/auth/auth-server";
 
 import { buildBackofficeLoginPath } from "../../auth-navigation";
-import { throwOrganisationNotFound } from "../../route-errors";
+import { fetchAutomationProjects } from "../../automations/data.server";
+import {
+  createIntegrationScopeSwitchOptions,
+  organizationIdFromScope,
+  resolveIntegrationContext,
+} from "../../integrations/scope";
 import type { Route } from "./+types/organisation-layout";
 import { fetchTelegramConfig } from "./data";
 import {
@@ -16,10 +21,6 @@ import {
 } from "./shared";
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
-  if (!params.orgId) {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const me = await getAuthMe(request, context);
   if (!me?.user) {
     const url = new URL(request.url);
@@ -29,26 +30,42 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     );
   }
 
-  const organisation =
-    me.organizations.find((entry) => entry.organization.id === params.orgId)?.organization ?? null;
-  if (!organisation) {
-    throwOrganisationNotFound(params.orgId);
-  }
+  const integration = resolveIntegrationContext({ params, me, integration: "telegram" });
+  const organizationForScope = organizationIdFromScope(integration.scope);
+  const organisation = organizationForScope
+    ? (me.organizations.find((entry) => entry.organization.id === organizationForScope)
+        ?.organization ?? null)
+    : null;
 
-  const { configState, configError } = await fetchTelegramConfig(context, params.orgId);
+  const projectOrgId =
+    organizationForScope ??
+    me.activeOrganization?.organization.id ??
+    me.organizations[0]?.organization.id;
+  const projectsResult = projectOrgId
+    ? await fetchAutomationProjects(request, context, projectOrgId)
+    : { projects: [] };
+  const scopeOptions = createIntegrationScopeSwitchOptions({
+    me,
+    projects: projectsResult.projects,
+    projectOrgId: projectOrgId ?? "",
+    integration: "telegram",
+  });
+
+  const { configState, configError } = await fetchTelegramConfig(context, integration.scope);
 
   return {
-    orgId: params.orgId,
+    ...integration,
     origin: new URL(request.url).origin,
     organisation,
+    scopeOptions,
     configState,
     configError,
   };
 }
 
 export function meta({ data }: Route.MetaArgs) {
-  const orgId = data?.orgId ?? "organisation";
-  return [{ title: `Telegram Setup · ${orgId}` }];
+  const label = data?.label ?? "scope";
+  return [{ title: `Telegram Setup · ${label}` }];
 }
 
 export function ErrorBoundary({ error, params }: Route.ErrorBoundaryProps) {
@@ -60,9 +77,14 @@ export default function BackofficeOrganisationTelegramLayout({
   matches,
 }: Route.ComponentProps) {
   const {
-    orgId,
     origin,
     organisation,
+    scope,
+    label,
+    basePath,
+    integrationsPath,
+    scopeSegment,
+    scopeOptions,
     configState: initialConfigState,
     configError: initialConfigError,
   } = loaderData;
@@ -73,7 +95,7 @@ export default function BackofficeOrganisationTelegramLayout({
   useEffect(() => {
     setConfigState(initialConfigState);
     setConfigError(initialConfigError);
-  }, [initialConfigError, initialConfigState, orgId]);
+  }, [initialConfigError, initialConfigState, scopeSegment]);
 
   let activeTab: TelegramTab = "configuration";
   const currentPath = (matches[matches.length - 1]?.pathname || "").replace(/\/+$/, "");
@@ -86,17 +108,26 @@ export default function BackofficeOrganisationTelegramLayout({
 
   return (
     <div className="space-y-4">
-      <TelegramHeader orgId={orgId} organisationName={organisation?.name ?? orgId} />
+      <TelegramHeader
+        organisationName={organisation?.name ?? label}
+        integrationsPath={integrationsPath}
+        scopeOptions={scopeOptions}
+      />
       <TelegramTabs
-        orgId={orgId}
+        basePath={basePath}
         activeTab={activeTab}
         isConfigured={Boolean(configState?.configured)}
       />
       <Outlet
         context={{
-          orgId,
           origin,
           organisation,
+          scope,
+          scopeSegment,
+          label,
+          basePath,
+          integrationsPath,
+          scopeOptions,
           configState,
           configLoading,
           configError,

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/shared.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/shared.tsx
@@ -1,9 +1,12 @@
 import type { Dispatch, SetStateAction } from "react";
 import { Link, isRouteErrorResponse } from "react-router";
 
+import type { BackofficeContextScope } from "@/backoffice-runtime/context";
 import { BackofficePageHeader } from "@/components/backoffice";
 import type { AuthMeData } from "@/fragno/auth/auth-client";
 
+import type { IntegrationScopeSwitchOption } from "../../integrations/scope";
+import { IntegrationScopeBreadcrumbSelector } from "../../integrations/scope-selector";
 import { getRouteErrorMessage, isOrganisationNotFoundError } from "../../route-errors";
 
 type BackofficeOrganisation = AuthMeData["organizations"][number]["organization"];
@@ -26,12 +29,17 @@ export type TelegramConfigState = {
 };
 
 export type TelegramLayoutContext = {
-  orgId: string;
   origin: string;
-  organisation: BackofficeOrganisation;
+  organisation: BackofficeOrganisation | null;
+  scope: BackofficeContextScope;
+  scopeSegment: string;
+  label: string;
+  basePath: string;
+  integrationsPath: string;
   configState: TelegramConfigState | null;
   configLoading: boolean;
   configError: string | null;
+  scopeOptions: IntegrationScopeSwitchOption[];
   setConfigState: Dispatch<SetStateAction<TelegramConfigState | null>>;
   setConfigError: Dispatch<SetStateAction<string | null>>;
 };
@@ -64,29 +72,36 @@ export const generateSecretToken = () => {
 };
 
 export function TelegramHeader({
-  orgId,
   organisationName,
+  integrationsPath,
+  scopeOptions,
 }: {
-  orgId: string;
   organisationName?: string | null;
+  integrationsPath: string;
+  scopeOptions: IntegrationScopeSwitchOption[];
 }) {
+  const scopeLabel = organisationName ?? "Scope";
+
   return (
     <BackofficePageHeader
       breadcrumbs={[
         { label: "Backoffice", to: "/backoffice" },
-        { label: "Connections", to: "/backoffice/connections" },
-        { label: "Telegram", to: "/backoffice/connections/telegram" },
-        { label: organisationName ?? orgId },
+        { label: "Automations", to: "/backoffice/automations" },
+        {
+          label: <IntegrationScopeBreadcrumbSelector label={scopeLabel} options={scopeOptions} />,
+        },
+        { label: "Integrations", to: integrationsPath },
+        { label: "Telegram" },
       ]}
       eyebrow="Integrations"
-      title={`Telegram for ${organisationName ?? orgId}`}
+      title={`Telegram for ${scopeLabel}`}
       description="Connect a Telegram bot, capture chat activity, and review messages per organisation."
       actions={
         <Link
-          to="/backoffice/connections/telegram"
+          to={integrationsPath}
           className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
         >
-          Back to Telegram
+          Back to integrations
         </Link>
       }
     />
@@ -94,15 +109,14 @@ export function TelegramHeader({
 }
 
 export function TelegramTabs({
-  orgId,
+  basePath,
   activeTab,
   isConfigured,
 }: {
-  orgId: string;
+  basePath: string;
   activeTab: TelegramTab;
   isConfigured: boolean;
 }) {
-  const basePath = `/backoffice/connections/telegram/${orgId}`;
   const tabs = [
     {
       id: "messages" as const,
@@ -158,10 +172,9 @@ export function TelegramTabs({
 
 export function TelegramErrorBoundary({
   error,
-  params,
 }: {
   error: unknown;
-  params: { orgId?: string };
+  params: { scopeKind?: string; scopeId?: string };
 }) {
   let statusCode = 500;
   let message = "An unexpected error occurred.";
@@ -174,13 +187,17 @@ export function TelegramErrorBoundary({
 
   message = getRouteErrorMessage(error, message);
 
-  if (statusCode === 404 && params.orgId && isOrganisationNotFoundError(error)) {
-    message = `Organisation '${params.orgId}' could not be found.`;
+  if (statusCode === 404 && isOrganisationNotFoundError(error)) {
+    message = "Organisation for this scope could not be found.";
   }
 
   return (
     <div className="space-y-4">
-      <TelegramHeader orgId={params.orgId ?? "organisation"} organisationName="Error" />
+      <TelegramHeader
+        integrationsPath="/backoffice/automations"
+        organisationName="Error"
+        scopeOptions={[]}
+      />
       <div className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-4 text-sm text-[var(--bo-muted)]">
         <p className="text-[10px] tracking-[0.22em] text-[var(--bo-muted-2)] uppercase">
           {statusCode} · {statusText}

--- a/apps/backoffice/app/routes/backoffice/integrations/scope-selector.tsx
+++ b/apps/backoffice/app/routes/backoffice/integrations/scope-selector.tsx
@@ -1,0 +1,87 @@
+import { Menu } from "@base-ui/react/menu";
+import { useNavigate } from "react-router";
+
+import type { IntegrationScopeSwitchOption } from "./scope";
+
+const scopeKindLabel = (kind: IntegrationScopeSwitchOption["kind"]) => {
+  switch (kind) {
+    case "system":
+      return "System";
+    case "org":
+      return "Org";
+    case "project":
+      return "Project";
+    case "user":
+      return "User";
+  }
+};
+
+export function IntegrationScopeBreadcrumbSelector({
+  label,
+  options,
+}: {
+  label: string;
+  options: IntegrationScopeSwitchOption[];
+}) {
+  const navigate = useNavigate();
+
+  if (options.length <= 1) {
+    return <span>{label}</span>;
+  }
+
+  return (
+    <Menu.Root modal={false}>
+      <Menu.Trigger
+        type="button"
+        className="inline-flex min-h-6 items-center gap-1 border border-transparent px-1.5 py-0.5 text-[10px] font-semibold tracking-[0.24em] text-[var(--bo-fg)] uppercase transition-colors hover:border-[color:var(--bo-border)] hover:bg-[var(--bo-panel-2)] data-[popup-open]:border-[color:var(--bo-border)] data-[popup-open]:bg-[var(--bo-panel-2)]"
+      >
+        <span>{label}</span>
+        <span aria-hidden="true" className="text-[8px] text-[var(--bo-muted-2)]">
+          ▾
+        </span>
+      </Menu.Trigger>
+      <Menu.Portal style={{ position: "relative", zIndex: 2147483647 }}>
+        <Menu.Positioner side="bottom" align="start" sideOffset={6} style={{ zIndex: 2147483647 }}>
+          <Menu.Popup className="relative max-h-[min(22rem,calc(100vh-8rem))] w-64 overflow-y-auto border border-[color:var(--bo-border-strong)] bg-[var(--bo-panel)] p-1.5 text-left tracking-normal shadow-[0_18px_50px_rgba(15,23,42,0.22)] outline-none dark:shadow-[0_22px_60px_rgba(0,0,0,0.55)]">
+            <Menu.Group className="space-y-1">
+              <Menu.GroupLabel className="px-2 py-1 text-[9px] font-semibold tracking-[0.24em] text-[var(--bo-muted-2)] uppercase">
+                Switch scope
+              </Menu.GroupLabel>
+              {options.map((option) => {
+                const isCurrent = option.label === label;
+                return (
+                  <Menu.Item
+                    key={option.id}
+                    disabled={isCurrent}
+                    onClick={() => {
+                      if (!isCurrent) {
+                        void navigate(option.to);
+                      }
+                    }}
+                    className={
+                      isCurrent
+                        ? "grid cursor-default gap-1 border border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] px-2.5 py-2 text-left text-[var(--bo-accent-fg)] outline-none"
+                        : "grid gap-1 border border-transparent px-2.5 py-2 text-left text-[var(--bo-muted)] transition-colors outline-none data-[highlighted]:border-[color:var(--bo-border-strong)] data-[highlighted]:bg-[var(--bo-panel-2)] data-[highlighted]:text-[var(--bo-fg)]"
+                    }
+                  >
+                    <span className="flex min-w-0 items-center justify-between gap-3">
+                      <span className="truncate text-sm font-medium tracking-normal text-[var(--bo-fg)] normal-case">
+                        {option.label}
+                      </span>
+                      <span className="shrink-0 text-[9px] font-semibold tracking-[0.18em] text-[var(--bo-muted-2)] uppercase">
+                        {scopeKindLabel(option.kind)}
+                      </span>
+                    </span>
+                    <span className="truncate text-xs tracking-normal text-[var(--bo-muted-2)] normal-case">
+                      {option.description}
+                    </span>
+                  </Menu.Item>
+                );
+              })}
+            </Menu.Group>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}

--- a/apps/backoffice/app/routes/backoffice/integrations/scope.ts
+++ b/apps/backoffice/app/routes/backoffice/integrations/scope.ts
@@ -1,0 +1,210 @@
+import type { RouterContextProvider } from "react-router";
+
+import type { BackofficeContextScope } from "@/backoffice-runtime/context";
+import {
+  backofficeContextScopeFromSinglePathSegment,
+  backofficeContextScopeSinglePathSegment,
+} from "@/backoffice-runtime/scope-codec";
+import type { AuthMeData } from "@/fragno/auth/auth-client";
+import { getAuthMe } from "@/fragno/auth/auth-server";
+
+import type { AutomationProjectRecord } from "../automations/data";
+import {
+  automationScopeBasePath,
+  automationScopeFromRouteParams,
+  createAutomationScopeOptions,
+  type AutomationScopeOption,
+  type AutomationUiScope,
+} from "../automations/scope";
+import { throwOrganisationNotFound } from "../route-errors";
+
+export type IntegrationRouteParams = {
+  scopeKind?: string;
+  scopeId?: string;
+};
+
+export type IntegrationScopeSwitchOption = AutomationScopeOption;
+
+export type ScopedIntegrationContext = {
+  scope: BackofficeContextScope;
+  uiScope: AutomationUiScope;
+  label: string;
+  basePath: string;
+  integrationsPath: string;
+  scopeSegment: string;
+  isScopedRoute: boolean;
+};
+
+export type AuthenticatedScopedIntegrationContext = ScopedIntegrationContext & {
+  me: AuthMeData;
+};
+
+export const scopeLabel = (scope: BackofficeContextScope, me: AuthMeData): string => {
+  switch (scope.kind) {
+    case "system":
+      return "System";
+    case "org": {
+      const organisation = me.organizations.find((entry) => entry.organization.id === scope.orgId);
+      return organisation?.organization.name ?? scope.orgId;
+    }
+    case "project":
+      return scope.projectId;
+    case "user":
+      return me.user.id === scope.userId ? (me.user.email ?? me.user.id) : scope.userId;
+  }
+};
+
+export const scopeToAutomationUiScope = (
+  scope: BackofficeContextScope,
+  me: AuthMeData,
+): AutomationUiScope => {
+  switch (scope.kind) {
+    case "system":
+      return { kind: "system", label: "System" };
+    case "org":
+      return { kind: "org", orgId: scope.orgId, label: scopeLabel(scope, me) };
+    case "project":
+      return {
+        kind: "project",
+        orgId: scope.orgId,
+        projectId: scope.projectId,
+        label: scope.projectId,
+      };
+    case "user":
+      return { kind: "user", userId: scope.userId, label: scopeLabel(scope, me) };
+  }
+};
+
+export const integrationBasePath = (scope: AutomationUiScope, integration: string) =>
+  `${automationScopeBasePath(scope)}/integrations/${integration}`;
+
+export const organizationIdFromScope = (scope: BackofficeContextScope): string | null =>
+  scope.kind === "org" || scope.kind === "project" ? scope.orgId : null;
+
+export const createIntegrationScopeSwitchOptions = ({
+  me,
+  projects,
+  projectOrgId,
+  integration,
+  allowedScopes,
+}: {
+  me: AuthMeData;
+  projects: AutomationProjectRecord[];
+  projectOrgId: string;
+  integration: string;
+  allowedScopes?: readonly BackofficeContextScope["kind"][];
+}): IntegrationScopeSwitchOption[] => {
+  const scopeOptions = createAutomationScopeOptions({
+    organisations: me.organizations.map((entry) => entry.organization),
+    projects,
+    user: me.user,
+    currentTab: "integrations",
+    projectOrgId,
+  });
+
+  return scopeOptions
+    .filter((option) => !allowedScopes || allowedScopes.includes(option.kind))
+    .map((option) => ({
+      ...option,
+      to: `${option.to}/${integration}`,
+    }));
+};
+
+export const resolveIntegrationContext = ({
+  params,
+  me,
+  integration,
+  allowedScopes,
+}: {
+  params: IntegrationRouteParams;
+  me: AuthMeData;
+  integration: string;
+  allowedScopes?: readonly BackofficeContextScope["kind"][];
+}): ScopedIntegrationContext => {
+  const scope = automationScopeFromRouteParams(params);
+  const isScopedRoute = true;
+
+  if (allowedScopes && !allowedScopes.includes(scope.kind)) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  if (scope.kind === "system" && me.user.role !== "admin") {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  const organizationId = organizationIdFromScope(scope);
+  if (
+    organizationId &&
+    !me.organizations.some((entry) => entry.organization.id === organizationId)
+  ) {
+    throwOrganisationNotFound(organizationId);
+  }
+
+  if (scope.kind === "user" && scope.userId !== me.user.id) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  const uiScope = scopeToAutomationUiScope(scope, me);
+  const scopedBasePath = integrationBasePath(uiScope, integration);
+  return {
+    scope,
+    uiScope,
+    label: scopeLabel(scope, me),
+    basePath: scopedBasePath,
+    integrationsPath: `${automationScopeBasePath(uiScope)}/integrations`,
+    scopeSegment: backofficeContextScopeSinglePathSegment(scope),
+    isScopedRoute,
+  };
+};
+
+export const resolveAuthenticatedIntegrationContext = async ({
+  request,
+  context,
+  params,
+  integration,
+  allowedScopes,
+}: {
+  request: Request;
+  context: Readonly<RouterContextProvider>;
+  params: IntegrationRouteParams;
+  integration: string;
+  allowedScopes?: readonly BackofficeContextScope["kind"][];
+}): Promise<AuthenticatedScopedIntegrationContext> => {
+  const me = await getAuthMe(request, context);
+  if (!me?.user) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  return {
+    ...resolveIntegrationContext({ params, me, integration, allowedScopes }),
+    me,
+  };
+};
+
+export const resolveScopeFromRouteParams = (
+  params: IntegrationRouteParams,
+): BackofficeContextScope => {
+  if (params.scopeKind && params.scopeId) {
+    return automationScopeFromRouteParams(params);
+  }
+
+  throw new Response("Not Found", { status: 404 });
+};
+
+export const resolveOrganizationScopeFromRouteParams = (
+  params: IntegrationRouteParams,
+): { scope: Extract<BackofficeContextScope, { kind: "org" }>; organizationId: string } => {
+  const scope = resolveScopeFromRouteParams(params);
+  if (scope.kind !== "org") {
+    throw new Response("Not Found", { status: 404 });
+  }
+  return { scope, organizationId: scope.orgId };
+};
+
+export const resolveScopeFromSinglePathOrOrg = (segment: string): BackofficeContextScope => {
+  try {
+    return backofficeContextScopeFromSinglePathSegment(segment);
+  } catch {
+    return { kind: "org", orgId: segment };
+  }
+};

--- a/packages-private/oxlint-plugins/package.json
+++ b/packages-private/oxlint-plugins/package.json
@@ -13,7 +13,8 @@
     "./fragment-dev-browser-exports": "./fragment-dev-browser-exports.js",
     "./docs-icons-sync": "./docs-icons-sync.js",
     "./vitest-assert-json-response": "./vitest-assert-json-response.js",
-    "./zod-inline-schema-definitions": "./zod-inline-schema-definitions.js"
+    "./zod-inline-schema-definitions": "./zod-inline-schema-definitions.js",
+    "./zod-v4-object-factories": "./zod-v4-object-factories.js"
   },
   "scripts": {
     "types:check": "tsgo --noEmit"

--- a/packages-private/oxlint-plugins/zod-v4-object-factories.js
+++ b/packages-private/oxlint-plugins/zod-v4-object-factories.js
@@ -1,0 +1,170 @@
+/**
+ * @import { Rule } from 'eslint'
+ */
+
+/**
+ * @param {any} node
+ * @returns {any}
+ */
+const unwrapExpression = (node) => {
+  let current = node;
+  while (
+    current?.type === "ChainExpression" ||
+    current?.type === "TSAsExpression" ||
+    current?.type === "TSSatisfiesExpression" ||
+    current?.type === "TSNonNullExpression"
+  ) {
+    current = current.expression;
+  }
+  return current;
+};
+
+/**
+ * @param {any} node
+ * @returns {node is { type: "Identifier", name: string }}
+ */
+const isIdentifier = (node) => unwrapExpression(node)?.type === "Identifier";
+
+/**
+ * @param {any} specifier
+ * @returns {string | null}
+ */
+const zodNamespaceNameFromSpecifier = (specifier) => {
+  if (specifier.type === "ImportNamespaceSpecifier") {
+    return specifier.local?.name ?? null;
+  }
+
+  if (specifier.type === "ImportSpecifier" && specifier.imported?.name === "z") {
+    return specifier.local?.name ?? null;
+  }
+
+  return null;
+};
+
+/**
+ * @param {any} callee
+ * @param {Set<string>} zodNamespaceNames
+ * @returns {string | null}
+ */
+const zodObjectNamespaceName = (callee, zodNamespaceNames) => {
+  const expression = unwrapExpression(callee);
+  if (
+    expression?.type !== "MemberExpression" ||
+    expression.computed === true ||
+    expression.property?.type !== "Identifier" ||
+    expression.property.name !== "object"
+  ) {
+    return null;
+  }
+
+  const namespace = unwrapExpression(expression.object);
+  if (!isIdentifier(namespace) || !zodNamespaceNames.has(namespace.name)) {
+    return null;
+  }
+
+  return namespace.name;
+};
+
+/** @type {Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prefer Zod 4 top-level object factories over Zod 3 object mode methods",
+      category: "Best Practices",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      preferStrictObject: "Use z.strictObject(...) instead of z.object(...).strict().",
+      preferLooseObject: "Use z.looseObject(...) instead of z.object(...).passthrough().",
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const sourceText = sourceCode.getText();
+    const zodNamespaceNames = new Set();
+
+    return {
+      /** @param {any} node */
+      Program(node) {
+        for (const statement of node.body) {
+          if (statement.type !== "ImportDeclaration" || statement.source?.value !== "zod") {
+            continue;
+          }
+
+          for (const specifier of statement.specifiers) {
+            const name = zodNamespaceNameFromSpecifier(specifier);
+            if (name) {
+              zodNamespaceNames.add(name);
+            }
+          }
+        }
+      },
+
+      /** @param {any} node */
+      CallExpression(node) {
+        const callee = unwrapExpression(node.callee);
+        if (
+          callee?.type !== "MemberExpression" ||
+          callee.computed === true ||
+          callee.property?.type !== "Identifier" ||
+          node.arguments.length > 0
+        ) {
+          return;
+        }
+
+        const replacementFactory =
+          callee.property.name === "strict"
+            ? "strictObject"
+            : callee.property.name === "passthrough"
+              ? "looseObject"
+              : null;
+        if (!replacementFactory) {
+          return;
+        }
+
+        const objectCall = unwrapExpression(callee.object);
+        if (objectCall?.type !== "CallExpression" || !objectCall.range || !node.range) {
+          return;
+        }
+
+        const namespaceName = zodObjectNamespaceName(objectCall.callee, zodNamespaceNames);
+        if (!namespaceName || !objectCall.callee?.range) {
+          return;
+        }
+
+        const openParenIndex = sourceText.indexOf("(", objectCall.callee.range[1]);
+        if (openParenIndex < 0 || openParenIndex >= objectCall.range[1]) {
+          return;
+        }
+
+        const argsText = sourceText.slice(openParenIndex + 1, objectCall.range[1] - 1);
+        context.report({
+          node,
+          messageId:
+            replacementFactory === "strictObject" ? "preferStrictObject" : "preferLooseObject",
+          fix(fixer) {
+            return fixer.replaceTextRange(
+              node.range,
+              `${namespaceName}.${replacementFactory}(${argsText})`,
+            );
+          },
+        });
+      },
+    };
+  },
+};
+
+const plugin = {
+  meta: {
+    name: "zod-v4-object-factories",
+    version: "1.0.0",
+  },
+  rules: {
+    "prefer-object-factories": rule,
+  },
+};
+
+export default plugin;

--- a/packages/api-fragment/src/oauth.ts
+++ b/packages/api-fragment/src/oauth.ts
@@ -23,16 +23,14 @@ export const oauthTokensSchema = z.object({
   raw: z.record(z.string(), z.unknown()).optional(),
 });
 
-const oauthTokenResponseSchema = z
-  .object({
-    access_token: z.string().optional(),
-    refresh_token: z.string().optional(),
-    token_type: z.string().optional(),
-    expires_in: z.coerce.number().finite().optional(),
-    scope: z.string().optional(),
-    id_token: z.string().optional(),
-  })
-  .passthrough();
+const oauthTokenResponseSchema = z.looseObject({
+  access_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  token_type: z.string().optional(),
+  expires_in: z.coerce.number().finite().optional(),
+  scope: z.string().optional(),
+  id_token: z.string().optional(),
+});
 
 export { bytesToBase64Url, randomBase64Url } from "./crypto";
 

--- a/packages/auth/src/session/session-seed.ts
+++ b/packages/auth/src/session/session-seed.ts
@@ -2,11 +2,9 @@ import { z } from "zod";
 
 import { toExternalId } from "../organization/utils";
 
-export const credentialSeedSchema = z
-  .object({
-    activeOrganizationId: z.string().trim().min(1).optional(),
-  })
-  .strict();
+export const credentialSeedSchema = z.strictObject({
+  activeOrganizationId: z.string().trim().min(1).optional(),
+});
 
 export type CredentialSeedInput = z.input<typeof credentialSeedSchema>;
 export type CredentialSeed = z.output<typeof credentialSeedSchema>;

--- a/packages/pi-fragment/src/pi/workflows/interactive-chat-workflow.ts
+++ b/packages/pi-fragment/src/pi/workflows/interactive-chat-workflow.ts
@@ -18,93 +18,77 @@ type InteractiveChatWorkflowParams = {
   initialMessages?: AgentMessage[];
 };
 
-const textContentSchema = z
-  .object({
-    type: z.literal("text"),
-    text: z.string(),
-    textSignature: z.string().optional(),
-  })
-  .passthrough();
+const textContentSchema = z.looseObject({
+  type: z.literal("text"),
+  text: z.string(),
+  textSignature: z.string().optional(),
+});
 
-const imageContentSchema = z
-  .object({
-    type: z.literal("image"),
-    data: z.string(),
-    mimeType: z.string(),
-  })
-  .passthrough();
+const imageContentSchema = z.looseObject({
+  type: z.literal("image"),
+  data: z.string(),
+  mimeType: z.string(),
+});
 
-const thinkingContentSchema = z
-  .object({
-    type: z.literal("thinking"),
-    thinking: z.string(),
-    thinkingSignature: z.string().optional(),
-    redacted: z.boolean().optional(),
-  })
-  .passthrough();
+const thinkingContentSchema = z.looseObject({
+  type: z.literal("thinking"),
+  thinking: z.string(),
+  thinkingSignature: z.string().optional(),
+  redacted: z.boolean().optional(),
+});
 
-const toolCallSchema = z
-  .object({
-    type: z.literal("toolCall"),
-    id: z.string(),
-    name: z.string(),
-    arguments: z.record(z.string(), z.unknown()),
-    thoughtSignature: z.string().optional(),
-  })
-  .passthrough();
+const toolCallSchema = z.looseObject({
+  type: z.literal("toolCall"),
+  id: z.string(),
+  name: z.string(),
+  arguments: z.record(z.string(), z.unknown()),
+  thoughtSignature: z.string().optional(),
+});
 
-const usageSchema = z
-  .object({
+const usageSchema = z.looseObject({
+  input: z.number(),
+  output: z.number(),
+  cacheRead: z.number(),
+  cacheWrite: z.number(),
+  totalTokens: z.number(),
+  cost: z.object({
     input: z.number(),
     output: z.number(),
     cacheRead: z.number(),
     cacheWrite: z.number(),
-    totalTokens: z.number(),
-    cost: z.object({
-      input: z.number(),
-      output: z.number(),
-      cacheRead: z.number(),
-      cacheWrite: z.number(),
-      total: z.number(),
-    }),
-  })
-  .passthrough();
+    total: z.number(),
+  }),
+});
 
 const agentMessageShapeSchema = z.discriminatedUnion("role", [
-  z
-    .object({
-      role: z.literal("user"),
-      content: z.union([z.string(), z.array(z.union([textContentSchema, imageContentSchema]))]),
-      timestamp: z.number(),
-    })
-    .passthrough(),
-  z
-    .object({
-      role: z.literal("assistant"),
-      content: z.array(z.union([textContentSchema, thinkingContentSchema, toolCallSchema])),
-      api: z.string(),
-      provider: z.string(),
-      model: z.string(),
-      responseModel: z.string().optional(),
-      responseId: z.string().optional(),
-      diagnostics: z.array(z.unknown()).optional(),
-      usage: usageSchema,
-      stopReason: z.enum(["stop", "length", "toolUse", "error", "aborted"]),
-      errorMessage: z.string().optional(),
-      timestamp: z.number(),
-    })
-    .passthrough(),
-  z
-    .object({
-      role: z.literal("toolResult"),
-      toolCallId: z.string(),
-      toolName: z.string(),
-      content: z.array(z.union([textContentSchema, imageContentSchema])),
-      details: z.unknown().optional(),
-      isError: z.boolean(),
-      timestamp: z.number(),
-    })
-    .passthrough(),
+  z.looseObject({
+    role: z.literal("user"),
+    content: z.union([z.string(), z.array(z.union([textContentSchema, imageContentSchema]))]),
+    timestamp: z.number(),
+  }),
+  z.looseObject({
+    role: z.literal("assistant"),
+    content: z.array(z.union([textContentSchema, thinkingContentSchema, toolCallSchema])),
+    api: z.string(),
+    provider: z.string(),
+    model: z.string(),
+    responseModel: z.string().optional(),
+    responseId: z.string().optional(),
+    diagnostics: z.array(z.unknown()).optional(),
+    usage: usageSchema,
+    stopReason: z.enum(["stop", "length", "toolUse", "error", "aborted"]),
+    errorMessage: z.string().optional(),
+    timestamp: z.number(),
+  }),
+  z.looseObject({
+    role: z.literal("toolResult"),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    content: z.array(z.union([textContentSchema, imageContentSchema])),
+    details: z.unknown().optional(),
+    isError: z.boolean(),
+    timestamp: z.number(),
+  }),
 ]);
 
 const agentMessageSchema = z.custom<AgentMessage>(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Integrations** section under Automations for Telegram, Resend, and GitHub.
  * Users can now switch between available scopes directly from integration breadcrumbs.
  * Updated navigation to surface integration settings in the Automations area.

* **Bug Fixes**
  * Improved routing for Telegram, Resend, and GitHub pages so links open the correct scoped workspace.
  * Fixed attachment, messages, threads, and configuration links to work across org, project, and system scopes.
  * Breadcrumbs now support richer labels and display more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->