### PR TITLE
Wilco/bo sessions lofi

### DIFF
--- a/.changeset/db-lofi-outbox-now-defaults.md
+++ b/.changeset/db-lofi-outbox-now-defaults.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/db": patch
+"@fragno-dev/lofi": patch
+---
+
+fix: include db-now defaults in create outbox payloads.

--- a/.changeset/lofi-runtime-stores.md
+++ b/.changeset/lofi-runtime-stores.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/lofi": patch
+---
+
+feat: add typed runtime retrieve transactions and store builders.

--- a/.changeset/lofi-schema-aliases.md
+++ b/.changeset/lofi-schema-aliases.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/lofi": patch
+---
+
+fix: resolve registered schema names consistently in Lofi adapters.

--- a/.changeset/workflows-step-emission-db-time.md
+++ b/.changeset/workflows-step-emission-db-time.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/workflows": patch
+---
+
+fix: persist workflow step emissions with database timestamps.

--- a/apps/backoffice/app/fragno/pi/pi-client.ts
+++ b/apps/backoffice/app/fragno/pi/pi-client.ts
@@ -1,5 +1,7 @@
 import { createSessionProjectionDataStore } from "@fragno-dev/pi-harness/client/workflow-lofi-session-projection";
 import { createPiFragmentClient } from "@fragno-dev/pi-harness/react";
+import { piSchema } from "@fragno-dev/pi-harness/schema";
+import type { PiSession, PiWorkflowStatus } from "@fragno-dev/pi-harness/types";
 import { workflowsSchema } from "@fragno-dev/workflows/schema";
 
 import { createLofiRuntime, createLofiRuntimeRegistry, IndexedDbAdapter } from "@fragno-dev/lofi";
@@ -7,6 +9,18 @@ import { createLofiRuntime, createLofiRuntimeRegistry, IndexedDbAdapter } from "
 const PI_LOFI_ENDPOINT = "backoffice-pi";
 
 const sanitizeDatabaseNamePart = (value: string) => value.replace(/[^a-zA-Z0-9_-]+/g, "_");
+
+const piWorkflowStatuses = new Set<string>([
+  "active",
+  "waiting",
+  "paused",
+  "complete",
+  "errored",
+  "terminated",
+]);
+
+const isPiWorkflowStatus = (value: string): value is PiWorkflowStatus =>
+  piWorkflowStatuses.has(value);
 
 const piLofiRuntimeConfig = (orgId: string) => ({
   orgId,
@@ -22,19 +36,81 @@ const piLofiRuntimes = createLofiRuntimeRegistry({
       adapter: new IndexedDbAdapter({
         dbName,
         endpointName: PI_LOFI_ENDPOINT,
-        schemas: [{ schema: workflowsSchema }],
+        schemas: [{ schema: piSchema }, { schema: workflowsSchema }],
         ignoreUnknownSchemas: true,
       }),
       sources: [
         {
-          id: `pi-workflows:${orgId}`,
-          outboxUrl: `/api/pi-workflows/${encodeURIComponent(orgId)}/_internal/outbox`,
+          id: `pi:${orgId}`,
+          outboxUrl: `/api/pi/${encodeURIComponent(orgId)}/_internal/outbox`,
         },
       ],
       outboxTransport: "stream",
       streamReconnectIntervalMs: 300,
     }),
 });
+
+export type PiLofiSessionListingData = {
+  sessions: PiSession[];
+  workflowStatuses: Record<string, PiWorkflowStatus | null>;
+};
+
+export const createPiLofiSessionListingStore = (
+  orgId: string,
+  workflowName: string,
+  options: { initialData: PiLofiSessionListingData; limit?: number },
+) => {
+  const runtime = piLofiRuntimes.get(piLofiRuntimeConfig(orgId));
+  const limit = options.limit ?? 50;
+
+  return runtime
+    .store()
+    .retrieve(({ forSchema }) => ({
+      sessions: forSchema(piSchema).find("session", (b) =>
+        b
+          .whereIndex("idx_session_workflow_created", (eb) => eb("workflowName", "=", workflowName))
+          .orderByIndex("idx_session_workflow_created", "desc")
+          .pageSize(limit)
+          .select(["sessionId", "name", "agent", "workflowName", "createdAt", "updatedAt"]),
+      ),
+      workflows: forSchema(workflowsSchema).find("workflow_instance", (b) =>
+        b
+          .whereIndex("idx_workflow_instance_workflowName_instanceId", (eb) =>
+            eb("workflowName", "=", workflowName),
+          )
+          .select(["instanceId", "status"]),
+      ),
+    }))
+    .transformRetrieve(({ sessions, workflows }) => {
+      const workflowStatusByInstanceId: Record<string, PiWorkflowStatus | null> = {};
+      for (const workflow of workflows) {
+        workflowStatusByInstanceId[workflow.instanceId] = isPiWorkflowStatus(workflow.status)
+          ? workflow.status
+          : null;
+      }
+
+      const mappedSessions = sessions.map(
+        (session): PiSession => ({
+          id: session.sessionId,
+          name: session.name ?? null,
+          agent: session.agent,
+          workflowName: session.workflowName,
+          createdAt: session.createdAt,
+          updatedAt: session.updatedAt,
+        }),
+      );
+      const workflowStatuses: Record<string, PiWorkflowStatus | null> = {};
+      for (const session of mappedSessions) {
+        workflowStatuses[session.id] = workflowStatusByInstanceId[session.id] ?? null;
+      }
+
+      return {
+        sessions: mappedSessions,
+        workflowStatuses,
+      };
+    })
+    .withInitialData(options.initialData);
+};
 
 export const createPiLofiSessionProjectionStore = (
   orgId: string,

--- a/apps/backoffice/app/routes/backoffice/sessions/sessions.tsx
+++ b/apps/backoffice/app/routes/backoffice/sessions/sessions.tsx
@@ -1,4 +1,5 @@
 import { ScrollArea } from "@base-ui/react/scroll-area";
+import { useStore } from "@fragno-dev/core/react";
 import type { PiSession, PiWorkflowStatus } from "@fragno-dev/pi-harness/types";
 import { INTERACTIVE_CHAT_WORKFLOW_NAME } from "@fragno-dev/pi-harness/workflows/interactive-chat-workflow";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
@@ -16,6 +17,7 @@ import {
 } from "react-router";
 
 import { getAuthMe } from "@/fragno/auth/auth-server";
+import { createPiLofiSessionListingStore } from "@/fragno/pi/pi-client";
 import {
   createPiAgentName,
   findPiModelOption,
@@ -323,8 +325,13 @@ export async function action({ request, params, context }: Route.ActionArgs) {
 }
 
 export default function BackofficeOrganisationPiSessionsLayout() {
-  const { sessions, configError, sessionsError, turnSummaries, workflowStatuses } =
-    useLoaderData<typeof loader>();
+  const {
+    sessions: serverSessions,
+    configError,
+    sessionsError,
+    turnSummaries: serverTurnSummaries,
+    workflowStatuses: serverWorkflowStatuses,
+  } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>() as PiSessionsActionData | undefined;
   const navigation = useNavigation();
   const { orgId, configState } = useOutletContext<PiLayoutContext>();
@@ -335,6 +342,25 @@ export default function BackofficeOrganisationPiSessionsLayout() {
   const isNewSession = searchParams.get("new") === "1";
   const basePath = `/backoffice/sessions/${orgId}/sessions`;
   const isDetailRoute = Boolean(selectedSessionId);
+  const lofiSessionListingStore = useMemo(
+    () =>
+      createPiLofiSessionListingStore(orgId, INTERACTIVE_CHAT_WORKFLOW_NAME, {
+        initialData: {
+          sessions: serverSessions,
+          workflowStatuses: serverWorkflowStatuses,
+        },
+      }),
+    [orgId, serverSessions, serverWorkflowStatuses],
+  );
+  const lofiSessionListing = useStore(lofiSessionListingStore);
+  const { sessions, workflowStatuses } = lofiSessionListing.data;
+  const turnSummaries = serverTurnSummaries;
+  const lofiSessionListingError =
+    lofiSessionListing.error instanceof Error
+      ? lofiSessionListing.error.message
+      : lofiSessionListing.error
+        ? "Pi session listing sync failed."
+        : null;
   const activeIntent = navigation.formData?.get("intent");
   const creating = navigation.state === "submitting" && activeIntent === "create-session";
   const harnesses = resolvePiHarnesses(configState?.config?.harnesses);
@@ -384,13 +410,9 @@ export default function BackofficeOrganisationPiSessionsLayout() {
     );
   }
 
-  if (sessionsError) {
-    return (
-      <div className="border border-red-200 bg-red-50 p-4 text-sm text-red-600">
-        {sessionsError}
-      </div>
-    );
-  }
+  const sessionListingServerError = sessionsError?.trim() || null;
+  const sessionListingBlockingError =
+    sessionListingServerError && sessions.length === 0 ? sessionListingServerError : null;
 
   const isDetailView = isDetailRoute || isNewSession;
   // Use flex for both; max-lg:hidden only applies below lg so lg layout stays stable
@@ -523,6 +545,18 @@ export default function BackofficeOrganisationPiSessionsLayout() {
             </span>
           </div>
         </Link>
+
+        {sessionListingServerError ? (
+          <div className="border border-amber-300/60 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-200">
+            {sessionListingBlockingError ?? "Server refresh failed; showing local session data."}
+          </div>
+        ) : null}
+
+        {lofiSessionListingError ? (
+          <div className="border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600">
+            {lofiSessionListingError}
+          </div>
+        ) : null}
 
         <ScrollArea.Root className="relative mt-3 flex min-h-0 flex-1 overflow-hidden">
           <ScrollArea.Viewport className="min-h-0 flex-1 pr-1">

--- a/apps/backoffice/scripts/create-dev-account.sh
+++ b/apps/backoffice/scripts/create-dev-account.sh
@@ -25,7 +25,7 @@ while [[ $# -gt 0 ]]; do
       fi
       BACKOFFICE_URL="$(
         printf '%s' "$BACKOFFICE_URL" |
-          sed -E "s#^(https?://[^/ :]+)(:[0-9]+)?(.*)$#\1:${PORT}\3#"
+          sed -E "s#^(https?://[^/ :]+)(:[0-9]+)?(.*)\$#\1:${PORT}\3#"
       )"
       shift 2
       ;;

--- a/packages/fragment-workflows/src/new-runner.ts
+++ b/packages/fragment-workflows/src/new-runner.ts
@@ -324,7 +324,7 @@ function addStepCommittedEmissions(
     if (!mutatedStepKeys.has(request.stepKey)) {
       continue;
     }
-    const createdAt = new Date();
+    const localObservedAt = new Date();
     const payload = { control: "step-committed" as const, epoch: request.epoch };
     const id = schemaUow.create("workflow_step_emission", {
       instanceRef: request.instanceRef,
@@ -333,7 +333,7 @@ function addStepCommittedEmissions(
       sequence: 0,
       actor: "system",
       payload,
-      createdAt,
+      createdAt: schemaUow.now(),
     });
     publishedStepEmissions.push({
       id: id.toString(),
@@ -342,7 +342,7 @@ function addStepCommittedEmissions(
       epoch: request.epoch,
       sequence: 0,
       payload,
-      createdAt,
+      createdAt: localObservedAt,
     });
   }
 }

--- a/packages/fragment-workflows/src/runner/step-live-pump.ts
+++ b/packages/fragment-workflows/src/runner/step-live-pump.ts
@@ -198,7 +198,7 @@ const writeWorkflowStepEmissionFlush = async <TOutEmission, TInEvent>(options: {
         actor: typeof WORKFLOW_EVENT_ACTOR_SYSTEM | typeof WORKFLOW_EVENT_ACTOR_USER;
         payload: unknown;
       }) => {
-        const createdAt = new Date();
+        const localObservedAt = new Date();
         const id = uow.create("workflow_step_emission", {
           instanceRef: instance.id,
           stepKey: row.stepKey,
@@ -206,9 +206,9 @@ const writeWorkflowStepEmissionFlush = async <TOutEmission, TInEvent>(options: {
           sequence: row.sequence,
           actor: row.actor,
           payload: row.payload,
-          createdAt,
+          createdAt: uow.now(),
         });
-        createdRows.push({ ...row, createdAt, id: id.toString() });
+        createdRows.push({ ...row, createdAt: localObservedAt, id: id.toString() });
       };
 
       for (const [stepKey, scope] of options.scopes) {

--- a/packages/fragno-db/src/outbox/outbox-builder.ts
+++ b/packages/fragno-db/src/outbox/outbox-builder.ts
@@ -1,5 +1,5 @@
 import { internalSchema } from "../fragments/internal-fragment.schema";
-import { getDbNowOffsetMs, isDbNow } from "../query/db-now";
+import { dbNow, getDbNowOffsetMs, isDbNow } from "../query/db-now";
 import type { MutationOperation } from "../query/unit-of-work/unit-of-work";
 import type { AnySchema, AnyTable } from "../schema/create";
 import { FragnoId, FragnoReference, getTableForeignKey } from "../schema/create";
@@ -44,7 +44,7 @@ export function buildOutboxPlan(operations: MutationOperation<AnySchema>[]): Out
         namespace,
         table: op.table,
         externalId: op.generatedExternalId,
-        values: encodeOutboxValues({
+        values: encodeOutboxCreateValues({
           table,
           values: op.values,
           mutationIndex,
@@ -140,6 +140,28 @@ function materializeOutboxDbNowValue(value: unknown, now: Date): unknown {
   }
 
   return value;
+}
+
+function encodeOutboxCreateValues(options: {
+  table: AnyTable;
+  values: Record<string, unknown>;
+  mutationIndex: number;
+  namespace?: string;
+  lookups: OutboxRefLookup[];
+}): Record<string, unknown> {
+  const output = encodeOutboxValues(options);
+
+  for (const [key, column] of Object.entries(options.table.columns)) {
+    if (column.role === "internal-id" || Object.prototype.hasOwnProperty.call(output, key)) {
+      continue;
+    }
+
+    if (column.default && "dbSpecial" in column.default && column.default.dbSpecial === "now") {
+      output[key] = dbNow();
+    }
+  }
+
+  return output;
 }
 
 function encodeOutboxValues(options: {

--- a/packages/fragno-db/src/outbox/outbox.test.ts
+++ b/packages/fragno-db/src/outbox/outbox.test.ts
@@ -24,7 +24,10 @@ const outboxSchema = schema("outbox", (s) => {
       return t
         .addColumn("id", idColumn())
         .addColumn("email", column("string"))
-        .addColumn("createdAt", column("timestamp").nullable())
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
         .createIndex("idx_users_email", ["email"], { unique: true });
     })
     .addTable("posts", (t) => {
@@ -288,6 +291,25 @@ describe("Fragno DB Outbox", () => {
     });
 
     await createUserWithDbNow(fragment, "db-now@example.com");
+
+    const entries = await listOutbox(internalFragment);
+    expect(entries).toHaveLength(1);
+    const payload = superjson.deserialize(entries[0].payload as SuperJSONResult) as OutboxPayload;
+    const mutation = payload.mutations[0];
+    assert(mutation.op === "create");
+    expect(mutation.values["createdAt"]).toBeInstanceOf(Date);
+    expect(mutation.values["createdAt"]).not.toMatchObject({ tag: "db-now" });
+
+    await cleanup();
+  });
+
+  it("materializes omitted db-now defaults before serializing create outbox payloads", async () => {
+    const { fragment, internalFragment, cleanup } = await buildOutboxTest({
+      type: "kysely-sqlite",
+      outboxEnabled: true,
+    });
+
+    await createUser(fragment, "db-now-default@example.com");
 
     const entries = await listOutbox(internalFragment);
     expect(entries).toHaveLength(1);

--- a/packages/lofi/src/adapters/in-memory/adapter.test.ts
+++ b/packages/lofi/src/adapters/in-memory/adapter.test.ts
@@ -74,6 +74,157 @@ const userViewProjection = defineLocalProjection({
 });
 
 describe("InMemoryLofiAdapter", () => {
+  it("normalizes default schema names for outbox application and queries", async () => {
+    const fragmentSchema = schema("app-fragment", (s) =>
+      s.addTable("users", (t) => t.addColumn("id", idColumn()).addColumn("name", column("string"))),
+    );
+    const adapter = new InMemoryLofiAdapter({
+      endpointName: "app",
+      schemas: [fragmentSchema],
+    });
+
+    await adapter.applyOutboxEntry({
+      sourceKey: "app::outbox",
+      versionstamp: "vs1",
+      uowId: "uow-vs1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app-fragment",
+          table: "users",
+          externalId: "user-1",
+          versionstamp: "vs1",
+          values: { name: "Ada" },
+        },
+      ],
+    });
+
+    const users = await adapter
+      .createQueryEngine(fragmentSchema)
+      .find("users", (b) => b.whereIndex("primary"));
+    expect(users).toEqual([expect.objectContaining({ name: "Ada" })]);
+  });
+
+  it("matches raw source schema names and writes through raw local schema names in projections", async () => {
+    const fragmentSchema = schema("app-fragment", (s) =>
+      s.addTable("users", (t) => t.addColumn("id", idColumn()).addColumn("name", column("string"))),
+    );
+    const localSchema = schema("local-user-view", (s) =>
+      s.addTable("user_cards", (t) =>
+        t.addColumn("id", idColumn()).addColumn("displayName", column("string")),
+      ),
+    );
+    const adapter = new InMemoryLofiAdapter({
+      endpointName: "app",
+      schemas: [fragmentSchema],
+      localSchemas: [localSchema],
+      projections: [
+        defineLocalProjection({
+          mutate: ({ mutations, match, tx }) => {
+            const userCards = tx.forSchema(localSchema);
+            for (const rawMutation of mutations) {
+              const mutation = match.one(rawMutation, fragmentSchema, "users", "create");
+              if (!mutation) {
+                continue;
+              }
+              userCards.create("user_cards", {
+                id: mutation.externalId,
+                displayName: String(mutation.values.name),
+              });
+            }
+          },
+        }),
+      ],
+    });
+
+    await adapter.applyOutboxEntry({
+      sourceKey: "app::outbox",
+      versionstamp: "vs1",
+      uowId: "uow-vs1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app-fragment",
+          table: "users",
+          externalId: "user-1",
+          versionstamp: "vs1",
+          values: { name: "Ada" },
+        },
+      ],
+    });
+
+    const cards = await adapter
+      .createQueryEngine(localSchema)
+      .find("user_cards", (b) => b.whereIndex("primary"));
+    expect(cards).toEqual([expect.objectContaining({ displayName: "Ada" })]);
+  });
+
+  it("lets projections from multiple outbox sources write into the same local database", async () => {
+    const adapter = new InMemoryLofiAdapter({
+      endpointName: "app",
+      schemas: [appSchema],
+      localSchemas: [userViewSchema],
+      projections: [
+        defineLocalProjection({
+          mutate: ({ mutations, match, source, tx }) => {
+            const userCards = tx.forSchema(userViewSchema);
+            for (const rawMutation of mutations) {
+              const mutation = match.one(rawMutation, appSchema, "users", "create");
+              if (!mutation) {
+                continue;
+              }
+
+              userCards.create("user_cards", {
+                id: `${source.sourceKey}:${mutation.externalId}`,
+                displayName: `${source.sourceKey}:${mutation.values.name}`,
+              });
+            }
+          },
+        }),
+      ],
+    });
+
+    await adapter.applyOutboxEntry({
+      sourceKey: "org-a::outbox",
+      versionstamp: "vs-a1",
+      uowId: "uow-a1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app",
+          table: "users",
+          externalId: "user-a",
+          versionstamp: "vs-a1",
+          values: { name: "Ada" },
+        },
+      ],
+    });
+    await adapter.applyOutboxEntry({
+      sourceKey: "org-b::outbox",
+      versionstamp: "vs-b1",
+      uowId: "uow-b1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app",
+          table: "users",
+          externalId: "user-b",
+          versionstamp: "vs-b1",
+          values: { name: "Bob" },
+        },
+      ],
+    });
+
+    const cards = await adapter
+      .createQueryEngine(userViewSchema)
+      .find("user_cards", (b) => b.whereIndex("primary"));
+
+    expect(cards).toMatchObject([
+      { displayName: "org-a::outbox:Ada" },
+      { displayName: "org-b::outbox:Bob" },
+    ]);
+  });
+
   it("applies outbox entries once and records inbox", async () => {
     const adapter = new InMemoryLofiAdapter({ endpointName: "app", schemas: [appSchema] });
 

--- a/packages/lofi/src/adapters/in-memory/adapter.ts
+++ b/packages/lofi/src/adapters/in-memory/adapter.ts
@@ -12,8 +12,12 @@ import {
   getLocalReadTarget,
   isThenable,
   mergeSchemaLists,
+  normalizeLofiSchemaName,
+  resolveLofiSchemaName,
   projectionRowToRecord,
   resolveProjectionReadPlan,
+  withLofiSchemaName,
+  type LofiSchemaNameAliases,
   type ProjectionQueuedMutation,
 } from "../../local/projection";
 import { resolveMutationValues, resolveMutations } from "../../query/mutation-values";
@@ -51,6 +55,16 @@ type InMemoryProjectionReadFallback = {
 type InMemoryApplyMutationsOptions = {
   projectionMutations?: LofiMutation[];
   projectionReadFallback?: InMemoryProjectionReadFallback;
+};
+
+const createSchemaNameAliases = (schemas: readonly AnySchema[]): Map<string, string> => {
+  const aliases = new Map<string, string>();
+  for (const schema of schemas) {
+    const schemaName = normalizeLofiSchemaName(schema.name);
+    aliases.set(schema.name, schemaName);
+    aliases.set(schemaName, schemaName);
+  }
+  return aliases;
 };
 
 const materializeProjectionMutation = (
@@ -108,6 +122,7 @@ export class InMemoryLofiAdapter
   private readonly localTableMap: Map<string, Map<string, AnyTable>>;
   private readonly projections: AnyLofiLocalProjection[];
   private readonly ignoreUnknownSchemas: boolean;
+  private readonly schemaNameAliases: LofiSchemaNameAliases;
   private readonly meta = new Map<string, string>();
   private readonly inbox = new Map<string, InboxRow>();
 
@@ -116,14 +131,20 @@ export class InMemoryLofiAdapter
       throw new Error("InMemoryLofiAdapter requires a non-empty endpointName.");
     }
 
-    const sourceSchemas = options.schemas;
-    const localSchemas = options.localSchemas ?? [];
+    const sourceSchemaInputs = options.schemas;
+    const localSchemaInputs = options.localSchemas ?? [];
+    const sourceSchemas = sourceSchemaInputs.map((schema) => withLofiSchemaName(schema));
+    const localSchemas = localSchemaInputs.map((schema) => withLofiSchemaName(schema));
     const allSchemas = mergeSchemaLists(sourceSchemas, localSchemas, "InMemoryLofiAdapter");
     const { schemaMap, tableMap } = createSchemaMaps(sourceSchemas, "InMemoryLofiAdapter");
     const { schemaMap: localSchemaMap, tableMap: localTableMap } = createSchemaMaps(
       localSchemas,
       "InMemoryLofiAdapter local",
     );
+    const schemaNameAliases = new Map([
+      ...createSchemaNameAliases(sourceSchemaInputs),
+      ...createSchemaNameAliases(localSchemaInputs),
+    ]);
 
     this.endpointName = options.endpointName;
     this.schemas = [...schemaMap.values()];
@@ -134,6 +155,7 @@ export class InMemoryLofiAdapter
     this.localTableMap = localTableMap;
     this.projections = options.projections ?? [];
     this.ignoreUnknownSchemas = options.ignoreUnknownSchemas ?? false;
+    this.schemaNameAliases = schemaNameAliases;
     this.store =
       options.store ??
       new InMemoryLofiStore({
@@ -162,6 +184,7 @@ export class InMemoryLofiAdapter
         ignoreUnknownSchemas: this.ignoreUnknownSchemas,
         schemaErrorPrefix: "Unknown outbox schema",
         tableErrorPrefix: "Unknown outbox table",
+        schemaNameAliases: this.schemaNameAliases,
       });
       if (known) {
         knownMutations.push(known.mutation);
@@ -243,7 +266,7 @@ export class InMemoryLofiAdapter
     return createInMemoryQueryEngine({
       schema,
       store: this.store,
-      schemaName: options?.schemaName,
+      schemaName: options?.schemaName ?? normalizeLofiSchemaName(schema.name),
     });
   }
 
@@ -270,6 +293,7 @@ export class InMemoryLofiAdapter
         ignoreUnknownSchemas: this.ignoreUnknownSchemas,
         schemaErrorPrefix,
         tableErrorPrefix,
+        schemaNameAliases: this.schemaNameAliases,
       });
       if (known) {
         knownMutations.push(known.mutation);
@@ -318,7 +342,7 @@ export class InMemoryLofiAdapter
       versionstamp: source.versionstamp,
     };
     const read: LofiLocalProjectionRead = createProjectionReadApi();
-    const match = createMutationMatcher(mutations);
+    const match = createMutationMatcher(mutations, this.schemaNameAliases);
 
     const ensureStageRow = async (options: {
       schemaName: string;
@@ -378,6 +402,7 @@ export class InMemoryLofiAdapter
         tableName,
         localSchemaMap: this.localSchemaMap,
         localTableMap: this.localTableMap,
+        schemaNameAliases: this.schemaNameAliases,
       });
       const row = await ensureStageRow({
         schemaName: target.schema.name,
@@ -388,7 +413,9 @@ export class InMemoryLofiAdapter
     };
 
     const writeMutation = async (mutation: ProjectionQueuedMutation): Promise<void> => {
-      const targetSchema = this.localSchemaMap.get(mutation.schema);
+      const targetSchema = this.localSchemaMap.get(
+        resolveLofiSchemaName(mutation.schema, this.schemaNameAliases),
+      );
       if (!targetSchema) {
         throw new Error(`Projection writes must target a local schema: ${mutation.schema}`);
       }
@@ -397,6 +424,7 @@ export class InMemoryLofiAdapter
         tableName: mutation.table,
         localSchemaMap: this.localSchemaMap,
         localTableMap: this.localTableMap,
+        schemaNameAliases: this.schemaNameAliases,
       });
       const key = rowKey(target.schema.name, mutation.table, mutation.externalId);
       const existing =
@@ -465,6 +493,7 @@ export class InMemoryLofiAdapter
         versionstamp: source.versionstamp,
         localSchemaMap: this.localSchemaMap,
         localTableMap: this.localTableMap,
+        schemaNameAliases: this.schemaNameAliases,
       });
       const mutateResult = projection.mutate({
         mutations,

--- a/packages/lofi/src/adapters/in-memory/query.ts
+++ b/packages/lofi/src/adapters/in-memory/query.ts
@@ -10,6 +10,7 @@ import {
 } from "@fragno-dev/db/unit-of-work";
 
 import type { ReferenceTarget } from "../../indexeddb/types";
+import { normalizeLofiSchemaName } from "../../local/projection";
 import { buildCondition, type Condition, type ConditionBuilder } from "../../query/conditions";
 import { normalizeValue } from "../../query/normalize";
 import {
@@ -1555,7 +1556,7 @@ export const createInMemoryQueryEngine = <T extends AnySchema>(options: {
   store: InMemoryLofiStore;
   schemaName?: string;
 }): LofiQueryInterface<T> => {
-  const schemaName = options.schemaName ?? options.schema.name;
+  const schemaName = options.schemaName ?? normalizeLofiSchemaName(options.schema.name);
   const context: QueryContext = {
     endpointName: options.store.endpointName,
     schemaName,

--- a/packages/lofi/src/adapters/in-memory/store.ts
+++ b/packages/lofi/src/adapters/in-memory/store.ts
@@ -2,6 +2,7 @@ import type { AnyColumn, AnySchema, AnyTable } from "@fragno-dev/db/schema";
 import { FragnoId, FragnoReference, getTableRelations } from "@fragno-dev/db/schema";
 
 import type { ReferenceTarget } from "../../indexeddb/types";
+import { withLofiSchemaName } from "../../local/projection";
 import { resolveMutationValues } from "../../query/mutation-values";
 import { normalizeValue } from "../../query/normalize";
 import type { LofiMutation } from "../../types";
@@ -345,7 +346,7 @@ export class InMemoryLofiStore {
     const schemaMap = new Map<string, AnySchema>();
     const tableMap = new Map<string, Map<string, AnyTable>>();
 
-    for (const schema of options.schemas) {
+    for (const schema of options.schemas.map((sourceSchema) => withLofiSchemaName(sourceSchema))) {
       if (!schema.name || schema.name.trim().length === 0) {
         throw new Error("InMemoryLofiStore schemas must have a non-empty name.");
       }

--- a/packages/lofi/src/indexeddb/adapter.test.ts
+++ b/packages/lofi/src/indexeddb/adapter.test.ts
@@ -74,6 +74,110 @@ describe("IndexedDbAdapter", () => {
     globalThis.IDBTransaction = IDBTransaction;
   });
 
+  it("normalizes default schema names for outbox application and queries", async () => {
+    const appSchema = schema("app-fragment", (s) =>
+      s.addTable("users", (t) => t.addColumn("id", idColumn()).addColumn("name", column("string"))),
+    );
+
+    const dbName = createDbName();
+    const adapter = new IndexedDbAdapter({
+      dbName,
+      endpointName: "app",
+      schemas: [{ schema: appSchema }],
+    });
+
+    await adapter.applyOutboxEntry({
+      sourceKey: "app::outbox",
+      versionstamp: "vs1",
+      uowId: "uow-vs1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app-fragment",
+          table: "users",
+          externalId: "user-1",
+          versionstamp: "vs1",
+          values: { name: "Ada" },
+        },
+      ],
+    });
+
+    const users = await adapter
+      .createQueryEngine(appSchema)
+      .find("users", (b) => b.whereIndex("primary"));
+    expect(users).toEqual([expect.objectContaining({ name: "Ada" })]);
+
+    const db = await openDb(dbName);
+    const row = await getRow(db, ["app", "app_fragment", "users", "user-1"]);
+    expect(row?.data).toMatchObject({ name: "Ada" });
+    db.close();
+  });
+
+  it("uses explicit schema aliases for source matching, projection writes, and queries", async () => {
+    const appSchema = schema("app-fragment", (s) =>
+      s.addTable("users", (t) => t.addColumn("id", idColumn()).addColumn("name", column("string"))),
+    );
+    const localSchema = schema("local-user-view", (s) =>
+      s.addTable("user_cards", (t) =>
+        t.addColumn("id", idColumn()).addColumn("displayName", column("string")),
+      ),
+    );
+    const dbName = createDbName();
+    const adapter = new IndexedDbAdapter({
+      dbName,
+      endpointName: "app",
+      schemas: [{ schema: appSchema, schemaName: "custom_app" }],
+      localSchemas: [{ schema: localSchema, schemaName: "custom_local" }],
+      projections: [
+        defineLocalProjection({
+          mutate: ({ mutations, match, tx }) => {
+            const userCards = tx.forSchema(localSchema);
+            for (const rawMutation of mutations) {
+              const mutation = match.one(rawMutation, appSchema, "users", "create");
+              if (!mutation) {
+                continue;
+              }
+              userCards.create("user_cards", {
+                id: mutation.externalId,
+                displayName: String(mutation.values.name),
+              });
+            }
+          },
+        }),
+      ],
+    });
+
+    await adapter.applyOutboxEntry({
+      sourceKey: "app::outbox",
+      versionstamp: "vs1",
+      uowId: "uow-vs1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app-fragment",
+          table: "users",
+          externalId: "user-1",
+          versionstamp: "vs1",
+          values: { name: "Ada" },
+        },
+      ],
+    });
+
+    const users = await adapter
+      .createQueryEngine(appSchema)
+      .find("users", (b) => b.whereIndex("primary"));
+    const cards = await adapter
+      .createQueryEngine(localSchema)
+      .find("user_cards", (b) => b.whereIndex("primary"));
+    expect(users).toEqual([expect.objectContaining({ name: "Ada" })]);
+    expect(cards).toEqual([expect.objectContaining({ displayName: "Ada" })]);
+
+    const db = await openDb(dbName);
+    expect(await getRow(db, ["app", "custom_app", "users", "user-1"])).toBeDefined();
+    expect(await getRow(db, ["app", "custom_local", "user_cards", "user-1"])).toBeDefined();
+    db.close();
+  });
+
   it("applies create/update/delete with idempotency and versioning", async () => {
     const appSchema = schema("app", (s) =>
       s.addTable("users", (t) =>
@@ -502,6 +606,90 @@ describe("IndexedDbAdapter", () => {
     expect(await getInboxRow(dbAfter, [customCursorKey, "uow-vs1", "vs1"])).toBeUndefined();
     expect(await adapterV2.getMeta(customCursorKey)).toBeUndefined();
     dbAfter.close();
+  });
+
+  it("lets projections from multiple indexeddb outbox sources write into the same local database", async () => {
+    const appSchema = schema("app", (s) =>
+      s.addTable("users", (t) => t.addColumn("id", idColumn()).addColumn("name", column("string"))),
+    );
+    const localSchema = schema("local_user_view", (s) =>
+      s.addTable("user_cards", (t) =>
+        t.addColumn("id", idColumn()).addColumn("displayName", column("string")),
+      ),
+    );
+    const dbName = createDbName();
+    const adapter = new IndexedDbAdapter({
+      dbName,
+      endpointName: "app",
+      schemas: [{ schema: appSchema }],
+      localSchemas: [{ schema: localSchema }],
+      projections: [
+        defineLocalProjection({
+          mutate: ({ mutations, match, source, tx }) => {
+            const userCards = tx.forSchema(localSchema);
+            for (const rawMutation of mutations) {
+              const mutation = match.one(rawMutation, appSchema, "users", "create");
+              if (!mutation) {
+                continue;
+              }
+
+              userCards.create("user_cards", {
+                id: `${source.sourceKey}:${mutation.externalId}`,
+                displayName: `${source.sourceKey}:${mutation.values.name}`,
+              });
+            }
+          },
+        }),
+      ],
+    });
+
+    await adapter.applyOutboxEntry({
+      sourceKey: "org-a::outbox",
+      versionstamp: "vs-a1",
+      uowId: "uow-a1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app",
+          table: "users",
+          externalId: "user-a",
+          versionstamp: "vs-a1",
+          values: { name: "Ada" },
+        },
+      ],
+    });
+    await adapter.applyOutboxEntry({
+      sourceKey: "org-b::outbox",
+      versionstamp: "vs-b1",
+      uowId: "uow-b1",
+      mutations: [
+        {
+          op: "create",
+          schema: "app",
+          table: "users",
+          externalId: "user-b",
+          versionstamp: "vs-b1",
+          values: { name: "Bob" },
+        },
+      ],
+    });
+
+    const cards = await adapter
+      .createQueryEngine(localSchema)
+      .find("user_cards", (b) => b.whereIndex("primary"));
+    expect(cards).toMatchObject([
+      { displayName: "org-a::outbox:Ada" },
+      { displayName: "org-b::outbox:Bob" },
+    ]);
+
+    const db = await openDb(dbName);
+    expect(
+      await getRow(db, ["app", "local_user_view", "user_cards", "org-a::outbox:user-a"]),
+    ).toBeDefined();
+    expect(
+      await getRow(db, ["app", "local_user_view", "user_cards", "org-b::outbox:user-b"]),
+    ).toBeDefined();
+    db.close();
   });
 
   it("materializes local schema rows in the same transaction", async () => {

--- a/packages/lofi/src/indexeddb/adapter.ts
+++ b/packages/lofi/src/indexeddb/adapter.ts
@@ -14,8 +14,12 @@ import {
   getLocalReadTarget,
   isThenable,
   mergeSchemaLists,
+  normalizeLofiSchemaName,
+  resolveLofiSchemaName,
   projectionRowToRecord,
   resolveProjectionReadPlan,
+  withLofiSchemaName,
+  type LofiSchemaNameAliases,
   type ProjectionQueuedMutation,
 } from "../local/projection";
 import { createIndexedDbQueryEngine, type IndexedDbQueryContext } from "../query/engine";
@@ -33,6 +37,7 @@ import type {
   LofiQueryEngineOptions,
   LofiQueryInterface,
   LofiQueryableAdapter,
+  LofiSchemaRegistration,
 } from "../types";
 import type { ReferenceTarget } from "./types";
 
@@ -96,6 +101,26 @@ const INDEX_SCHEMA_TABLE = "idx_schema_table";
 const INDEX_INBOX_SOURCE_UOW = "idx_inbox_source_uow";
 const LEGACY_INBOX_INDEX = "idx_inbox_source_version";
 
+const resolveRegisteredSchemaName = (registration: LofiSchemaRegistration): string =>
+  registration.schemaName ?? normalizeLofiSchemaName(registration.schema.name);
+
+const createRegisteredSchemaAliasMap = (
+  registrations: readonly LofiSchemaRegistration[],
+): Map<string, string> => {
+  const aliases = new Map<string, string>();
+  for (const registration of registrations) {
+    const schemaName = resolveRegisteredSchemaName(registration);
+    aliases.set(registration.schema.name, schemaName);
+    aliases.set(schemaName, schemaName);
+  }
+  return aliases;
+};
+
+const toRegisteredSchemas = (registrations: readonly LofiSchemaRegistration[]): AnySchema[] =>
+  registrations.map((registration) =>
+    withLofiSchemaName(registration.schema, registration.schemaName),
+  );
+
 const createReferenceTargets = (schemas: AnySchema[]): Map<string, ReferenceTarget> => {
   const referenceTargets = new Map<string, ReferenceTarget>();
   for (const schema of schemas) {
@@ -126,6 +151,7 @@ export class IndexedDbAdapter
   private readonly localSchemaMap: Map<string, AnySchema>;
   private readonly localTableMap: Map<string, Map<string, AnyTable>>;
   private readonly referenceTargets: Map<string, ReferenceTarget>;
+  private readonly schemaNameAliases: LofiSchemaNameAliases;
   private readonly schemaFingerprint: string;
   private readonly indexDefinitions: IndexDefinition[];
   private readonly projections: AnyLofiLocalProjection[];
@@ -138,8 +164,9 @@ export class IndexedDbAdapter
       throw new Error("IndexedDbAdapter requires a non-empty endpointName.");
     }
 
-    const sourceSchemas = options.schemas.map((registration) => registration.schema);
-    const localSchemas = (options.localSchemas ?? []).map((registration) => registration.schema);
+    const sourceSchemas = toRegisteredSchemas(options.schemas);
+    const localSchemaRegistrations = options.localSchemas ?? [];
+    const localSchemas = toRegisteredSchemas(localSchemaRegistrations);
     const allSchemas = mergeSchemaLists(sourceSchemas, localSchemas, "IndexedDbAdapter");
     const { schemaMap, tableMap } = createSchemaMaps(sourceSchemas, "IndexedDbAdapter");
     const { schemaMap: localSchemaMap, tableMap: localTableMap } = createSchemaMaps(
@@ -147,6 +174,10 @@ export class IndexedDbAdapter
       "IndexedDbAdapter local",
     );
     const referenceTargets = createReferenceTargets(allSchemas);
+    const schemaNameAliases = new Map([
+      ...createRegisteredSchemaAliasMap(options.schemas),
+      ...createRegisteredSchemaAliasMap(localSchemaRegistrations),
+    ]);
 
     this.dbName = options.dbName ?? `fragno_lofi_${options.endpointName}`;
     this.endpointName = options.endpointName;
@@ -158,6 +189,7 @@ export class IndexedDbAdapter
     this.localSchemaMap = localSchemaMap;
     this.localTableMap = localTableMap;
     this.referenceTargets = referenceTargets;
+    this.schemaNameAliases = schemaNameAliases;
     this.indexDefinitions = buildIndexDefinitions(this.allSchemas);
     this.schemaFingerprint = buildSchemaFingerprint(this.allSchemas, this.indexDefinitions);
     this.projections = options.projections ?? [];
@@ -182,6 +214,7 @@ export class IndexedDbAdapter
         ignoreUnknownSchemas: this.ignoreUnknownSchemas,
         schemaErrorPrefix: "Unknown outbox schema",
         tableErrorPrefix: "Unknown outbox table",
+        schemaNameAliases: this.schemaNameAliases,
       });
       if (known) {
         knownMutations.push(known);
@@ -279,6 +312,7 @@ export class IndexedDbAdapter
         ignoreUnknownSchemas: this.ignoreUnknownSchemas,
         schemaErrorPrefix: "Unknown mutation schema",
         tableErrorPrefix: "Unknown mutation table",
+        schemaNameAliases: this.schemaNameAliases,
       });
       if (known) {
         knownMutations.push(known);
@@ -364,7 +398,7 @@ export class IndexedDbAdapter
       endpointName: this.endpointName,
       getDb: () => this.openDatabase(),
       referenceTargets: this.referenceTargets,
-      schemaName: options?.schemaName,
+      schemaName: options?.schemaName ?? this.schemaNameAliases.get(schema.name),
     });
   }
 
@@ -424,6 +458,7 @@ export class IndexedDbAdapter
         tableName,
         localSchemaMap: this.localSchemaMap,
         localTableMap: this.localTableMap,
+        schemaNameAliases: this.schemaNameAliases,
       });
       const row = (await rowsStore.get([
         this.endpointName,
@@ -435,7 +470,9 @@ export class IndexedDbAdapter
     };
 
     const writeMutation = async (mutation: ProjectionQueuedMutation): Promise<void> => {
-      const targetSchema = this.localSchemaMap.get(mutation.schema);
+      const targetSchema = this.localSchemaMap.get(
+        resolveLofiSchemaName(mutation.schema, this.schemaNameAliases),
+      );
       if (!targetSchema) {
         throw new Error(`Projection writes must target a local schema: ${mutation.schema}`);
       }
@@ -444,6 +481,7 @@ export class IndexedDbAdapter
         tableName: mutation.table,
         localSchemaMap: this.localSchemaMap,
         localTableMap: this.localTableMap,
+        schemaNameAliases: this.schemaNameAliases,
       });
       if (mutation.op === "update" && mutation.checkVersion) {
         const existing = (await rowsStore.get([
@@ -469,7 +507,7 @@ export class IndexedDbAdapter
       });
     };
 
-    const match = createMutationMatcher(mutations);
+    const match = createMutationMatcher(mutations, this.schemaNameAliases);
     for (const projection of this.projections) {
       let retrieved: unknown;
       if (projection.retrieve) {
@@ -491,6 +529,7 @@ export class IndexedDbAdapter
         versionstamp: source.versionstamp,
         localSchemaMap: this.localSchemaMap,
         localTableMap: this.localTableMap,
+        schemaNameAliases: this.schemaNameAliases,
       });
       const mutateResult = projection.mutate({
         mutations,

--- a/packages/lofi/src/local/projection.ts
+++ b/packages/lofi/src/local/projection.ts
@@ -24,6 +24,21 @@ export type SchemaMaps = {
   tableMap: Map<string, Map<string, AnyTable>>;
 };
 
+export type LofiSchemaNameAliases = ReadonlyMap<string, string>;
+
+export const normalizeLofiSchemaName = (schemaName: string): string =>
+  schemaName.replace(/-/g, "_");
+
+export const resolveLofiSchemaName = (
+  schemaName: string,
+  aliases?: LofiSchemaNameAliases,
+): string => aliases?.get(schemaName) ?? normalizeLofiSchemaName(schemaName);
+
+export const withLofiSchemaName = (schema: AnySchema, schemaName?: string): AnySchema => ({
+  ...schema,
+  name: schemaName ?? normalizeLofiSchemaName(schema.name),
+});
+
 export const createSchemaMaps = (schemas: readonly AnySchema[], owner: string): SchemaMaps => {
   const schemaMap = new Map<string, AnySchema>();
   const tableMap = new Map<string, Map<string, AnyTable>>();
@@ -76,6 +91,7 @@ export const getKnownMutation = (options: {
   ignoreUnknownSchemas: boolean;
   schemaErrorPrefix: string;
   tableErrorPrefix: string;
+  schemaNameAliases?: LofiSchemaNameAliases;
 }): { mutation: LofiMutation; schema: AnySchema; table: AnyTable } | undefined => {
   const {
     mutation,
@@ -84,22 +100,24 @@ export const getKnownMutation = (options: {
     ignoreUnknownSchemas,
     schemaErrorPrefix,
     tableErrorPrefix,
+    schemaNameAliases,
   } = options;
-  const schema = schemaMap.get(mutation.schema);
+  const schemaName = resolveLofiSchemaName(mutation.schema, schemaNameAliases);
+  const schema = schemaMap.get(schemaName) ?? schemaMap.get(mutation.schema);
   if (!schema) {
     if (ignoreUnknownSchemas) {
       return undefined;
     }
     throw new Error(`${schemaErrorPrefix}: ${mutation.schema}`);
   }
-  const table = tableMap.get(mutation.schema)?.get(mutation.table);
+  const table = tableMap.get(schema.name)?.get(mutation.table);
   if (!table) {
     if (ignoreUnknownSchemas) {
       return undefined;
     }
     throw new Error(`${tableErrorPrefix}: ${mutation.schema}.${mutation.table}`);
   }
-  return { mutation, schema, table };
+  return { mutation: { ...mutation, schema: schema.name }, schema, table };
 };
 
 export const matchMutation = <
@@ -111,6 +129,7 @@ export const matchMutation = <
   schema: TSchema,
   table: TTableName,
   op: TOp,
+  schemaNameAliases?: LofiSchemaNameAliases,
 ):
   | LofiTypedMutation<
       TSchema,
@@ -119,7 +138,11 @@ export const matchMutation = <
     >
   | undefined => {
   const matchesOp = Array.isArray(op) ? op.includes(mutation.op) : mutation.op === op;
-  if (mutation.schema !== schema.name || mutation.table !== table || !matchesOp) {
+  if (
+    mutation.schema !== resolveLofiSchemaName(schema.name, schemaNameAliases) ||
+    mutation.table !== table ||
+    !matchesOp
+  ) {
     return undefined;
   }
   return mutation as LofiTypedMutation<
@@ -129,11 +152,15 @@ export const matchMutation = <
   >;
 };
 
-export const createMutationMatcher = (mutations: readonly LofiMutation[]): LofiMutationMatcher => ({
-  one: matchMutation,
+export const createMutationMatcher = (
+  mutations: readonly LofiMutation[],
+  schemaNameAliases?: LofiSchemaNameAliases,
+): LofiMutationMatcher => ({
+  one: (mutation, schema, table, op) =>
+    matchMutation(mutation, schema, table, op, schemaNameAliases),
   all: (schema, table, op) =>
     mutations.flatMap((mutation) => {
-      const matched = matchMutation(mutation, schema, table, op);
+      const matched = matchMutation(mutation, schema, table, op, schemaNameAliases);
       return matched ? [matched] : [];
     }),
 });
@@ -319,15 +346,18 @@ const getLocalProjectionTarget = (options: {
   localSchemaMap: Map<string, AnySchema>;
   localTableMap: Map<string, Map<string, AnyTable>>;
   errorPrefix: string;
+  schemaNameAliases?: LofiSchemaNameAliases;
 }): { schema: AnySchema; table: AnyTable } => {
-  const { schema, tableName, localSchemaMap, localTableMap, errorPrefix } = options;
-  const localSchema = localSchemaMap.get(schema.name);
+  const { schema, tableName, localSchemaMap, localTableMap, errorPrefix, schemaNameAliases } =
+    options;
+  const schemaName = resolveLofiSchemaName(schema.name, schemaNameAliases);
+  const localSchema = localSchemaMap.get(schemaName);
   if (!localSchema) {
-    throw new Error(`${errorPrefix}: ${schema.name}`);
+    throw new Error(`${errorPrefix}: ${schemaName}`);
   }
-  const table = localTableMap.get(schema.name)?.get(tableName);
+  const table = localTableMap.get(schemaName)?.get(tableName);
   if (!table) {
-    throw new Error(`Unknown local projection table: ${schema.name}.${tableName}`);
+    throw new Error(`Unknown local projection table: ${schemaName}.${tableName}`);
   }
   return { schema: localSchema, table };
 };
@@ -337,6 +367,7 @@ export const getLocalMutationTarget = (options: {
   tableName: string;
   localSchemaMap: Map<string, AnySchema>;
   localTableMap: Map<string, Map<string, AnyTable>>;
+  schemaNameAliases?: LofiSchemaNameAliases;
 }): { schema: AnySchema; table: AnyTable } =>
   getLocalProjectionTarget({
     ...options,
@@ -348,6 +379,7 @@ export const getLocalReadTarget = (options: {
   tableName: string;
   localSchemaMap: Map<string, AnySchema>;
   localTableMap: Map<string, Map<string, AnyTable>>;
+  schemaNameAliases?: LofiSchemaNameAliases;
 }): { schema: AnySchema; table: AnyTable } =>
   getLocalProjectionTarget({
     ...options,
@@ -468,15 +500,17 @@ export const createProjectionTx = (options: {
   versionstamp: string;
   localSchemaMap: Map<string, AnySchema>;
   localTableMap: Map<string, Map<string, AnyTable>>;
+  schemaNameAliases?: LofiSchemaNameAliases;
 }): LofiProjectionTx & { drainMutations(): ProjectionQueuedMutation[] } => {
-  const { versionstamp, localSchemaMap, localTableMap } = options;
+  const { versionstamp, localSchemaMap, localTableMap, schemaNameAliases } = options;
   const mutations: ProjectionQueuedMutation[] = [];
 
   return {
     forSchema(schema) {
-      const localSchema = localSchemaMap.get(schema.name);
+      const schemaName = resolveLofiSchemaName(schema.name, schemaNameAliases);
+      const localSchema = localSchemaMap.get(schemaName);
       if (!localSchema) {
-        throw new Error(`Projection writes must target a local schema: ${schema.name}`);
+        throw new Error(`Projection writes must target a local schema: ${schemaName}`);
       }
 
       return {

--- a/packages/lofi/src/mod.ts
+++ b/packages/lofi/src/mod.ts
@@ -55,7 +55,9 @@ export {
   createLofiQueryStore,
   createLofiRuntime,
   createLofiRuntimeRegistry,
+  createLofiRuntimeTx,
   isLofiRuntimeBootstrapped,
+  isLofiRuntimeTxBuilder,
 } from "./reactive";
 export type {
   LofiQueryState,
@@ -64,6 +66,9 @@ export type {
   LofiQueryStoreResolvedRetrieve,
   LofiQueryStoreRetrieveContext,
   LofiQueryStoreRetrieveUnit,
+  LofiRuntimeStoreBuilder,
+  LofiRuntimeStoreFactory,
+  LofiRuntimeStoreRetrieveBuilder,
   LofiRuntime,
   LofiRuntimeOptions,
   LofiRuntimeRegistry,
@@ -72,4 +77,11 @@ export type {
   LofiRuntimeStatus,
   LofiRuntimeStatusValue,
   LofiRuntimeSyncResult,
+  LofiRuntimeTxBuilder,
+  LofiRuntimeTxFactory,
+  LofiRuntimeTxResolved,
+  LofiRuntimeTxResult,
+  LofiRuntimeTxRetrieveContext,
+  LofiRuntimeTxSchemaRead,
+  LofiRuntimeTxTransformContext,
 } from "./reactive";

--- a/packages/lofi/src/outbox.test.ts
+++ b/packages/lofi/src/outbox.test.ts
@@ -175,6 +175,36 @@ describe("outbox utilities", () => {
     ]);
   });
 
+  it("adds db-now defaults when converting create uow operations", () => {
+    const appSchema = schema("app", (s) =>
+      s.addTable("users", (t) =>
+        t
+          .addColumn("id", idColumn())
+          .addColumn("name", column("string"))
+          .addColumn(
+            "createdAt",
+            column("timestamp").defaultTo((b) => b.now()),
+          ),
+      ),
+    );
+
+    const [mutation] = uowOperationsToLofiMutations([
+      {
+        type: "create",
+        schema: appSchema,
+        table: "users",
+        generatedExternalId: "user-1",
+        values: { name: "Ada" },
+      },
+    ]);
+
+    assert(mutation?.op === "create");
+    expect(mutation.values).toMatchObject({
+      name: "Ada",
+      createdAt: { tag: "db-now" },
+    });
+  });
+
   it("converts outbox mutations into uow operations", () => {
     const appSchema = schema("app", (s) =>
       s.addTable("users", (t) => t.addColumn("id", idColumn()).addColumn("name", column("string"))),

--- a/packages/lofi/src/outbox/uow.ts
+++ b/packages/lofi/src/outbox/uow.ts
@@ -19,6 +19,25 @@ const resolveVersionstamp = (
     ? options.versionstamp(operation, index)
     : (options?.versionstamp ?? `uow-${(index + 1).toString().padStart(3, "0")}`);
 
+const fillCreateDbNowDefaults = (
+  operation: Extract<MutationOperation<AnySchema>, { type: "create" }>,
+): Record<string, unknown> => {
+  const values = { ...(operation.values as Record<string, unknown>) };
+  const table = operation.schema.tables[operation.table];
+
+  for (const [key, column] of Object.entries(table?.columns ?? {})) {
+    if (column.role === "internal-id" || Object.prototype.hasOwnProperty.call(values, key)) {
+      continue;
+    }
+
+    if (column.default && "dbSpecial" in column.default && column.default.dbSpecial === "now") {
+      values[key] = { tag: "db-now" };
+    }
+  }
+
+  return values;
+};
+
 export function uowOperationsToLofiMutations(
   operations: readonly MutationOperation<AnySchema>[],
   options?: UowOperationsToLofiMutationsOptions,
@@ -37,7 +56,7 @@ export function uowOperationsToLofiMutations(
           schema: operation.schema.name,
           table: operation.table,
           externalId: operation.generatedExternalId,
-          values: operation.values as Record<string, unknown>,
+          values: fillCreateDbNowDefaults(operation),
           versionstamp,
         },
       ];

--- a/packages/lofi/src/reactive/index.ts
+++ b/packages/lofi/src/reactive/index.ts
@@ -1,4 +1,5 @@
 export { createLofiRuntime, isLofiRuntimeBootstrapped } from "./runtime";
+export { createLofiRuntimeTx, isLofiRuntimeTxBuilder } from "./tx";
 export type {
   LofiRuntime,
   LofiRuntimeOptions,
@@ -7,6 +8,15 @@ export type {
   LofiRuntimeStatusValue,
   LofiRuntimeSyncResult,
 } from "./runtime";
+export type {
+  LofiRuntimeTxBuilder,
+  LofiRuntimeTxFactory,
+  LofiRuntimeTxResolved,
+  LofiRuntimeTxResult,
+  LofiRuntimeTxRetrieveContext,
+  LofiRuntimeTxSchemaRead,
+  LofiRuntimeTxTransformContext,
+} from "./tx";
 export { createLofiQueryStore } from "./query-store";
 export type {
   LofiQueryState,
@@ -15,6 +25,9 @@ export type {
   LofiQueryStoreResolvedRetrieve,
   LofiQueryStoreRetrieveContext,
   LofiQueryStoreRetrieveUnit,
+  LofiRuntimeStoreBuilder,
+  LofiRuntimeStoreFactory,
+  LofiRuntimeStoreRetrieveBuilder,
 } from "./query-store";
 export { createLofiRuntimeRegistry } from "./registry";
 export type { LofiRuntimeRegistry, LofiRuntimeRegistryOptions } from "./registry";

--- a/packages/lofi/src/reactive/query-store.ts
+++ b/packages/lofi/src/reactive/query-store.ts
@@ -8,7 +8,14 @@ import type {
 } from "../query-types";
 import type { LofiFindBuilder } from "../query/read-plan";
 import type { LofiQueryEngineOptions } from "../types";
-import { isLofiRuntimeBootstrapped, type LofiRuntime } from "./runtime";
+import type { LofiRuntime, LofiRuntimeStatus } from "./runtime";
+import {
+  isLofiRuntimeTxBuilder,
+  type LofiRuntimeTxBuilder,
+  type LofiRuntimeTxResolved,
+  type LofiRuntimeTxResult,
+  type LofiRuntimeTxRetrieveContext,
+} from "./tx";
 
 export type LofiQueryState<TData> = {
   data: TData;
@@ -21,6 +28,9 @@ export type LofiQueryState<TData> = {
 export type LofiQueryStore<TData> = ReadableAtom<LofiQueryState<TData>> & {
   refresh: () => Promise<void>;
 };
+
+const isLofiRuntimeBootstrappedStatus = (status: LofiRuntimeStatus): boolean =>
+  Object.values(status.sources).every((source) => source.status === "bootstrapped");
 
 type LofiNoInfer<T> = [T][T extends T ? 0 : never];
 
@@ -90,8 +100,24 @@ type RawLofiQueryStoreOptions<TRaw> = {
 
 type MappedLofiQueryStoreOptions<TRaw, TData> = {
   initialData: LofiNoInfer<TData>;
-  map: (rows: TRaw) => TData;
+  map: (rows: TRaw) => TData | Promise<TData>;
 };
+
+export interface LofiRuntimeStoreRetrieveBuilder<TRetrieveResult, TData = TRetrieveResult> {
+  transformRetrieve<TNewData>(
+    fn: (retrieveResult: TRetrieveResult) => TNewData | Promise<TNewData>,
+  ): LofiRuntimeStoreRetrieveBuilder<TRetrieveResult, Awaited<TNewData>>;
+
+  withInitialData(initialData: LofiNoInfer<TData>): LofiQueryStore<TData>;
+}
+
+export interface LofiRuntimeStoreBuilder {
+  retrieve<TSelection>(
+    fn: (context: LofiRuntimeTxRetrieveContext) => TSelection,
+  ): LofiRuntimeStoreRetrieveBuilder<Awaited<LofiRuntimeTxResolved<TSelection>>>;
+}
+
+export type LofiRuntimeStoreFactory = () => LofiRuntimeStoreBuilder;
 
 type LofiQueryOperation = {
   schema: AnySchema;
@@ -130,14 +156,64 @@ const createRetrieveUnit = <const TSchema extends AnySchema>(
   return unit as unknown as LofiQueryStoreRetrieveUnit<TSchema>;
 };
 
+class RuntimeStoreRetrieveBuilder<
+  TRetrieveResult,
+  TData = TRetrieveResult,
+> implements LofiRuntimeStoreRetrieveBuilder<TRetrieveResult, TData> {
+  private readonly runtime: LofiRuntime;
+  private readonly retrieveFn: (context: LofiRuntimeTxRetrieveContext) => unknown;
+  private readonly transformRetrieveFn?: (
+    retrieveResult: TRetrieveResult,
+  ) => TData | Promise<TData>;
+
+  constructor(
+    runtime: LofiRuntime,
+    retrieveFn: (context: LofiRuntimeTxRetrieveContext) => unknown,
+    transformRetrieveFn?: (retrieveResult: TRetrieveResult) => TData | Promise<TData>,
+  ) {
+    this.runtime = runtime;
+    this.retrieveFn = retrieveFn;
+    this.transformRetrieveFn = transformRetrieveFn;
+  }
+
+  transformRetrieve<TNewData>(
+    fn: (retrieveResult: TRetrieveResult) => TNewData | Promise<TNewData>,
+  ): LofiRuntimeStoreRetrieveBuilder<TRetrieveResult, Awaited<TNewData>> {
+    return new RuntimeStoreRetrieveBuilder(this.runtime, this.retrieveFn, fn as never);
+  }
+
+  withInitialData(initialData: LofiNoInfer<TData>): LofiQueryStore<TData> {
+    if (this.transformRetrieveFn) {
+      return createLofiQueryStore(this.runtime, () => this.runtime.tx().retrieve(this.retrieveFn), {
+        initialData,
+        map: this.transformRetrieveFn,
+      } as never) as LofiQueryStore<TData>;
+    }
+
+    return createLofiQueryStore(this.runtime, () => this.runtime.tx().retrieve(this.retrieveFn), {
+      initialData,
+    } as never) as LofiQueryStore<TData>;
+  }
+}
+
+export const createLofiRuntimeStore = (runtime: LofiRuntime): LofiRuntimeStoreBuilder => ({
+  retrieve<TSelection>(fn: (context: LofiRuntimeTxRetrieveContext) => TSelection) {
+    return new RuntimeStoreRetrieveBuilder<Awaited<LofiRuntimeTxResolved<TSelection>>>(runtime, fn);
+  },
+});
+
 const executeRetrieve = async (
   runtime: LofiRuntime,
   retrieveFn: (context: LofiQueryStoreRetrieveContext) => unknown,
-): Promise<unknown[]> => {
+): Promise<unknown> => {
   const operations: LofiQueryOperation[] = [];
-  retrieveFn({
+  const result = retrieveFn({
     forSchema: (schema, options) => createRetrieveUnit(operations, schema, options),
   });
+
+  if (isLofiRuntimeTxBuilder(result)) {
+    return await result.execute();
+  }
 
   return await Promise.all(
     operations.map((operation) => {
@@ -193,6 +269,34 @@ export function createLofiQueryStore<
     TData
   >,
 ): LofiQueryStore<TData>;
+export function createLofiQueryStore<
+  TRetrieveResult,
+  TTransformResult,
+  HasTransform extends boolean,
+>(
+  runtime: LofiRuntime,
+  retrieveFn: (
+    context: LofiQueryStoreRetrieveContext,
+  ) => LofiRuntimeTxBuilder<TRetrieveResult, TTransformResult, HasTransform>,
+  options: RawLofiQueryStoreOptions<
+    LofiRuntimeTxResult<TRetrieveResult, TTransformResult, HasTransform>
+  >,
+): LofiQueryStore<LofiRuntimeTxResult<TRetrieveResult, TTransformResult, HasTransform>>;
+export function createLofiQueryStore<
+  TRetrieveResult,
+  TTransformResult,
+  HasTransform extends boolean,
+  TData,
+>(
+  runtime: LofiRuntime,
+  retrieveFn: (
+    context: LofiQueryStoreRetrieveContext,
+  ) => LofiRuntimeTxBuilder<TRetrieveResult, TTransformResult, HasTransform>,
+  options: MappedLofiQueryStoreOptions<
+    LofiRuntimeTxResult<TRetrieveResult, TTransformResult, HasTransform>,
+    TData
+  >,
+): LofiQueryStore<TData>;
 export function createLofiQueryStore<TRaw, TData = TRaw>(
   runtime: LofiRuntime,
   retrieveFn: ((context: LofiQueryStoreRetrieveContext) => unknown) | AnySchema,
@@ -235,7 +339,7 @@ export function createLofiQueryStore<TRaw, TData = TRaw>(
               .createQueryEngine(retrieveFn)
               .find(optionsOrTable as keyof AnySchema["tables"] & string, builderFn as never)
       ) as TRaw;
-      const data = options.map ? options.map(rows) : (rows as unknown as TData);
+      const data = options.map ? await options.map(rows) : (rows as unknown as TData);
 
       if (requestId !== currentRequestId) {
         return;
@@ -268,7 +372,7 @@ export function createLofiQueryStore<TRaw, TData = TRaw>(
     let mounted = true;
     const releaseRuntime = runtime.retain();
     const unsubscribeRevision = runtime.$revision.listen(() => {
-      if (isLofiRuntimeBootstrapped(runtime.$status.get())) {
+      if (isLofiRuntimeBootstrappedStatus(runtime.$status.get())) {
         void runQuery();
       }
     });

--- a/packages/lofi/src/reactive/runtime.test.ts
+++ b/packages/lofi/src/reactive/runtime.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi, assert } from "vitest";
+import { describe, expect, expectTypeOf, it, vi, assert } from "vitest";
+
+import { column, idColumn, schema } from "@fragno-dev/db/schema";
 
 import { InMemoryLofiAdapter } from "../adapters/in-memory/adapter";
 import { isLofiRuntimeBootstrapped, createLofiRuntime } from "./runtime";
@@ -47,6 +49,68 @@ describe("createLofiRuntime", () => {
     const users = await query.find("users", (b) => b.whereIndex("primary"));
     expect(users).toEqual([expect.objectContaining({ name: "Alice" })]);
 
+    unlisten();
+  });
+
+  it("runs typed local tx retrieves across schemas", async () => {
+    const projectSchema = schema("projects", (s) =>
+      s.addTable("projects", (t) =>
+        t.addColumn("id", idColumn()).addColumn("title", column("string")),
+      ),
+    );
+    const adapter = new InMemoryLofiAdapter({
+      endpointName: "app",
+      schemas: [reactiveTestSchema, projectSchema],
+    });
+    await adapter.applyMutations([
+      createUserMutation("user-a", "Alice"),
+      {
+        op: "create",
+        schema: projectSchema.name,
+        table: "projects",
+        externalId: "project-a",
+        values: { title: "Launch" },
+        versionstamp: "v-project-a",
+      },
+    ]);
+    const runtime = createLofiRuntime({
+      endpointName: "app",
+      adapter,
+      outboxUrl: "https://example.com/outbox",
+      fetch: (async () => new Response(JSON.stringify([]))) as typeof fetch,
+    });
+
+    const result = await runtime
+      .tx()
+      .retrieve(({ forSchema }) => ({
+        users: forSchema(reactiveTestSchema).find("users", (b) => b.whereIndex("primary")),
+        project: forSchema(projectSchema).findFirst("projects", (b) => b.whereIndex("primary")),
+      }))
+      .execute();
+
+    expectTypeOf(result.users[0]!.name).toEqualTypeOf<string>();
+    expectTypeOf(result.project?.title).toEqualTypeOf<string | undefined>();
+    expect(result.users.map((user) => user.name)).toEqual(["Alice"]);
+    assert(result.project?.title === "Launch");
+
+    const $summary = runtime
+      .store()
+      .retrieve(({ forSchema }) => ({
+        users: forSchema(reactiveTestSchema).find("users", (b) => b.whereIndex("primary")),
+        project: forSchema(projectSchema).findFirst("projects", (b) => b.whereIndex("primary")),
+      }))
+      .transformRetrieve(({ users, project }) => ({
+        names: users.map((user) => user.name),
+        projectTitle: project?.title ?? null,
+      }))
+      .withInitialData({ names: [] as string[], projectTitle: null as string | null });
+    expectTypeOf($summary.get().data).toEqualTypeOf<{
+      names: string[];
+      projectTitle: string | null;
+    }>();
+    const unlisten = $summary.subscribe(() => undefined);
+    await waitFor(() => $summary.get().synced);
+    expect($summary.get().data).toEqual({ names: ["Alice"], projectTitle: "Launch" });
     unlisten();
   });
 

--- a/packages/lofi/src/reactive/runtime.ts
+++ b/packages/lofi/src/reactive/runtime.ts
@@ -7,6 +7,8 @@ import type {
   LofiQueryableAdapter,
   LofiSyncResult,
 } from "../types";
+import { createLofiRuntimeStore, type LofiRuntimeStoreFactory } from "./query-store";
+import { createLofiRuntimeTx, type LofiRuntimeTxFactory } from "./tx";
 
 export type LofiRuntimeSource = {
   id: string;
@@ -81,6 +83,8 @@ export type LofiRuntime = {
   whenBootstrapped: () => Promise<void>;
   syncOnce: (sourceId?: string) => Promise<LofiRuntimeSyncResult>;
   refresh: () => void;
+  tx: LofiRuntimeTxFactory;
+  store: LofiRuntimeStoreFactory;
   addSource: (source: LofiRuntimeSource) => void;
   removeSource: (sourceId: string) => void;
 };
@@ -610,11 +614,15 @@ export const createLofiRuntime = (options: LofiRuntimeOptions): LofiRuntime => {
     addSource(source);
   }
 
-  if (options.autoStart) {
-    start();
-  }
+  const tx: LofiRuntimeTxFactory = () =>
+    createLofiRuntimeTx({
+      adapter: options.adapter,
+      whenBootstrapped,
+    });
+  let runtime: LofiRuntime;
+  const store: LofiRuntimeStoreFactory = () => createLofiRuntimeStore(runtime);
 
-  return {
+  runtime = {
     endpointName: options.endpointName,
     adapter: options.adapter,
     $status,
@@ -626,9 +634,17 @@ export const createLofiRuntime = (options: LofiRuntimeOptions): LofiRuntime => {
     whenBootstrapped,
     syncOnce,
     refresh,
+    tx,
+    store,
     addSource,
     removeSource,
   };
+
+  if (options.autoStart) {
+    start();
+  }
+
+  return runtime;
 };
 
 const createAbortError = (): Error => {

--- a/packages/lofi/src/reactive/tx.ts
+++ b/packages/lofi/src/reactive/tx.ts
@@ -1,0 +1,190 @@
+import type { AnySchema } from "@fragno-dev/db/schema";
+
+import type {
+  LofiQueryFindFirstResult,
+  LofiQueryFindResult,
+  LofiQueryFindWithCursorResult,
+} from "../query-types";
+import type { LofiFindBuilder } from "../query/read-plan";
+import type { LofiQueryEngineOptions, LofiQueryableAdapter } from "../types";
+
+const lofiRuntimeTxBuilderBrand = Symbol("lofi.runtime.tx.builder");
+const lofiRuntimeTxQueryBrand = Symbol("lofi.runtime.tx.query");
+
+type LofiRuntimeTxQuery<TResult> = {
+  readonly [lofiRuntimeTxQueryBrand]: true;
+  execute: () => Promise<TResult>;
+};
+
+export type LofiRuntimeTxResolved<T> =
+  T extends LofiRuntimeTxQuery<infer TResult>
+    ? TResult
+    : T extends readonly [infer THead, ...infer TTail]
+      ? readonly [LofiRuntimeTxResolved<THead>, ...LofiRuntimeTxResolved<TTail>]
+      : T extends readonly (infer TItem)[]
+        ? LofiRuntimeTxResolved<TItem>[]
+        : T extends object
+          ? { [K in keyof T]: LofiRuntimeTxResolved<T[K]> }
+          : T;
+
+export type LofiRuntimeTxSchemaRead<TSchema extends AnySchema> = {
+  find: <TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    table: TTableName,
+    builderFn: (builder: LofiFindBuilder<TSchema, TTableName>) => TBuilderResult,
+  ) => LofiRuntimeTxQuery<LofiQueryFindResult<TSchema["tables"][TTableName], TBuilderResult>>;
+
+  findFirst: <TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    table: TTableName,
+    builderFn: (builder: LofiFindBuilder<TSchema, TTableName>) => TBuilderResult,
+  ) => LofiRuntimeTxQuery<LofiQueryFindFirstResult<TSchema["tables"][TTableName], TBuilderResult>>;
+
+  findWithCursor: <TTableName extends keyof TSchema["tables"] & string, const TBuilderResult>(
+    table: TTableName,
+    builderFn: (builder: LofiFindBuilder<TSchema, TTableName>) => TBuilderResult,
+  ) => LofiRuntimeTxQuery<
+    LofiQueryFindWithCursorResult<TSchema["tables"][TTableName], TBuilderResult>
+  >;
+};
+
+export type LofiRuntimeTxRetrieveContext = {
+  forSchema: <const TSchema extends AnySchema>(
+    schema: TSchema,
+    options?: LofiQueryEngineOptions,
+  ) => LofiRuntimeTxSchemaRead<TSchema>;
+};
+
+export type LofiRuntimeTxTransformContext<TRetrieveResult> = {
+  retrieveResult: TRetrieveResult;
+};
+
+export type LofiRuntimeTxResult<
+  TRetrieveResult,
+  TTransformResult,
+  HasTransform extends boolean,
+> = HasTransform extends true ? TTransformResult : TRetrieveResult;
+
+export type LofiRuntimeTxBuilder<
+  TRetrieveResult = [],
+  TTransformResult = unknown,
+  HasTransform extends boolean = false,
+> = {
+  readonly [lofiRuntimeTxBuilderBrand]: true;
+
+  retrieve: <TSelection>(
+    fn: (
+      ctx: LofiRuntimeTxRetrieveContext,
+    ) => TSelection extends PromiseLike<unknown> ? never : TSelection,
+  ) => LofiRuntimeTxBuilder<LofiRuntimeTxResolved<TSelection>, TTransformResult, false>;
+
+  transform: <TNewTransformResult>(
+    fn: (ctx: LofiRuntimeTxTransformContext<TRetrieveResult>) => TNewTransformResult,
+  ) => LofiRuntimeTxBuilder<TRetrieveResult, Awaited<TNewTransformResult>, true>;
+
+  execute: () => Promise<LofiRuntimeTxResult<TRetrieveResult, TTransformResult, HasTransform>>;
+};
+
+export type LofiRuntimeTxFactory = () => LofiRuntimeTxBuilder;
+
+type LofiRuntimeTxOptions = {
+  adapter: LofiQueryableAdapter;
+  whenBootstrapped: () => Promise<void>;
+};
+
+type LofiRuntimeTxState = {
+  retrieveFn?: (ctx: LofiRuntimeTxRetrieveContext) => unknown;
+  transformFn?: (ctx: LofiRuntimeTxTransformContext<unknown>) => unknown;
+};
+
+const createQueryToken = <TResult>(execute: () => Promise<TResult>): LofiRuntimeTxQuery<TResult> =>
+  ({
+    [lofiRuntimeTxQueryBrand]: true,
+    execute,
+  }) as LofiRuntimeTxQuery<TResult>;
+
+const isQueryToken = (value: unknown): value is LofiRuntimeTxQuery<unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { [lofiRuntimeTxQueryBrand]?: boolean })[lofiRuntimeTxQueryBrand] === true;
+
+const resolveSelection = async (selection: unknown): Promise<unknown> => {
+  if (isQueryToken(selection)) {
+    return await selection.execute();
+  }
+
+  if (Array.isArray(selection)) {
+    return await Promise.all(selection.map((entry) => resolveSelection(entry)));
+  }
+
+  if (typeof selection === "object" && selection !== null) {
+    const entries = await Promise.all(
+      Object.entries(selection).map(async ([key, value]) => [key, await resolveSelection(value)]),
+    );
+    return Object.fromEntries(entries);
+  }
+
+  return selection;
+};
+
+const createRetrieveContext = (adapter: LofiQueryableAdapter): LofiRuntimeTxRetrieveContext => ({
+  forSchema(schema, options) {
+    const query = adapter.createQueryEngine(schema, options);
+    return {
+      find(table, builderFn) {
+        return createQueryToken(() => query.find(table, builderFn));
+      },
+      findFirst(table, builderFn) {
+        return createQueryToken(() => query.findFirst(table, builderFn));
+      },
+      findWithCursor(table, builderFn) {
+        return createQueryToken(() => query.findWithCursor(table, builderFn));
+      },
+    };
+  },
+});
+
+class RuntimeTxBuilder<
+  TRetrieveResult,
+  TTransformResult,
+  HasTransform extends boolean,
+> implements LofiRuntimeTxBuilder<TRetrieveResult, TTransformResult, HasTransform> {
+  readonly [lofiRuntimeTxBuilderBrand] = true;
+  private readonly options: LofiRuntimeTxOptions;
+  private readonly state: LofiRuntimeTxState;
+
+  constructor(options: LofiRuntimeTxOptions, state: LofiRuntimeTxState = {}) {
+    this.options = options;
+    this.state = state;
+  }
+
+  retrieve<TSelection>(fn: (ctx: LofiRuntimeTxRetrieveContext) => TSelection) {
+    return new RuntimeTxBuilder(this.options, { ...this.state, retrieveFn: fn }) as never;
+  }
+
+  transform<TNewTransformResult>(
+    fn: (ctx: LofiRuntimeTxTransformContext<TRetrieveResult>) => TNewTransformResult,
+  ) {
+    return new RuntimeTxBuilder(this.options, { ...this.state, transformFn: fn as never }) as never;
+  }
+
+  async execute(): Promise<LofiRuntimeTxResult<TRetrieveResult, TTransformResult, HasTransform>> {
+    await this.options.whenBootstrapped();
+
+    const retrieveResult = this.state.retrieveFn
+      ? await resolveSelection(this.state.retrieveFn(createRetrieveContext(this.options.adapter)))
+      : [];
+
+    if (this.state.transformFn) {
+      return (await this.state.transformFn({ retrieveResult })) as never;
+    }
+
+    return retrieveResult as never;
+  }
+}
+
+export const createLofiRuntimeTx = (options: LofiRuntimeTxOptions): LofiRuntimeTxBuilder =>
+  new RuntimeTxBuilder<[], unknown, false>(options);
+
+export const isLofiRuntimeTxBuilder = (value: unknown): value is LofiRuntimeTxBuilder<unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { [lofiRuntimeTxBuilderBrand]?: boolean })[lofiRuntimeTxBuilderBrand] === true;

--- a/packages/lofi/src/types.ts
+++ b/packages/lofi/src/types.ts
@@ -56,7 +56,7 @@ export type LofiSyncResult = {
   aborted?: boolean;
 };
 
-export type LofiSchemaRegistration = { schema: AnySchema };
+export type LofiSchemaRegistration = { schema: AnySchema; schemaName?: string };
 
 type Prettify<T> = T extends (...args: never[]) => unknown
   ? T

--- a/packages/pi-harness/src/client/projection.test.ts
+++ b/packages/pi-harness/src/client/projection.test.ts
@@ -2,10 +2,21 @@ import { describe, expect, it, assert } from "vitest";
 
 import { buildScopedInstanceRowId } from "@fragno-dev/workflows/instance-ref";
 import { workflowsSchema } from "@fragno-dev/workflows/schema";
+import {
+  IDBCursor,
+  IDBDatabase,
+  IDBFactory,
+  IDBIndex,
+  IDBKeyRange,
+  IDBObjectStore,
+  IDBOpenDBRequest,
+  IDBRequest,
+  IDBTransaction,
+} from "fake-indexeddb";
 import { Type } from "typebox";
 
 import {
-  InMemoryLofiAdapter,
+  IndexedDbAdapter,
   createLofiRuntime,
   uowOperationsToLofiMutations,
   type LofiMutation,
@@ -36,10 +47,24 @@ import {
 
 const workflowName = "interactive-chat";
 
+const installFakeIndexedDb = () => {
+  globalThis.indexedDB = new IDBFactory();
+  globalThis.IDBCursor = IDBCursor;
+  globalThis.IDBDatabase = IDBDatabase;
+  globalThis.IDBIndex = IDBIndex;
+  globalThis.IDBKeyRange = IDBKeyRange;
+  globalThis.IDBObjectStore = IDBObjectStore;
+  globalThis.IDBOpenDBRequest = IDBOpenDBRequest;
+  globalThis.IDBRequest = IDBRequest;
+  globalThis.IDBTransaction = IDBTransaction;
+};
+
 const createRuntime = async (mutations: readonly LofiMutation[] = []) => {
-  const adapter = new InMemoryLofiAdapter({
+  installFakeIndexedDb();
+  const adapter = new IndexedDbAdapter({
+    dbName: `pi-harness-projection-test-${Math.random().toString(16).slice(2)}`,
     endpointName: "pi-harness-projection-test",
-    schemas: [workflowsSchema],
+    schemas: [{ schema: workflowsSchema }],
   });
   await adapter.applyMutations([...mutations]);
   const runtime = createLofiRuntime({
@@ -58,9 +83,11 @@ const projectWorkflowMutations = async (
 ): Promise<PiWorkflowLofiSessionProjectionState> => {
   const { runtime } = await createRuntime(uowOperationsToLofiMutations(mutations));
   const store = createSessionProjectionDataStore(runtime, workflowName, sessionId, options);
+  const unlisten = store.listen(() => undefined);
 
   await runtime.whenBootstrapped();
   await store.refresh();
+  unlisten();
 
   return store.get().data;
 };
@@ -158,9 +185,11 @@ const projectManualWorkflow = async (
   ];
   const { runtime } = await createRuntime(mutations);
   const store = createSessionProjectionDataStore(runtime, workflowName, sessionId, storeOptions);
+  const unlisten = store.listen(() => undefined);
 
   await runtime.whenBootstrapped();
   await store.refresh();
+  unlisten();
 
   return store.get().data;
 };
@@ -182,19 +211,35 @@ const projectFauxPrompt = async (options: {
   return await projectWorkflowMutations(options.sessionId, recording.mutations);
 };
 
+type CheckpointProjectionOptions = {
+  mutations?: "live" | "deleted-step-emissions";
+  resume?: boolean;
+  waitForDone?: boolean;
+};
+
 const withFauxCheckpointProjection = async (
   run: ReturnType<typeof startFauxPiHarnessOperation>,
   sessionId: string,
   checkpointName: string,
   assertProjection: (projection: PiWorkflowLofiSessionProjectionState) => void | Promise<void>,
+  options: CheckpointProjectionOptions = {},
 ) => {
   const checkpoint = await run.waitForCheckpoint(checkpointName);
+  const mutations =
+    options.mutations === "deleted-step-emissions"
+      ? checkpoint.mutationsWithDeletedStepEmissions()
+      : checkpoint.mutations;
 
   try {
-    await assertProjection(await projectWorkflowMutations(sessionId, checkpoint.mutations));
+    await assertProjection(await projectWorkflowMutations(sessionId, mutations));
   } finally {
-    checkpoint.resume();
-    await run.done;
+    const shouldResume = options.resume ?? true;
+    if (shouldResume) {
+      checkpoint.resume();
+    }
+    if (options.waitForDone ?? shouldResume) {
+      await run.done;
+    }
   }
 };
 
@@ -1182,6 +1227,119 @@ describe("Pi harness workflow projection", () => {
       expect(projection.draftAgentMessage).toBeNull();
       expect(projection.statusText).toBeNull();
       assert(projection.readyForInput);
+    });
+
+    it("projects one run across live and emission-deleted checkpoint snapshots", async () => {
+      const sessionId = "multi-checkpoint-completed-step";
+      const run = startFauxPiHarnessOperation({
+        workflowName,
+        sessionId,
+        operation: { kind: "prompt", args: ["stay visible"] },
+        responses: [
+          fauxAssistantMessageWithCheckpoints(
+            [
+              fauxEventCheckpoint("assistant-text", "text_delta", { contentIndex: 0 }),
+              fauxEventCheckpoint("assistant-end", "message_end", { messageRole: "assistant" }),
+              fauxText("Still visible."),
+            ],
+            { timestamp: 1 },
+          ),
+        ],
+      });
+
+      await withFauxCheckpointProjection(
+        run,
+        sessionId,
+        "assistant-text",
+        (projection) => {
+          expect(projection.state.messages.map(messageTextContent)).toEqual(["stay visible"]);
+          expect(projection.draftAgentMessage).toMatchObject({ activity: "writing" });
+          assert(!projection.readyForInput);
+        },
+        {
+          waitForDone: false,
+        },
+      );
+
+      await withFauxCheckpointProjection(
+        run,
+        sessionId,
+        "assistant-end",
+        (projection) => {
+          expect(projection.state.messages.map(messageTextContent)).toEqual([
+            "stay visible",
+            "Still visible.",
+          ]);
+          expect(projection.draftAgentMessage).toBeNull();
+        },
+        {
+          waitForDone: false,
+        },
+      );
+
+      await withFauxCheckpointProjection(
+        run,
+        sessionId,
+        "assistant-end",
+        (projection) => {
+          expect(projection.state.messages.map(messageTextContent)).toEqual([
+            "stay visible",
+            "Still visible.",
+          ]);
+          expect(projection.draftAgentMessage).toBeNull();
+        },
+        {
+          mutations: "deleted-step-emissions",
+          resume: false,
+          waitForDone: false,
+        },
+      );
+
+      const recording = await run.done;
+      const completedProjection = await projectWorkflowMutations(sessionId, recording.mutations);
+      expect(completedProjection.state.messages.map(messageTextContent)).toEqual([
+        "stay visible",
+        "Still visible.",
+      ]);
+      expect(completedProjection.draftAgentMessage).toBeNull();
+      expect(completedProjection.statusText).toBeNull();
+      assert(completedProjection.readyForInput);
+    });
+
+    it("keeps messages visible in indexeddb after completed step emissions are deleted", async () => {
+      const sessionId = "indexeddb-deleted-emissions-after-completion";
+      const run = startFauxPiHarnessOperation({
+        workflowName,
+        sessionId,
+        operation: { kind: "prompt", args: ["stay visible"] },
+        responses: [
+          fauxAssistantMessageWithCheckpoints(
+            [
+              fauxEventCheckpoint("assistant-text", "text_delta", { contentIndex: 0 }),
+              fauxText("Still visible."),
+            ],
+            { timestamp: 1 },
+          ),
+        ],
+      });
+
+      const liveCheckpoint = await run.waitForCheckpoint("assistant-text");
+      liveCheckpoint.resume();
+      const recording = await run.done;
+      const completedProjection = await projectWorkflowMutations(sessionId, recording.mutations);
+      expect(completedProjection.state.messages.map(messageTextContent)).toEqual([
+        "stay visible",
+        "Still visible.",
+      ]);
+
+      const afterEmissionDeletionProjection = await projectWorkflowMutations(
+        sessionId,
+        run.mutationsWithDeletedStepEmissions(recording.mutations),
+      );
+      expect(afterEmissionDeletionProjection.state.messages.map(messageTextContent)).toEqual([
+        "stay visible",
+        "Still visible.",
+      ]);
     });
 
     it("keeps messages visible when live emissions settle into an outbox-shaped completed step", async () => {

--- a/packages/pi-harness/src/pi/pi-test-utils.ts
+++ b/packages/pi-harness/src/pi/pi-test-utils.ts
@@ -555,9 +555,12 @@ const createCheckpointStreamFn = (options: {
       const resumed = new Promise<void>((resolve) => {
         resume = resolve;
       });
+      const checkpointMutations = [...options.getMutations()];
       checkpoint.deferred.resolve({
         name: checkpoint.name,
-        mutations: [...options.getMutations()],
+        mutations: checkpointMutations,
+        mutationsWithDeletedStepEmissions: () =>
+          mutationsWithDeletedStepEmissions(checkpointMutations),
         resume,
       });
       await resumed;
@@ -704,13 +707,39 @@ const harnessEventFromMutation = (
 export type FauxPiHarnessCheckpointResult = {
   name: string;
   mutations: MutationOperation<AnySchema>[];
+  mutationsWithDeletedStepEmissions: () => MutationOperation<AnySchema>[];
   resume: () => void;
 };
 
 export type StartedFauxPiHarnessOperation = {
   waitForCheckpoint: (name: string) => Promise<FauxPiHarnessCheckpointResult>;
   done: Promise<RecordedWorkflowStepRun>;
+  mutationsWithDeletedStepEmissions: (
+    mutations?: readonly MutationOperation<AnySchema>[],
+  ) => MutationOperation<AnySchema>[];
 };
+
+const mutationsWithDeletedStepEmissions = (
+  mutations: readonly MutationOperation<AnySchema>[],
+): MutationOperation<AnySchema>[] => [
+  ...mutations,
+  ...mutations.flatMap((mutation): MutationOperation<AnySchema>[] => {
+    if (mutation.type !== "create" || mutation.table !== "workflow_step_emission") {
+      return [];
+    }
+
+    return [
+      {
+        type: "delete",
+        schema: mutation.schema,
+        namespace: mutation.namespace,
+        table: mutation.table,
+        id: mutation.generatedExternalId,
+        checkVersion: false,
+      },
+    ];
+  }),
+];
 
 const registerDeterministicFauxProvider = (options?: RegisterFauxProviderOptions) =>
   registerFauxProvider({
@@ -790,9 +819,12 @@ export const startFauxPiHarnessOperation = (
           const resumed = new Promise<void>((resolve) => {
             resume = resolve;
           });
+          const checkpointMutations = allMutations.slice(0, previousMutationCount + index + 1);
           checkpoint.deferred.resolve({
             name: checkpoint.name,
-            mutations: allMutations.slice(0, previousMutationCount + index + 1),
+            mutations: checkpointMutations,
+            mutationsWithDeletedStepEmissions: () =>
+              mutationsWithDeletedStepEmissions(checkpointMutations),
             resume,
           });
           await resumed;
@@ -828,6 +860,8 @@ export const startFauxPiHarnessOperation = (
       return checkpoint.deferred.promise;
     },
     done,
+    mutationsWithDeletedStepEmissions: (snapshot = mutations) =>
+      mutationsWithDeletedStepEmissions(snapshot),
   };
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed runtime transaction and store-building support for more flexible, schema-aware retrieval.
  * Backoffice “Pi sessions” now uses a local listing store with improved sync-driven rendering.
* **Bug Fixes**
  * Fixed schema-name alias/normalization so reads, writes, and projections resolve consistently across adapter setups.
  * Ensure outbox “db-now” defaults are applied correctly to create payloads.
  * Improved session error banners so local data remains visible when server refresh fails.
* **Tests**
  * Added coverage for schema aliasing/alias-aware projections and typed retrieval across schemas (plus related adapter integration tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->