### PR TITLE
Wilco/deprecated fragno db

### DIFF
--- a/.changeset/remove-deprecated-db-apis.md
+++ b/.changeset/remove-deprecated-db-apis.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/db": patch
+"@fragno-dev/test": patch
+---
+
+refactor: remove deprecated query engine, hook scheduler, and processor compatibility APIs

--- a/apps/backoffice/app/fragno/runtime-tools/automation-host.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/automation-host.test.ts
@@ -229,7 +229,7 @@ const createPiRuntime = (): PiRuntime => ({
     updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     workflow: { status: "waiting" as const },
     assistantText: text,
-    messageStatus: "active" as const,
+    commandStatus: "active" as const,
     stream: [
       {
         type: "snapshot" as const,

--- a/apps/backoffice/app/fragno/runtime-tools/families/pi-runtime.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/pi-runtime.test.ts
@@ -66,7 +66,7 @@ const createTurnResult = (sessionId: string, assistantText = "assistant:hello") 
       status: "waiting" as const,
     },
     assistantText,
-    messageStatus: "active" as const,
+    commandStatus: "active" as const,
     stream: [{ type: "snapshot" as const, state }],
     terminalState: state,
   };
@@ -495,7 +495,7 @@ describe("pi bash command registration", () => {
     expect(JSON.parse(defaultTurnLine ?? "null")).toMatchObject({
       id: "session-1",
       assistantText: "assistant:hello world",
-      messageStatus: "active",
+      commandStatus: "active",
     });
 
     expect(createCalls).toEqual([
@@ -913,7 +913,7 @@ describe("createPiRouteRuntime", () => {
     expect(turned).toMatchObject({
       id: "session-2",
       assistantText: "assistant:route-turn",
-      messageStatus: "active",
+      commandStatus: "active",
       workflow: { status: "waiting" },
       terminalState: {
         messages: expect.arrayContaining([

--- a/apps/backoffice/app/fragno/runtime-tools/families/pi-runtime.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/pi-runtime.ts
@@ -36,9 +36,7 @@ export type PiSessionTurnArgs = {
 
 export type PiSessionTurnResult = PiSessionDetail & {
   assistantText: string;
-  commandStatus?: PiWorkflowStatus;
-  /** @deprecated Use commandStatus. */
-  messageStatus: PiWorkflowStatus;
+  commandStatus: PiWorkflowStatus;
   stream: unknown[];
   /** Agent state after the turn (from session detail fetch). */
   terminalState: PiSessionDetail["agent"]["state"];
@@ -248,7 +246,6 @@ export const createPiRouteRuntime = ({
         ...detail,
         assistantText: extractAssistantText(detail.agent.state.messages),
         commandStatus: promptResponse.data.status,
-        messageStatus: promptResponse.data.status,
         stream: [],
         terminalState: detail.agent.state,
       };

--- a/apps/backoffice/app/fragno/runtime-tools/families/pi.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/pi.test.ts
@@ -32,7 +32,7 @@ const createRuntime = (): PiRuntime =>
     runTurn: vi.fn(async ({ sessionId, text }) => ({
       ...createSessionDetail(sessionId),
       assistantText: `echo: ${text}`,
-      messageStatus: "waiting",
+      commandStatus: "waiting",
       stream: [],
       terminalState: { messages: [] },
     })),

--- a/apps/backoffice/app/fragno/runtime-tools/families/pi.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/pi.ts
@@ -102,9 +102,7 @@ const sessionDetailOutputSchema = sessionDetailBaseOutputSchema.extend(sessionEx
 
 const sessionTurnOutputSchema = sessionDetailOutputSchema.extend({
   assistantText: z.string(),
-  commandStatus: z.enum(PI_SESSION_STATUSES).optional(),
-  /** @deprecated Use commandStatus. */
-  messageStatus: z.enum(PI_SESSION_STATUSES),
+  commandStatus: z.enum(PI_SESSION_STATUSES),
   stream: z.array(z.unknown()),
   terminalState: piAgentStateSnapshotOutputSchema,
 });

--- a/packages/fragno-db/src/adapters/adapters.ts
+++ b/packages/fragno-db/src/adapters/adapters.ts
@@ -1,6 +1,5 @@
 import type { RequestContextStorage } from "@fragno-dev/core/internal/request-context-storage";
 
-import type { FragnoDatabase } from "../fragno-database";
 import type { SqlNamingStrategy } from "../naming/sql-naming";
 import type { IUnitOfWork, TypedUnitOfWork } from "../query/unit-of-work/unit-of-work";
 import type { AnySchema } from "../schema/create";
@@ -73,14 +72,6 @@ export interface DatabaseAdapter<TUOWConfig = void> {
   ) => TypedUnitOfWork<T, [], unknown>;
 
   createBaseUnitOfWork: (name?: string, config?: TUOWConfig) => IUnitOfWork;
-
-  /**
-   * @deprecated Prefer adapter.createUnitOfWork(schema, namespace, ...) directly.
-   */
-  createQueryEngine: <const T extends AnySchema>(
-    schema: T,
-    namespace: string | null,
-  ) => FragnoDatabase<T, TUOWConfig>;
 
   prepareMigrations?: (schema: AnySchema, namespace: string | null) => PreparedMigrations;
 

--- a/packages/fragno-db/src/adapters/generic-sql/generic-sql-adapter.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/generic-sql-adapter.ts
@@ -1,6 +1,5 @@
 import { RequestContextStorage } from "@fragno-dev/core/internal/request-context-storage";
 
-import { FragnoDatabase } from "../../fragno-database";
 import { getOutboxConfigForAdapter } from "../../internal/outbox-state";
 import {
   createNamingResolver,
@@ -9,6 +8,8 @@ import {
 } from "../../naming/sql-naming";
 import type {
   CompiledMutation,
+  IUnitOfWork,
+  TypedUnitOfWork,
   UOWExecutor,
   UOWInstrumentation,
   UnitOfWorkConfig as BaseUnitOfWorkConfig,
@@ -218,15 +219,12 @@ export class SqlAdapter implements DatabaseAdapter<UnitOfWorkConfig> {
     namespace: string | null,
     name?: string,
     config?: UnitOfWorkConfig,
-  ): ReturnType<FragnoDatabase<T, UnitOfWorkConfig>["createUnitOfWork"]> {
+  ): TypedUnitOfWork<T, [], unknown> {
     this.registerSchema(schema, namespace);
     return this.createBaseUnitOfWork(name, config).forSchema(schema);
   }
 
-  createBaseUnitOfWork(
-    name?: string,
-    config?: UnitOfWorkConfig,
-  ): ReturnType<FragnoDatabase<AnySchema, UnitOfWorkConfig>["createBaseUnitOfWork"]> {
+  createBaseUnitOfWork(name?: string, config?: UnitOfWorkConfig): IUnitOfWork {
     const compiler = createUOWCompilerFromOperationCompiler(this.#createOperationCompiler());
     const executor: UOWExecutor<CompiledQuery, unknown> = createExecutor(
       this.#driver,
@@ -248,14 +246,6 @@ export class SqlAdapter implements DatabaseAdapter<UnitOfWorkConfig> {
       this.#normalizeUowConfig({ ...this.uowConfig, ...config }),
       this.#schemaNamespaceMap,
     );
-  }
-
-  createQueryEngine<T extends AnySchema>(
-    schema: T,
-    namespace: string | null,
-  ): FragnoDatabase<T, UnitOfWorkConfig> {
-    this.registerSchema(schema, namespace);
-    return new FragnoDatabase({ adapter: this, schema, namespace });
   }
 }
 

--- a/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-uow.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/sql-adapter-sqlite3-uow.test.ts
@@ -112,7 +112,6 @@ describe("SqlAdapter SQLite", () => {
     };
   }, 12000);
   it("should fail inserting duplicate triggered hook ids", async () => {
-    const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
     const hookId = "hook-duplicate-id";
     const hooks: HooksMap = {
       onTest: () => {},
@@ -123,7 +122,9 @@ describe("SqlAdapter SQLite", () => {
     } as unknown as InternalFragmentInstance;
 
     const buildHookUow = (name: string) => {
-      const uow = queryEngine.createUnitOfWork(name).forSchema(testSchema, hooks);
+      const uow = adapter
+        .createUnitOfWork(testSchema, "namespace", name)
+        .forSchema(testSchema, hooks);
       uow.triggerHook("onTest", { data: name }, { id: hookId });
       prepareHookMutations(
         uow,
@@ -140,7 +141,7 @@ describe("SqlAdapter SQLite", () => {
     const secondUow = buildHookUow("hook-duplicate-second");
     await expect(secondUow.executeMutations()).rejects.toThrow();
 
-    const verifyUow = queryEngine.createUnitOfWork("verify-duplicate-hook-id");
+    const verifyUow = adapter.createUnitOfWork(testSchema, "namespace", "verify-duplicate-hook-id");
     const internalUow = verifyUow.forSchema(internalSchema);
     const findUow = internalUow.find("fragno_hooks", (b) =>
       b.whereIndex("primary", (eb) => eb("id", "=", hookId)),

--- a/packages/fragno-db/src/adapters/in-memory/in-memory-adapter.ts
+++ b/packages/fragno-db/src/adapters/in-memory/in-memory-adapter.ts
@@ -1,6 +1,5 @@
 import { RequestContextStorage } from "@fragno-dev/core/internal/request-context-storage";
 
-import { FragnoDatabase } from "../../fragno-database";
 import { getOutboxConfigForAdapter } from "../../internal/outbox-state";
 import {
   createNamingResolver,
@@ -166,13 +165,5 @@ export class InMemoryAdapter implements DatabaseAdapter<InMemoryUowConfig> {
         };
       },
     };
-  }
-
-  createQueryEngine<T extends AnySchema>(
-    schema: T,
-    namespace: string | null,
-  ): FragnoDatabase<T, InMemoryUowConfig> {
-    this.registerSchema(schema, namespace);
-    return new FragnoDatabase({ adapter: this, schema, namespace });
   }
 }

--- a/packages/fragno-db/src/adapters/prisma/prisma-adapter-sqlite3.test.ts
+++ b/packages/fragno-db/src/adapters/prisma/prisma-adapter-sqlite3.test.ts
@@ -135,11 +135,14 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
   });
 
   it("should store prisma storage values using sqlite-friendly types", async () => {
-    const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
     const happenedOn = new Date("2024-06-18T12:34:56.789Z");
     const bigScore = 12345n;
 
-    const createUow = queryEngine.createUnitOfWork("create-prisma-storage-event");
+    const createUow = adapter.createUnitOfWork(
+      testSchema,
+      "namespace",
+      "create-prisma-storage-event",
+    );
     createUow.create("events", {
       name: "Prisma Storage Event",
       happened_on: happenedOn,
@@ -177,11 +180,14 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
       expect(fragnoAdapter.sqliteStorageMode).toBe(sqliteStorageDefault);
 
-      const queryEngine = fragnoAdapter.createQueryEngine(testSchema, "namespace");
       const happenedOn = new Date("2024-06-18T12:34:56.789Z");
       const bigScore = 1234567890123n;
 
-      const createUow = queryEngine.createUnitOfWork("create-fragno-storage-event");
+      const createUow = fragnoAdapter.createUnitOfWork(
+        testSchema,
+        "namespace",
+        "create-fragno-storage-event",
+      );
       createUow.create("events", {
         name: "Fragno Storage Event",
         happened_on: happenedOn,
@@ -205,10 +211,9 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     }
   });
   it("should store Date values as UTC ISO strings for sqlite prisma storage", async () => {
-    const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
     const happenedOn = new Date("2024-06-18T12:34:56.789Z");
 
-    const createUow = queryEngine.createUnitOfWork("create-iso-event");
+    const createUow = adapter.createUnitOfWork(testSchema, "namespace", "create-iso-event");
     createUow.create("events", {
       name: "ISO Stored Event",
       happened_on: happenedOn,
@@ -225,10 +230,9 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
     expect(row?.happened_on).toBe(happenedOn.toISOString());
   });
   it("should parse CURRENT_TIMESTAMP strings as UTC", async () => {
-    const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
     const tableName = adapter.namingStrategy.tableName("events", "namespace");
 
-    const createUow = queryEngine.createUnitOfWork("create-utc-event");
+    const createUow = adapter.createUnitOfWork(testSchema, "namespace", "create-utc-event");
     createUow.create("events", {
       name: "UTC Timestamp",
       happened_on: new Date("2024-06-15T00:00:00.000Z"),
@@ -241,8 +245,8 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       .prepare(`UPDATE ${tableName} SET created_at = ? WHERE name = ?`)
       .run("2024-06-15 14:30:00", "UTC Timestamp");
 
-    const [[event]] = await queryEngine
-      .createUnitOfWork("get-utc-event")
+    const [[event]] = await adapter
+      .createUnitOfWork(testSchema, "namespace", "get-utc-event")
       .find("events", (b) =>
         b.whereIndex("events_name_idx", (eb) => eb("name", "=", "UTC Timestamp")),
       )
@@ -254,12 +258,15 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
   it("should roundtrip BigInt when sqlite returns bigint values", async () => {
     sqliteDatabase.defaultSafeIntegers(true);
-    const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
     const safeIntegerLimit = BigInt(Number.MAX_SAFE_INTEGER);
     const bigScore = safeIntegerLimit + 42n;
 
     try {
-      const createUow = queryEngine.createUnitOfWork("create-safe-bigint-event");
+      const createUow = adapter.createUnitOfWork(
+        testSchema,
+        "namespace",
+        "create-safe-bigint-event",
+      );
       createUow.create("events", {
         name: "Safe BigInt",
         happened_on: new Date("2024-06-17T00:00:00.000Z"),
@@ -268,8 +275,8 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       });
       await createUow.executeMutations();
 
-      const [[event]] = await queryEngine
-        .createUnitOfWork("get-safe-bigint-event")
+      const [[event]] = await adapter
+        .createUnitOfWork(testSchema, "namespace", "get-safe-bigint-event")
         .find("events", (b) =>
           b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Safe BigInt")),
         )
@@ -283,11 +290,10 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
 
   it("should throw when sqlite returns unsafe BigInt numbers", async () => {
     sqliteDatabase.defaultSafeIntegers(false);
-    const queryEngine = adapter.createQueryEngine(testSchema, "namespace");
     const unsafeBigScore = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
 
     try {
-      const createUow = queryEngine.createUnitOfWork("create-unsafe-event");
+      const createUow = adapter.createUnitOfWork(testSchema, "namespace", "create-unsafe-event");
       createUow.create("events", {
         name: "Unsafe BigInt",
         happened_on: new Date("2024-06-16T00:00:00.000Z"),
@@ -297,8 +303,8 @@ describe("SqlAdapter SQLite (prisma profile)", () => {
       await createUow.executeMutations();
 
       await expect(
-        queryEngine
-          .createUnitOfWork("get-unsafe-event")
+        adapter
+          .createUnitOfWork(testSchema, "namespace", "get-unsafe-event")
           .find("events", (b) =>
             b.whereIndex("events_name_idx", (eb) => eb("name", "=", "Unsafe BigInt")),
           )

--- a/packages/fragno-db/src/db-fragment-definition-builder.test.ts
+++ b/packages/fragno-db/src/db-fragment-definition-builder.test.ts
@@ -18,7 +18,6 @@ import {
   type ImplicitDatabaseDependencies,
 } from "./db-fragment-definition-builder";
 import { internalSchema } from "./fragments/internal-fragment";
-import type { FragnoDatabase } from "./fragno-database";
 import { getDurableHooksRuntimeByToken } from "./hooks/durable-hooks-runtime";
 import type { HookFn } from "./hooks/hooks";
 import * as hooks from "./hooks/hooks";
@@ -40,8 +39,6 @@ const testSchema = schema("test", (s) => {
   });
 });
 
-type TestSchema = typeof testSchema;
-
 // Mock database adapter
 function createMockAdapter(): DatabaseAdapter {
   const createMockUow = () => ({
@@ -52,16 +49,10 @@ function createMockAdapter(): DatabaseAdapter {
     reset: vi.fn(),
   });
 
-  const mockdb = {
-    createUnitOfWork: vi.fn(() => createMockUow()),
-    createBaseUnitOfWork: vi.fn(() => createMockUow()),
-  } as unknown as FragnoDatabase<TestSchema>;
-
   return {
     registerSchema: vi.fn(),
     createUnitOfWork: vi.fn(() => createMockUow()),
     createBaseUnitOfWork: vi.fn(() => createMockUow()),
-    createQueryEngine: vi.fn(() => mockdb),
     getSchemaVersion: vi.fn(async () => undefined),
     close: vi.fn(),
     contextStorage: new RequestContextStorage(),

--- a/packages/fragno-db/src/db-fragment-instantiator.test.ts
+++ b/packages/fragno-db/src/db-fragment-instantiator.test.ts
@@ -11,7 +11,6 @@ import { z } from "zod";
 import { instantiate, defineFragment } from "@fragno-dev/core";
 
 import type { DatabaseAdapter } from "./adapters/adapters";
-import type { FragnoDatabase } from "./fragno-database";
 import { suffixNamingStrategy } from "./naming/sql-naming";
 import { schema, idColumn, column } from "./schema/create";
 import { withDatabase } from "./with-database";
@@ -29,8 +28,6 @@ const dashedSchema = schema("my-fragment", (s) => {
     return t.addColumn("id", idColumn()).addColumn("label", column("string"));
   });
 });
-
-type TestSchema = typeof testSchema;
 
 // Mock database adapter
 function createMockAdapter(): DatabaseAdapter {
@@ -89,17 +86,10 @@ function createMockAdapter(): DatabaseAdapter {
     state: "building-retrieval",
   });
 
-  const mockdb = {
-    createUnitOfWork: vi.fn(() => createMockUow()),
-    createBaseUnitOfWork: vi.fn(() => createMockUow()),
-    type: "mock",
-  } as unknown as FragnoDatabase<TestSchema>;
-
   return {
     registerSchema: vi.fn(),
     createUnitOfWork: vi.fn(() => createMockUow()),
     createBaseUnitOfWork: vi.fn(() => createMockUow()),
-    createQueryEngine: vi.fn(() => mockdb),
     getSchemaVersion: vi.fn(async () => undefined),
     close: vi.fn(),
     type: "mock",

--- a/packages/fragno-db/src/dispatchers/cloudflare-do/index.test.ts
+++ b/packages/fragno-db/src/dispatchers/cloudflare-do/index.test.ts
@@ -23,7 +23,6 @@ describe("createDurableHooksDispatcherDurableObject", () => {
     const handlerFactory = createDurableHooksDispatcherDurableObject({
       createProcessor: () => ({
         processDue,
-        process: processDue,
         getNextWakeAt,
         drain,
         namespace: "test",
@@ -46,7 +45,6 @@ describe("createDurableHooksDispatcherDurableObject", () => {
     const handlerFactory = createDurableHooksDispatcherDurableObject({
       createProcessor: () => ({
         processDue,
-        process: processDue,
         getNextWakeAt,
         drain,
         namespace: "test",
@@ -73,7 +71,6 @@ describe("createDurableHooksDispatcherDurableObject", () => {
     const handlerFactory = createDurableHooksDispatcherDurableObject({
       createProcessor: () => ({
         processDue,
-        process: processDue,
         getNextWakeAt,
         drain,
         namespace: "test",
@@ -109,7 +106,6 @@ describe("createDurableHooksDispatcherDurableObject", () => {
     const handlerFactory = createDurableHooksDispatcherDurableObject({
       createProcessor: () => ({
         processDue,
-        process: processDue,
         getNextWakeAt,
         drain,
         namespace: "test",
@@ -136,7 +132,6 @@ describe("createDurableHooksDispatcherDurableObject", () => {
     const handlerFactory = createDurableHooksDispatcherDurableObject({
       createProcessor: () => ({
         processDue,
-        process: processDue,
         getNextWakeAt,
         drain,
         namespace: "test",
@@ -171,7 +166,6 @@ describe("createDurableHooksDispatcherDurableObject", () => {
     const handlerFactory = createDurableHooksDispatcherDurableObject({
       createProcessor: () => ({
         processDue,
-        process: processDue,
         getNextWakeAt,
         drain,
         namespace: "test",
@@ -212,7 +206,6 @@ describe("createDurableHooksDispatcherDurableObject", () => {
     const handlerFactory = createDurableHooksDispatcherDurableObject({
       createProcessor: () => ({
         processDue,
-        process: processDue,
         getNextWakeAt,
         drain,
         namespace: "test",

--- a/packages/fragno-db/src/dispatchers/node/index.test.ts
+++ b/packages/fragno-db/src/dispatchers/node/index.test.ts
@@ -10,7 +10,6 @@ describe("createDurableHooksDispatcher", () => {
       const dispatcher = createDurableHooksDispatcher({
         processor: {
           processDue,
-          process: processDue,
           getNextWakeAt: vi.fn().mockResolvedValue(null),
           drain: vi.fn().mockResolvedValue(undefined),
           namespace: "test",
@@ -36,7 +35,7 @@ describe("createDurableHooksDispatcher", () => {
     const drain = vi.fn().mockResolvedValue(undefined);
 
     const dispatcher = createDurableHooksDispatcher({
-      processor: { processDue, process: processDue, getNextWakeAt, drain, namespace: "test" },
+      processor: { processDue, getNextWakeAt, drain, namespace: "test" },
     });
 
     await dispatcher.wake();
@@ -55,7 +54,6 @@ describe("createDurableHooksDispatcher", () => {
     const dispatcher = createDurableHooksDispatcher({
       processor: {
         processDue,
-        process: processDue,
         getNextWakeAt: vi.fn().mockResolvedValue(null),
         drain,
         namespace: "test",
@@ -84,7 +82,7 @@ describe("createDurableHooksDispatcher", () => {
     const drain = vi.fn().mockResolvedValue(undefined);
 
     const dispatcher = createDurableHooksDispatcher({
-      processor: { processDue, process: processDue, getNextWakeAt, drain, namespace: "test" },
+      processor: { processDue, getNextWakeAt, drain, namespace: "test" },
       pollIntervalMs: 1000,
     });
 
@@ -106,7 +104,7 @@ describe("createDurableHooksDispatcher", () => {
     const drain = vi.fn().mockResolvedValue(undefined);
 
     const dispatcher = createDurableHooksDispatcher({
-      processor: { processDue, process: processDue, getNextWakeAt, drain, namespace: "test" },
+      processor: { processDue, getNextWakeAt, drain, namespace: "test" },
       pollIntervalMs: 1000,
     });
 

--- a/packages/fragno-db/src/hooks/durable-hooks-processor.test.ts
+++ b/packages/fragno-db/src/hooks/durable-hooks-processor.test.ts
@@ -206,7 +206,6 @@ describe("createDurableHooksProcessorGroupFromProcessors", () => {
     return {
       namespace: "test",
       processDue,
-      process: processDue,
       getNextWakeAt: vi.fn().mockResolvedValue(null),
       drain: vi.fn().mockResolvedValue(undefined),
     };

--- a/packages/fragno-db/src/hooks/durable-hooks-processor.ts
+++ b/packages/fragno-db/src/hooks/durable-hooks-processor.ts
@@ -5,10 +5,6 @@ import { createDurableHooksRunner } from "./hooks";
 
 export type DurableHooksProcessor = {
   processDue: () => Promise<number>;
-  /**
-   * @deprecated Use processDue().
-   */
-  process: () => Promise<number>;
   getNextWakeAt: () => Promise<Date | null>;
   drain: () => Promise<void>;
   namespace: string;
@@ -50,21 +46,11 @@ export function createDurableHooksProcessor(
     durableHooks.stuckProcessingTimeoutMinutes,
   );
   const runner =
-    durableHooks.runner ??
-    // oxlint-disable-next-line typescript/no-deprecated -- Preserve the deprecated scheduler bridge until its public compatibility API is removed.
-    (durableHooks.runner = durableHooks.scheduler
-      ? {
-          // oxlint-disable-next-line typescript/no-deprecated -- Adapt the legacy scheduler contract to the current runner contract.
-          processDue: () => durableHooks.scheduler!.schedule(),
-          // oxlint-disable-next-line typescript/no-deprecated -- Adapt the legacy scheduler contract to the current runner contract.
-          drain: () => durableHooks.scheduler!.drain(),
-        }
-      : createDurableHooksRunner(durableHooks));
+    durableHooks.runner ?? (durableHooks.runner = createDurableHooksRunner(durableHooks));
 
   return {
     namespace,
     processDue: async () => runner.processDue(),
-    process: async () => runner.processDue(),
     drain: async () => runner.drain(),
     getNextWakeAt: async () => {
       return await internalFragment.inContext(async function () {
@@ -130,7 +116,6 @@ export function createDurableHooksProcessorGroupFromProcessors(
   return {
     namespace,
     processDue,
-    process: processDue,
     drain: async () => {
       const results = await Promise.allSettled(
         processors.map(async (processor) => await processor.drain()),

--- a/packages/fragno-db/src/hooks/hooks.ts
+++ b/packages/fragno-db/src/hooks/hooks.ts
@@ -141,14 +141,6 @@ export type DurableHooksRunner = {
 };
 
 /**
- * @deprecated Use DurableHooksRunner.
- */
-export type HookScheduler = {
-  schedule: () => Promise<number>;
-  drain: () => Promise<void>;
-};
-
-/**
  * Configuration for hook processing.
  */
 export interface HookProcessorConfig<THooks extends HooksMap = HooksMap> {
@@ -169,11 +161,6 @@ export interface HookProcessorConfig<THooks extends HooksMap = HooksMap> {
    * Post-commit durable hooks notifier.
    */
   notifier?: HookNotifier;
-  /**
-   * @deprecated Use `runner`.
-   */
-  // oxlint-disable-next-line typescript/no-deprecated -- Keep the public scheduler compatibility field typed by its legacy contract.
-  scheduler?: HookScheduler;
   defaultRetryPolicy?: RetryPolicy;
   /**
    * Re-queue hooks that have been in `processing` for at least this many minutes.
@@ -643,16 +630,4 @@ export function createDurableHooksRunner(config: HookProcessorConfig): DurableHo
   };
 
   return { processDue, drain };
-}
-
-/**
- * @deprecated Use createDurableHooksRunner.
- */
-// oxlint-disable-next-line typescript/no-deprecated -- Keep the deprecated factory's return type accurate for compatibility callers.
-export function createHookScheduler(config: HookProcessorConfig): HookScheduler {
-  const runner = createDurableHooksRunner(config);
-  return {
-    schedule: () => runner.processDue(),
-    drain: () => runner.drain(),
-  };
 }

--- a/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
+++ b/packages/fragno-db/src/query/unit-of-work/execute-unit-of-work.test.ts
@@ -48,10 +48,6 @@ function setupCrossSchemaHookTest() {
   const namespaceA = "alpha";
   const namespaceB = "beta";
 
-  const queryA = adapter.createQueryEngine(schemaA, namespaceA);
-  const queryB = adapter.createQueryEngine(schemaB, namespaceB);
-  const internalQuery = adapter.createQueryEngine(internalSchema, null);
-
   const internalFragment = {
     $internal: {
       deps: {
@@ -66,9 +62,7 @@ function setupCrossSchemaHookTest() {
     schemaB,
     namespaceA,
     namespaceB,
-    queryA,
-    queryB,
-    internalQuery,
+    adapter,
     internalFragment,
   };
 }
@@ -2175,7 +2169,7 @@ describe("Unified Tx API", () => {
     });
 
     it("should create hook records when handler uses schema A and service uses schema B", async () => {
-      const { schemaA, schemaB, namespaceA, namespaceB, queryA, internalQuery, internalFragment } =
+      const { schemaA, schemaB, namespaceA, namespaceB, adapter, internalFragment } =
         setupCrossSchemaHookTest();
 
       type HooksA = {
@@ -2204,7 +2198,7 @@ describe("Unified Tx API", () => {
 
       await createHandlerTxBuilder({
         createUnitOfWork: () => {
-          currentUow = queryA.createBaseUnitOfWork();
+          currentUow = adapter.createBaseUnitOfWork();
           currentUow.registerSchema(schemaA, namespaceA);
           currentUow.registerSchema(schemaB, namespaceB);
           currentUow.registerSchema(internalSchema, null);
@@ -2223,8 +2217,8 @@ describe("Unified Tx API", () => {
         .execute();
 
       const hooks = await (async () => {
-        const uow = internalQuery
-          .createUnitOfWork("read")
+        const uow = adapter
+          .createUnitOfWork(internalSchema, null, "read")
           .find("fragno_hooks", (b) => b.whereIndex("primary"));
         await uow.executeRetrieve();
         return (await uow.retrievalPhase)[0];
@@ -2239,7 +2233,7 @@ describe("Unified Tx API", () => {
     });
 
     it("should create hook records when handler uses schema B and service uses schema A", async () => {
-      const { schemaA, schemaB, namespaceA, namespaceB, queryB, internalQuery, internalFragment } =
+      const { schemaA, schemaB, namespaceA, namespaceB, adapter, internalFragment } =
         setupCrossSchemaHookTest();
 
       type HooksA = {
@@ -2268,7 +2262,7 @@ describe("Unified Tx API", () => {
 
       await createHandlerTxBuilder({
         createUnitOfWork: () => {
-          currentUow = queryB.createBaseUnitOfWork();
+          currentUow = adapter.createBaseUnitOfWork();
           currentUow.registerSchema(schemaA, namespaceA);
           currentUow.registerSchema(schemaB, namespaceB);
           currentUow.registerSchema(internalSchema, null);
@@ -2287,8 +2281,8 @@ describe("Unified Tx API", () => {
         .execute();
 
       const hooks = await (async () => {
-        const uow = internalQuery
-          .createUnitOfWork("read")
+        const uow = adapter
+          .createUnitOfWork(internalSchema, null, "read")
           .find("fragno_hooks", (b) => b.whereIndex("primary"));
         await uow.executeRetrieve();
         return (await uow.retrievalPhase)[0];

--- a/packages/fragno-test/src/adapter-conformance.test.ts
+++ b/packages/fragno-test/src/adapter-conformance.test.ts
@@ -78,6 +78,21 @@ async function withAdapter<T>(config: SupportedAdapter, run: (db: ConformanceDb)
 
 for (const adapterCase of adapterCases) {
   describe(`adapter conformance (${adapterCase.name})`, () => {
+    it("returns schema-view retrievals through the base unit of work", async () => {
+      await withAdapter(adapterCase.config, async (db) => {
+        const createUow = db.createUnitOfWork("create-user");
+        createUow.forSchema(conformanceSchema).create("users", { name: "Ada" });
+        const createResult = await createUow.executeMutations();
+        assert(createResult.success);
+
+        const readUow = db.createUnitOfWork("read-users");
+        readUow.forSchema(conformanceSchema).find("users", (b) => b.whereIndex("users_by_name"));
+
+        const [users] = await readUow.executeRetrieve();
+        expect(users).toEqual([expect.objectContaining({ name: "Ada" })]);
+      });
+    });
+
     it("enforces optimistic checks and version bumps", async () => {
       await withAdapter(adapterCase.config, async (db) => {
         const createUow = db.createUnitOfWork("create-user").forSchema(conformanceSchema);

--- a/packages/fragno-test/src/common-test-context.ts
+++ b/packages/fragno-test/src/common-test-context.ts
@@ -1,7 +1,7 @@
-import type { DatabaseAdapter, FragnoDatabase } from "@fragno-dev/db";
+import type { DatabaseAdapter } from "@fragno-dev/db";
 
 import type { SupportedAdapter, AdapterContext } from "./adapters";
-import { createTestDb, type TestDb } from "./test-db";
+import { createTestDb, type TestDb, type TestUnitOfWorkFactory } from "./test-db";
 
 /**
  * Base test context with common functionality across all adapters.
@@ -21,22 +21,20 @@ export interface InternalTestContextMethods {
 }
 
 /**
- * Helper to create common test context methods from an ORM map.
+ * Helper to create common test context methods from schema-bound unit-of-work factories.
  * This is used internally by adapter implementations to avoid code duplication.
  */
 export function createCommonTestContextMethods(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ormMap: Map<string | null, FragnoDatabase<any>>,
+  unitOfWorkFactories: Map<string | null, TestUnitOfWorkFactory>,
 ): InternalTestContextMethods {
   return {
-    getDb: (namespace: string | null) =>
-      createTestDb((name, config) => {
-        const orm = ormMap.get(namespace);
-        if (!orm) {
-          throw new Error(`No ORM found for namespace: ${String(namespace)}`);
-        }
-        return orm.createBaseUnitOfWork(name, config as never);
-      }),
+    getDb: (namespace: string | null) => {
+      const createUnitOfWork = unitOfWorkFactories.get(namespace);
+      if (!createUnitOfWork) {
+        throw new Error(`No schema registered for namespace: ${String(namespace)}`);
+      }
+      return createTestDb(createUnitOfWork);
+    },
   };
 }
 

--- a/packages/fragno-test/src/db-test.ts
+++ b/packages/fragno-test/src/db-test.ts
@@ -521,7 +521,6 @@ export class DatabaseFragmentsTestBuilder<
             registerSchema: () => {},
             createUnitOfWork: () => ({ schema: null }),
             createBaseUnitOfWork: () => ({ schema: null }),
-            createQueryEngine: () => ({ schema: null }),
             getSchemaVersion: async () => undefined,
             namingStrategy: {
               namespaceScope: "suffix",

--- a/packages/fragno-test/src/test-adapters/drizzle-pglite.ts
+++ b/packages/fragno-test/src/test-adapters/drizzle-pglite.ts
@@ -6,13 +6,13 @@ import { PGLiteDriverConfig } from "@fragno-dev/db/drivers";
 import { drizzle } from "drizzle-orm/pglite";
 import { KyselyPGlite } from "kysely-pglite";
 
-import type { FragnoDatabase } from "@fragno-dev/db";
 import { internalFragmentDef } from "@fragno-dev/db";
 
 import { PGlite } from "@electric-sql/pglite";
 
 import type { AdapterFactoryResult, DrizzlePgliteAdapter, SchemaConfig } from "../adapters";
 import { createCommonTestContextMethods } from "../common-test-context";
+import type { TestUnitOfWorkFactory } from "../test-db";
 
 const runInternalFragmentMigrations = async (
   adapter: SqlAdapter,
@@ -63,8 +63,7 @@ export async function createDrizzlePgliteAdapter(
 
     internalSchemaConfig = await runInternalFragmentMigrations(adapter);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ormMap = new Map<string | null, FragnoDatabase<any, any>>();
+    const unitOfWorkFactories = new Map<string | null, TestUnitOfWorkFactory>();
     for (const { schema, namespace, migrateToVersion } of schemas) {
       const preparedMigrations = adapter.prepareMigrations(schema, namespace);
       if (migrateToVersion !== undefined) {
@@ -75,8 +74,10 @@ export async function createDrizzlePgliteAdapter(
         await preparedMigrations.execute(0, schema.version, { updateVersionInMigration: false });
       }
 
-      const orm = adapter.createQueryEngine(schema, namespace);
-      ormMap.set(namespace, orm);
+      adapter.registerSchema(schema, namespace);
+      unitOfWorkFactories.set(namespace, (name, uowConfig) =>
+        adapter.createBaseUnitOfWork(name, uowConfig as never),
+      );
     }
 
     // oxlint-disable-next-line typescript/no-explicit-any
@@ -89,10 +90,15 @@ export async function createDrizzlePgliteAdapter(
         uowConfig: config.uowConfig,
       });
 
-    return { drizzle: db, adapter, ormMap, createAdditionalAdapter };
+    return { drizzle: db, adapter, unitOfWorkFactories, createAdditionalAdapter };
   };
 
-  const { drizzle: drizzleDb, adapter, ormMap, createAdditionalAdapter } = await createDatabase();
+  const {
+    drizzle: drizzleDb,
+    adapter,
+    unitOfWorkFactories,
+    createAdditionalAdapter,
+  } = await createDatabase();
 
   const resetDatabase = async () => {
     if (databasePath && databasePath !== ":memory:") {
@@ -135,7 +141,7 @@ export async function createDrizzlePgliteAdapter(
     }
   };
 
-  const commonMethods = createCommonTestContextMethods(ormMap);
+  const commonMethods = createCommonTestContextMethods(unitOfWorkFactories);
 
   return {
     testContext: {

--- a/packages/fragno-test/src/test-adapters/in-memory.ts
+++ b/packages/fragno-test/src/test-adapters/in-memory.ts
@@ -1,9 +1,8 @@
 import { InMemoryAdapter } from "@fragno-dev/db/adapters/in-memory";
 
-import type { FragnoDatabase } from "@fragno-dev/db";
-
 import type { AdapterFactoryResult, InMemoryAdapterConfig, SchemaConfig } from "../adapters";
 import { createCommonTestContextMethods } from "../common-test-context";
+import type { TestUnitOfWorkFactory } from "../test-db";
 
 export async function createInMemoryAdapter(
   config: InMemoryAdapterConfig,
@@ -11,11 +10,12 @@ export async function createInMemoryAdapter(
 ): Promise<AdapterFactoryResult<InMemoryAdapterConfig>> {
   const adapter = new InMemoryAdapter(config.options);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const ormMap = new Map<string | null, FragnoDatabase<any, any>>();
+  const unitOfWorkFactories = new Map<string | null, TestUnitOfWorkFactory>();
   for (const { schema, namespace } of schemas) {
-    const orm = adapter.createQueryEngine(schema, namespace);
-    ormMap.set(namespace, orm);
+    adapter.registerSchema(schema, namespace);
+    unitOfWorkFactories.set(namespace, (name, uowConfig) =>
+      adapter.createBaseUnitOfWork(name, uowConfig as never),
+    );
   }
 
   const resetDatabase = async () => {
@@ -26,7 +26,7 @@ export async function createInMemoryAdapter(
     await adapter.close();
   };
 
-  const commonMethods = createCommonTestContextMethods(ormMap);
+  const commonMethods = createCommonTestContextMethods(unitOfWorkFactories);
 
   return {
     testContext: {

--- a/packages/fragno-test/src/test-adapters/kysely-pglite.ts
+++ b/packages/fragno-test/src/test-adapters/kysely-pglite.ts
@@ -6,11 +6,11 @@ import { PGLiteDriverConfig } from "@fragno-dev/db/drivers";
 import { Kysely } from "kysely";
 import { KyselyPGlite } from "kysely-pglite";
 
-import type { FragnoDatabase } from "@fragno-dev/db";
 import { internalFragmentDef } from "@fragno-dev/db";
 
 import type { AdapterFactoryResult, KyselyPgliteAdapter, SchemaConfig } from "../adapters";
 import { createCommonTestContextMethods } from "../common-test-context";
+import type { TestUnitOfWorkFactory } from "../test-db";
 
 const runInternalFragmentMigrations = async (
   adapter: SqlAdapter,
@@ -64,8 +64,7 @@ export async function createKyselyPgliteAdapter(
     });
     internalSchemaConfig = await runInternalFragmentMigrations(adapter);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ormMap = new Map<string | null, FragnoDatabase<any, any>>();
+    const unitOfWorkFactories = new Map<string | null, TestUnitOfWorkFactory>();
 
     for (const { schema, namespace, migrateToVersion } of schemas) {
       const preparedMigrations = adapter.prepareMigrations(schema, namespace);
@@ -77,8 +76,10 @@ export async function createKyselyPgliteAdapter(
         await preparedMigrations.execute(0, schema.version, { updateVersionInMigration: false });
       }
 
-      const orm = adapter.createQueryEngine(schema, namespace);
-      ormMap.set(namespace, orm);
+      adapter.registerSchema(schema, namespace);
+      unitOfWorkFactories.set(namespace, (name, uowConfig) =>
+        adapter.createBaseUnitOfWork(name, uowConfig as never),
+      );
     }
 
     const createAdditionalAdapter = async () =>
@@ -88,10 +89,11 @@ export async function createKyselyPgliteAdapter(
         uowConfig: config.uowConfig,
       });
 
-    return { kysely, adapter, kyselyPglite, ormMap, createAdditionalAdapter };
+    return { kysely, adapter, kyselyPglite, unitOfWorkFactories, createAdditionalAdapter };
   };
 
-  const { kysely, adapter, kyselyPglite, ormMap, createAdditionalAdapter } = await createDatabase();
+  const { kysely, adapter, kyselyPglite, unitOfWorkFactories, createAdditionalAdapter } =
+    await createDatabase();
 
   const resetDatabase = async () => {
     if (databasePath && databasePath !== ":memory:") {
@@ -124,7 +126,7 @@ export async function createKyselyPgliteAdapter(
     }
   };
 
-  const commonMethods = createCommonTestContextMethods(ormMap);
+  const commonMethods = createCommonTestContextMethods(unitOfWorkFactories);
 
   return {
     testContext: {

--- a/packages/fragno-test/src/test-adapters/kysely-sqlite.ts
+++ b/packages/fragno-test/src/test-adapters/kysely-sqlite.ts
@@ -3,11 +3,11 @@ import { SQLocalDriverConfig } from "@fragno-dev/db/drivers";
 import { Kysely } from "kysely";
 import { SQLocalKysely } from "sqlocal/kysely";
 
-import type { FragnoDatabase } from "@fragno-dev/db";
 import { internalFragmentDef } from "@fragno-dev/db";
 
 import type { KyselySqliteAdapter, AdapterFactoryResult, SchemaConfig } from "../adapters";
 import { createCommonTestContextMethods } from "../common-test-context";
+import type { TestUnitOfWorkFactory } from "../test-db";
 
 const runInternalFragmentMigrations = async (
   adapter: SqlAdapter,
@@ -49,8 +49,7 @@ export async function createKyselySqliteAdapter(
     });
     internalSchemaConfig = await runInternalFragmentMigrations(adapter);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ormMap = new Map<string | null, FragnoDatabase<any, any>>();
+    const unitOfWorkFactories = new Map<string | null, TestUnitOfWorkFactory>();
     for (const { schema, namespace, migrateToVersion } of schemas) {
       const preparedMigrations = adapter.prepareMigrations(schema, namespace);
       if (migrateToVersion !== undefined) {
@@ -61,8 +60,10 @@ export async function createKyselySqliteAdapter(
         await preparedMigrations.execute(0, schema.version, { updateVersionInMigration: false });
       }
 
-      const orm = adapter.createQueryEngine(schema, namespace);
-      ormMap.set(namespace, orm);
+      adapter.registerSchema(schema, namespace);
+      unitOfWorkFactories.set(namespace, (name, uowConfig) =>
+        adapter.createBaseUnitOfWork(name, uowConfig as never),
+      );
     }
 
     const createAdditionalAdapter = async () =>
@@ -72,10 +73,10 @@ export async function createKyselySqliteAdapter(
         uowConfig: config.uowConfig,
       });
 
-    return { kysely, adapter, ormMap, createAdditionalAdapter };
+    return { kysely, adapter, unitOfWorkFactories, createAdditionalAdapter };
   };
 
-  let { kysely, adapter, ormMap, createAdditionalAdapter } = await createDatabase();
+  let { kysely, adapter, unitOfWorkFactories, createAdditionalAdapter } = await createDatabase();
 
   const resetDatabase = async () => {
     const schemasToTruncate = internalSchemaConfig ? [internalSchemaConfig, ...schemas] : schemas;
@@ -92,7 +93,7 @@ export async function createKyselySqliteAdapter(
     await kysely.destroy();
   };
 
-  const commonMethods = createCommonTestContextMethods(ormMap);
+  const commonMethods = createCommonTestContextMethods(unitOfWorkFactories);
 
   return {
     testContext: {

--- a/packages/fragno-test/src/test-db.ts
+++ b/packages/fragno-test/src/test-db.ts
@@ -1,11 +1,11 @@
 import type { IUnitOfWork } from "@fragno-dev/db";
 
+export type TestUnitOfWorkFactory = (name?: string, config?: unknown) => IUnitOfWork;
+
 export interface TestDb {
-  createUnitOfWork: (name?: string, config?: unknown) => IUnitOfWork;
+  createUnitOfWork: TestUnitOfWorkFactory;
 }
 
-export function createTestDb(
-  createUnitOfWork: (name?: string, config?: unknown) => IUnitOfWork,
-): TestDb {
+export function createTestDb(createUnitOfWork: TestUnitOfWorkFactory): TestDb {
   return { createUnitOfWork };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated database query-engine and hook-scheduler APIs.
  * Updated durable hook processing to use `processDue` instead of the deprecated `process` method.
  * Replaced the deprecated `messageStatus` response field with required `commandStatus` in Pi runtime results.

* **Improvements**
  * Simplified database access through direct unit-of-work creation.
  * Added validation coverage for schema views and updated adapter compatibility tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->