### PR TITLE
feat(workflows): create events from step transactions

### DIFF
--- a/.changeset/workflow-step-events.md
+++ b/.changeset/workflow-step-events.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/workflows": patch
+---
+
+feat: allow workflow step transactions to create events for local workflow instances.

--- a/packages/fragment-workflows/src/remote-workflow.test.ts
+++ b/packages/fragment-workflows/src/remote-workflow.test.ts
@@ -291,6 +291,88 @@ describe("remote workflow step host", () => {
     });
   });
 
+  test("remote step tx can create an event for another workflow instance", async () => {
+    const ParentWorkflow = defineWorkflow(
+      { name: "remote-event-parent-workflow" },
+      async (_event, step) => {
+        const child = await step.waitForEvent<{ value: number }>("join child", {
+          type: "child:complete",
+        });
+        return { value: child.payload.value };
+      },
+    );
+    const RemoteChildWorkflow = defineRemoteWorkflow<
+      "remote-event-child-workflow",
+      { parentId: string; value: number },
+      { completed: true }
+    >({ name: "remote-event-child-workflow" }, async (event, host) => {
+      await host.do(null, "complete child", undefined, async (tx) => {
+        tx.workflowServiceCalls(() => [
+          {
+            type: "createEvent",
+            workflowName: "remote-event-parent-workflow",
+            instanceId: event.payload.parentId,
+            eventId: `${event.instanceId}:complete`,
+            eventType: "child:complete",
+            payload: { value: event.payload.value },
+          },
+        ]);
+      });
+      return { completed: true };
+    });
+    const harness = await createWorkflowsTestHarness({
+      workflows: { PARENT: ParentWorkflow, CHILD: RemoteChildWorkflow },
+      adapter: { type: "in-memory" },
+      testBuilder: buildDatabaseFragmentsTest(),
+      autoTickHooks: false,
+    });
+
+    const parentId = await harness.createInstance("PARENT", { id: "remote-event-parent-1" });
+    await harness.runUntilIdle({
+      workflowName: "remote-event-parent-workflow",
+      instanceId: parentId,
+      reason: "create",
+    });
+    await expect(harness.getStatus("PARENT", parentId)).resolves.toMatchObject({
+      status: "waiting",
+    });
+
+    const childId = await harness.createInstance("CHILD", {
+      id: "remote-event-child-1",
+      params: { parentId, value: 42 },
+      remoteWorkflowName: "remote-event-child-body",
+    });
+    await harness.runUntilIdle({
+      workflowName: "remote-event-child-workflow",
+      instanceId: childId,
+      reason: "create",
+    });
+
+    await expect(harness.getStatus("CHILD", childId)).resolves.toMatchObject({
+      status: "complete",
+      output: { completed: true },
+    });
+    await expect(harness.getHistory("PARENT", parentId)).resolves.toMatchObject({
+      events: [
+        expect.objectContaining({
+          id: "remote-event-child-1:complete",
+          type: "child:complete",
+          payload: { value: 42 },
+        }),
+      ],
+    });
+
+    await harness.runUntilIdle({
+      workflowName: "remote-event-parent-workflow",
+      instanceId: parentId,
+      reason: "event",
+    });
+    await expect(harness.getStatus("PARENT", parentId)).resolves.toMatchObject({
+      status: "complete",
+      output: { value: 42 },
+    });
+  });
+
   test("supports Promise.all, Promise.race, Promise.any, and Promise.allSettled in remote steps", async () => {
     const RemotePromiseWorkflow = defineRemoteWorkflow(
       { name: "remote-promise-combinators" },

--- a/packages/fragment-workflows/src/runner/plan-writes.ts
+++ b/packages/fragment-workflows/src/runner/plan-writes.ts
@@ -4,6 +4,7 @@ import type { HandlerTxContext, HooksMap, IUnitOfWork, TypedUnitOfWork } from "@
 
 import { buildScopedInstanceRowId } from "../instance-ref";
 import { workflowsSchema } from "../schema";
+import { WORKFLOW_EVENT_ACTOR_USER } from "../system-events";
 import type {
   AnyTxResult,
   WorkflowRegistryEntry,
@@ -145,9 +146,30 @@ function applyWorkflowServiceCalls(
 
   for (const queuedCall of calls) {
     const call = validateAndNormalizeWorkflowOperation(workflowsByName, queuedCall);
+    const instanceRef = buildScopedInstanceRowId(call.workflowName, call.instanceId);
 
-    const instanceRef = schemaUow.create("workflow_instance", {
-      id: buildScopedInstanceRowId(call.workflowName, call.instanceId),
+    if (call.type === "createEvent") {
+      schemaUow.create("workflow_event", {
+        id: call.eventId,
+        instanceRef,
+        actor: WORKFLOW_EVENT_ACTOR_USER,
+        type: call.eventType,
+        payload: call.payload ?? null,
+        deliveredAt: null,
+        consumedByStepKey: null,
+      });
+
+      uow.triggerHook(namespace, "onWorkflowEnqueued", {
+        workflowName: call.workflowName,
+        instanceId: call.instanceId,
+        instanceRef,
+        reason: "event",
+      });
+      continue;
+    }
+
+    const createdInstanceRef = schemaUow.create("workflow_instance", {
+      id: instanceRef,
       workflowName: call.workflowName,
       remoteWorkflowName: call.remoteWorkflowName ?? null,
       instanceId: call.instanceId,
@@ -163,7 +185,7 @@ function applyWorkflowServiceCalls(
     uow.triggerHook(namespace, "onWorkflowEnqueued", {
       workflowName: call.workflowName,
       instanceId: call.instanceId,
-      instanceRef: String(instanceRef),
+      instanceRef: String(createdInstanceRef),
       reason: "create",
     });
   }

--- a/packages/fragment-workflows/src/scenario-runner.test.ts
+++ b/packages/fragment-workflows/src/scenario-runner.test.ts
@@ -96,6 +96,149 @@ describe("Workflows Runner (Scenario DSL)", () => {
     await runScenario(scenario);
   });
 
+  test("starts racing child workflows and joins their completion events", async () => {
+    const ChildWorkflow = defineWorkflow<
+      "scenario-racing-child",
+      { parentId: string; child: "alpha" | "beta"; value: number },
+      { child: "alpha" | "beta"; value: number }
+    >({ name: "scenario-racing-child" }, async (event, step) => {
+      await step.do("complete child", (tx) => {
+        tx.workflowServiceCalls(() => [
+          {
+            type: "createEvent",
+            workflowName: "scenario-racing-parent",
+            instanceId: event.payload.parentId,
+            eventId: `${event.instanceId}:complete`,
+            eventType: `child:${event.payload.child}:complete`,
+            payload: { child: event.payload.child, value: event.payload.value },
+          },
+        ]);
+      });
+
+      return { child: event.payload.child, value: event.payload.value };
+    });
+
+    const ParentWorkflow = defineWorkflow(
+      { name: "scenario-racing-parent" },
+      async (event, step) => {
+        await step.do("start children", (tx) => {
+          tx.workflowServiceCalls(() => [
+            {
+              type: "createInstance",
+              workflowName: "scenario-racing-child",
+              instanceId: `${event.instanceId}:alpha`,
+              params: { parentId: event.instanceId, child: "alpha", value: 21 },
+            },
+            {
+              type: "createInstance",
+              workflowName: "scenario-racing-child",
+              instanceId: `${event.instanceId}:beta`,
+              params: { parentId: event.instanceId, child: "beta", value: 34 },
+            },
+          ]);
+        });
+
+        const [alpha, beta] = await Promise.all([
+          step.waitForEvent<{ child: "alpha"; value: number }>("join alpha", {
+            type: "child:alpha:complete",
+          }),
+          step.waitForEvent<{ child: "beta"; value: number }>("join beta", {
+            type: "child:beta:complete",
+          }),
+        ]);
+
+        return { values: [alpha.payload.value, beta.payload.value] };
+      },
+    );
+
+    const workflows = { PARENT: ParentWorkflow, CHILD: ChildWorkflow };
+
+    const scenario = defineScenario<
+      typeof workflows,
+      Record<string, never>,
+      undefined,
+      Record<string, never>,
+      ["parent", "alpha", "beta"]
+    >({
+      name: "racing-child-workflows-join",
+      workflows,
+      runners: ["parent", "alpha", "beta"],
+      steps: ({ workflow, runners, concurrent }) => [
+        runners.parent.initializeAndRunUntilIdle({ workflow: "PARENT", id: "parent-1" }),
+        workflow.read({
+          read: (ctx) => ctx.state.getStatus("PARENT", "parent-1"),
+          assert: (status) => expect(status).toMatchObject({ status: "waiting" }),
+        }),
+        concurrent({
+          alpha: [
+            runners.alpha.runUntilIdle({
+              workflow: "CHILD",
+              instanceId: "parent-1:alpha",
+              reason: "create",
+            }),
+          ],
+          beta: [
+            runners.beta.runUntilIdle({
+              workflow: "CHILD",
+              instanceId: "parent-1:beta",
+              reason: "create",
+            }),
+          ],
+        }),
+        workflow.read({
+          read: async (ctx) => ({
+            alpha: await ctx.state.getStatus("CHILD", "parent-1:alpha"),
+            beta: await ctx.state.getStatus("CHILD", "parent-1:beta"),
+            events: await ctx.state.getEvents("PARENT", "parent-1"),
+          }),
+          assert: (state) => {
+            expect(state.alpha).toMatchObject({ status: "complete" });
+            expect(state.beta).toMatchObject({ status: "complete" });
+            expect(state.events).toHaveLength(2);
+          },
+        }),
+        runners.parent.runUntilIdle({
+          workflow: "PARENT",
+          instanceId: "parent-1",
+          reason: "event",
+        }),
+        runners.parent.runUntilIdle({
+          workflow: "PARENT",
+          instanceId: "parent-1",
+          reason: "event",
+        }),
+        workflow.read({
+          read: (ctx) => ctx.state.getStatus("PARENT", "parent-1"),
+          assert: (status) => {
+            expect(status).toMatchObject({
+              status: "complete",
+              output: { values: [21, 34] },
+            });
+          },
+        }),
+        workflow.read({
+          read: (ctx) => ctx.state.getEvents("PARENT", "parent-1"),
+          assert: (events) => {
+            expect(events).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  type: "child:alpha:complete",
+                  consumedByStepKey: "waitForEvent:join alpha",
+                }),
+                expect.objectContaining({
+                  type: "child:beta:complete",
+                  consumedByStepKey: "waitForEvent:join beta",
+                }),
+              ]),
+            );
+          },
+        }),
+      ],
+    });
+
+    await runScenario(scenario);
+  });
+
   test("records a completed step", async () => {
     const StepWorkflow = defineWorkflow({ name: "step-workflow" }, async (_event, step) => {
       const value = await step.do("compute", () => 42);

--- a/packages/fragment-workflows/src/workflow-operation.test.ts
+++ b/packages/fragment-workflows/src/workflow-operation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import type { WorkflowStepWorkflowOperation } from "./workflow";
+import { validateAndNormalizeWorkflowOperation } from "./workflow-operation";
+
+const workflowsByName = new Map([
+  ["local-workflow", { remote: false }],
+  ["remote-workflow-host", { remote: true }],
+]);
+
+describe("validateAndNormalizeWorkflowOperation", () => {
+  test("rejects unsupported operation types from runtime callers", () => {
+    const operation = {
+      type: "terminateInstance",
+      workflowName: "local-workflow",
+      instanceId: "instance-1",
+    } as unknown as WorkflowStepWorkflowOperation;
+
+    expect(() => validateAndNormalizeWorkflowOperation(workflowsByName, operation)).toThrow(
+      "WORKFLOW_STEP_WORKFLOW_OPERATION_UNSUPPORTED",
+    );
+  });
+
+  test("rejects events targeting a remote workflow host", () => {
+    expect(() =>
+      validateAndNormalizeWorkflowOperation(workflowsByName, {
+        type: "createEvent",
+        workflowName: "remote-workflow-host",
+        instanceId: "instance-1",
+        eventId: "event-1",
+        eventType: "approval",
+      }),
+    ).toThrow("WORKFLOW_EVENT_REMOTE_TARGET_UNSUPPORTED");
+  });
+});

--- a/packages/fragment-workflows/src/workflow-operation.ts
+++ b/packages/fragment-workflows/src/workflow-operation.ts
@@ -2,11 +2,30 @@ import type { WorkflowRegistryEntry, WorkflowStepWorkflowOperation } from "./wor
 
 export type WorkflowOperationRegistry = ReadonlyMap<string, Pick<WorkflowRegistryEntry, "remote">>;
 
+type CreateWorkflowInstanceOperation = Extract<
+  WorkflowStepWorkflowOperation,
+  { type: "createInstance" }
+>;
+type CreateWorkflowEventOperation = Extract<WorkflowStepWorkflowOperation, { type: "createEvent" }>;
+
+export function validateAndNormalizeWorkflowOperation(
+  workflowsByName: WorkflowOperationRegistry,
+  operation: CreateWorkflowInstanceOperation,
+): CreateWorkflowInstanceOperation;
+export function validateAndNormalizeWorkflowOperation(
+  workflowsByName: WorkflowOperationRegistry,
+  operation: CreateWorkflowEventOperation,
+): CreateWorkflowEventOperation;
+export function validateAndNormalizeWorkflowOperation(
+  workflowsByName: WorkflowOperationRegistry,
+  operation: WorkflowStepWorkflowOperation,
+): WorkflowStepWorkflowOperation;
 export function validateAndNormalizeWorkflowOperation(
   workflowsByName: WorkflowOperationRegistry,
   operation: WorkflowStepWorkflowOperation,
 ): WorkflowStepWorkflowOperation {
-  if (operation.type !== "createInstance") {
+  const operationType: unknown = (operation as { type?: unknown }).type;
+  if (operationType !== "createInstance" && operationType !== "createEvent") {
     throw new Error("WORKFLOW_STEP_WORKFLOW_OPERATION_UNSUPPORTED");
   }
 
@@ -14,14 +33,36 @@ export function validateAndNormalizeWorkflowOperation(
   if (!workflow) {
     throw new Error("WORKFLOW_NOT_FOUND");
   }
+  if (!operation.instanceId) {
+    throw new Error("WORKFLOW_INSTANCE_ID_REQUIRED");
+  }
+
+  if (operation.type === "createEvent") {
+    if (!operation.eventId) {
+      throw new Error("WORKFLOW_EVENT_ID_REQUIRED");
+    }
+    if (!operation.eventType) {
+      throw new Error("WORKFLOW_EVENT_TYPE_REQUIRED");
+    }
+    if (workflow.remote === true) {
+      throw new Error("WORKFLOW_EVENT_REMOTE_TARGET_UNSUPPORTED");
+    }
+
+    return {
+      type: "createEvent",
+      workflowName: operation.workflowName,
+      instanceId: operation.instanceId,
+      eventId: operation.eventId,
+      eventType: operation.eventType,
+      payload: operation.payload ?? null,
+    };
+  }
+
   if (workflow.remote === true && !operation.remoteWorkflowName) {
     throw new Error("WORKFLOW_REMOTE_NAME_REQUIRED");
   }
   if (operation.remoteWorkflowName && workflow.remote !== true) {
     throw new Error("WORKFLOW_REMOTE_HOST_INVALID");
-  }
-  if (!operation.instanceId) {
-    throw new Error("WORKFLOW_INSTANCE_ID_REQUIRED");
   }
 
   return {

--- a/packages/fragment-workflows/src/workflow.ts
+++ b/packages/fragment-workflows/src/workflow.ts
@@ -80,13 +80,23 @@ export type WorkflowStepEmission<TPayload = unknown> = {
   createdAt: Date;
 };
 
-export type WorkflowStepWorkflowOperation = {
-  type: "createInstance";
-  workflowName: string;
-  instanceId: string;
-  params: unknown;
-  remoteWorkflowName?: string | null;
-};
+export type WorkflowStepWorkflowOperation =
+  | {
+      type: "createInstance";
+      workflowName: string;
+      instanceId: string;
+      params: unknown;
+      remoteWorkflowName?: string | null;
+    }
+  | {
+      /** Atomically send an event to a non-remote workflow instance. */
+      type: "createEvent";
+      workflowName: string;
+      instanceId: string;
+      eventId: string;
+      eventType: string;
+      payload?: unknown;
+    };
 
 export type WorkflowStepConsumeTx<THooks extends HooksMap = HooksMap> = {
   serviceCalls: (factory: () => readonly AnyTxResult[]) => void;


### PR DESCRIPTION
Add a createEvent workflow service operation that atomically persists and enqueues events for local workflow instances. Support remote step hosts and concurrent child-workflow joins while rejecting unknown operation types and remote workflow targets at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow steps can now create events for local workflow instances.
  * Parent workflows can wait for and resume from events emitted by child workflows.
  * Concurrent child workflow completions and event results are supported.

* **Bug Fixes**
  * Added validation for event operations, including required identifiers and unsupported remote targets.
  * Event payloads now default to `null` when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->