### PR TITLE
fix(pi-harness): continue chats after provider errors

### DIFF
--- a/.changeset/pi-harness-provider-error-recovery.md
+++ b/.changeset/pi-harness-provider-error-recovery.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/pi-harness": patch
+---
+
+fix: keep interactive chat sessions available after terminal provider stream errors.

--- a/packages/pi-harness/src/pi/harness/workflow-agent-harness.recovery-accounting.test.ts
+++ b/packages/pi-harness/src/pi/harness/workflow-agent-harness.recovery-accounting.test.ts
@@ -256,6 +256,7 @@ const runAccountingInvocation = async (options: {
   previousEmissions?: readonly WorkflowStepEmission[];
   streamFn: ReturnType<typeof createTextStreamFn>;
   tools?: readonly AgentTool[];
+  checkpointTerminalAssistantError?: boolean;
   attempt: AccountingAttempt;
 }) => {
   const models = createModelsForStreamFn(mockModel, options.streamFn);
@@ -284,6 +285,7 @@ const runAccountingInvocation = async (options: {
     harness,
     tx: options.attempt.tx,
     runDurableStep: () => harness.prompt("hello"),
+    checkpointTerminalAssistantError: options.checkpointTerminalAssistantError,
     onTerminalOutcome: ({ operationEntries }) => {
       schedulePiOperationCompletedHook({
         tx: options.attempt.tx,
@@ -505,7 +507,7 @@ describe("workflow AgentHarness recovery accounting", () => {
     ]);
   });
 
-  test("accounts only the winning call after an uncommitted provider failure", async () => {
+  test("accounts only the winning call after a provider failure fails the default workflow step", async () => {
     const operationId = "failed-attempt-winner";
     const failedUsage = usage({ input: 500, output: 10, cacheRead: 50 });
     const successfulUsage = usage({ input: 60, output: 15, cacheRead: 5 });
@@ -538,6 +540,53 @@ describe("workflow AgentHarness recovery accounting", () => {
         payload: expect.objectContaining({
           modelCalls: [expect.objectContaining({ stopReason: "stop", usage: successfulUsage })],
           usage: successfulUsage,
+        }),
+      },
+    ]);
+  });
+
+  test("replays an explicitly checkpointed provider failure without calling the provider again", async () => {
+    const operationId = "checkpointed-provider-failure";
+    const failedUsage = usage({ input: 500, output: 10, cacheRead: 50 });
+    const firstStreamFn = vi.fn(createErrorStreamFn("provider down", failedUsage));
+    const firstAttempt = createAccountingAttempt();
+
+    const firstResult = await runAccountingInvocation({
+      operationId,
+      streamFn: firstStreamFn,
+      attempt: firstAttempt,
+      checkpointTerminalAssistantError: true,
+    });
+    expect(firstResult.value).toMatchObject({
+      stopReason: "error",
+      errorMessage: "provider down",
+    });
+    expect(firstAttempt.emitted).toContainEqual(
+      expect.objectContaining({ kind: "harness-operation-complete" }),
+    );
+
+    const replayStreamFn = vi.fn(
+      createTextStreamFn("must not run", usage({ input: 1, output: 1 })),
+    );
+    const replayAttempt = createAccountingAttempt();
+    const replayResult = await runAccountingInvocation({
+      operationId,
+      streamFn: replayStreamFn,
+      attempt: replayAttempt,
+      previousEmissions: toPreviousEmissions(firstAttempt.emitted),
+      checkpointTerminalAssistantError: true,
+    });
+    const hooks = replayAttempt.commit();
+
+    expect(firstStreamFn).toHaveBeenCalledTimes(1);
+    expect(replayStreamFn).not.toHaveBeenCalled();
+    expect(replayResult).toEqual(firstResult);
+    expect(hooks).toEqual([
+      {
+        name: "onOperationCompleted",
+        payload: expect.objectContaining({
+          modelCalls: [expect.objectContaining({ stopReason: "error", usage: failedUsage })],
+          usage: failedUsage,
         }),
       },
     ]);

--- a/packages/pi-harness/src/pi/harness/workflow-agent-harness.scenario.test.ts
+++ b/packages/pi-harness/src/pi/harness/workflow-agent-harness.scenario.test.ts
@@ -337,11 +337,11 @@ describe("workflow-backed AgentHarness state", () => {
     expect(replayStream).not.toHaveBeenCalled();
   });
 
-  test("reports and rejects a failed terminal assistant without checkpointing it", async () => {
-    const operationId = "failed-assistant:prompt";
+  test("rejects a terminal assistant error by default when the callback transforms its result", async () => {
+    const operationId = "failed-assistant-default:prompt";
     const state = createPiHarnessSessionState({
       metadata: {
-        id: "failed-assistant",
+        id: "failed-assistant-default",
         createdAt: "2026-07-01T12:00:00.000Z",
       },
     });
@@ -369,7 +369,7 @@ describe("workflow-backed AgentHarness state", () => {
         storage,
         harness,
         tx: emissions.tx,
-        runDurableStep: () => harness.prompt("hello"),
+        runDurableStep: async () => messageText(await harness.prompt("hello")),
         onTerminalOutcome: terminalOutcome,
       }),
     ).rejects.toThrow("Pi harness agent stream failed: provider down");
@@ -386,6 +386,63 @@ describe("workflow-backed AgentHarness state", () => {
       }),
     );
     expect(emissions.emitted).not.toContainEqual(
+      expect.objectContaining({ kind: "harness-operation-complete", operationId }),
+    );
+  });
+
+  test("checkpoints a failed terminal assistant when explicitly configured", async () => {
+    const operationId = "failed-assistant:prompt";
+    const state = createPiHarnessSessionState({
+      metadata: {
+        id: "failed-assistant",
+        createdAt: "2026-07-01T12:00:00.000Z",
+      },
+    });
+    const {
+      session,
+      storage,
+      options: restoredOptions,
+    } = restoreWorkflowBackedSession({
+      operationId,
+      state,
+      previousEmissions: [],
+      models: createModelsForStreamFn([mockModel, alternateModel], createTextStreamFn("unused")),
+    });
+    const harness = new AgentHarness({
+      models: createModelsForStreamFn(mockModel, createErrorStreamFn("provider down")),
+      model: mockModel,
+      ...restoredOptions,
+    });
+    const emissions = createEmissionRecorder();
+    const terminalOutcome = vi.fn();
+
+    const result = await withWorkflowAgentHarness({
+      session,
+      storage,
+      harness,
+      tx: emissions.tx,
+      runDurableStep: () => harness.prompt("hello"),
+      checkpointTerminalAssistantError: true,
+      onTerminalOutcome: terminalOutcome,
+    });
+
+    expect(result.value).toMatchObject({
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "provider down",
+    });
+    expect(terminalOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationId,
+        operationEntries: expect.arrayContaining([
+          expect.objectContaining({
+            type: "message",
+            message: expect.objectContaining({ role: "assistant", stopReason: "error" }),
+          }),
+        ]),
+      }),
+    );
+    expect(emissions.emitted).toContainEqual(
       expect.objectContaining({ kind: "harness-operation-complete", operationId }),
     );
   });

--- a/packages/pi-harness/src/pi/workflows/interactive-chat-workflow.scenario.test.ts
+++ b/packages/pi-harness/src/pi/workflows/interactive-chat-workflow.scenario.test.ts
@@ -82,12 +82,14 @@ const createTextStreamFn = (text: string) => () => {
 };
 
 const createErrorStreamFn =
-  (errorMessage: string): StreamFn =>
+  (errorMessage?: string): StreamFn =>
   () => {
     const stream = createAssistantMessageEventStream();
     const message = createAssistantMessage("");
     message.stopReason = "error";
-    message.errorMessage = errorMessage;
+    if (errorMessage !== undefined) {
+      message.errorMessage = errorMessage;
+    }
     stream.push({ type: "error", reason: "error", error: message });
     return stream;
   };
@@ -433,6 +435,148 @@ describe("Interactive chat workflow scenarios", () => {
         ],
       }),
     );
+  });
+
+  test("continues the interactive session after a provider stream error", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const streamFn = vi.fn<StreamFn>((model, context, options) => {
+      const latestMessage = context.messages.at(-1);
+      assert(latestMessage, "expected a model message");
+
+      if (modelMessageText(latestMessage) === "continue") {
+        return createTextStreamFn("continued after provider error")();
+      }
+
+      return createErrorStreamFn()(model, context, options);
+    });
+    const interactiveChatWorkflow = createInteractiveChatWorkflow({
+      name: "interactive-chat-provider-error-continuation-workflow",
+      options: {
+        model: mockModel,
+        models: createModelsForStreamFn(mockModel, streamFn),
+      },
+    });
+    const config: PiFragmentConfig = { workflows: [interactiveChatWorkflow] };
+
+    try {
+      await runScenario(
+        defineScenario({
+          name: "pi-harness-interactive-chat-provider-error-continuation",
+          workflows: createPiWorkflows({ workflows: config.workflows }),
+          vars: () => ({ sessionId: undefined as string | undefined }),
+          harness: {
+            configureFragments: (harness) => ({
+              pi: instantiate(piHarnessDefinition)
+                .withConfig(config)
+                .withRoutes([piRoutesFactory])
+                .withServices({ workflows: harness.fragment.services }),
+            }),
+          },
+          clients: ({ clientConfig }) => ({
+            user: createPiFragmentClients(clientConfig("pi", { runner: "user" })),
+          }),
+          runners: ["agent", "user"],
+          steps: ({ workflow, runners, clients }) => [
+            workflow.read({
+              read: async () => {
+                const session = await clients.user.useCreateSession.mutateQuery({
+                  path: { workflowName: interactiveChatWorkflow.name },
+                  body: { name: "Provider error continuation", input: {} },
+                });
+                assert(session && !Array.isArray(session), "expected session response");
+                return session.id;
+              },
+              storeAs: "sessionId",
+            }),
+            runners.agent.runUntilIdle({
+              workflow: interactiveChatWorkflow.name,
+              instanceId: (ctx) => ctx.vars.sessionId!,
+              reason: "create",
+            }),
+            workflow.read({
+              read: async (ctx) =>
+                clients.user.useCommandSession.mutateQuery({
+                  path: {
+                    workflowName: interactiveChatWorkflow.name,
+                    sessionId: ctx.vars.sessionId!,
+                  },
+                  body: { kind: "prompt", input: { text: "fail" } },
+                }),
+            }),
+            runners.agent.runUntilIdle({
+              workflow: interactiveChatWorkflow.name,
+              instanceId: (ctx) => ctx.vars.sessionId!,
+              reason: "event",
+            }),
+            workflow.read({
+              read: async (ctx) =>
+                clients.user.useCommandSession.mutateQuery({
+                  path: {
+                    workflowName: interactiveChatWorkflow.name,
+                    sessionId: ctx.vars.sessionId!,
+                  },
+                  body: { kind: "prompt", input: { text: "continue" } },
+                }),
+              assert: (ack) => {
+                assert(ack && !Array.isArray(ack), "expected command acknowledgement");
+                assert(ack.accepted);
+              },
+            }),
+            runners.agent.runUntilIdle({
+              workflow: interactiveChatWorkflow.name,
+              instanceId: (ctx) => ctx.vars.sessionId!,
+              reason: "event",
+            }),
+            workflow.read({
+              read: async (ctx) => ({
+                status: await ctx.state.getStatus(
+                  interactiveChatWorkflow.name,
+                  ctx.vars.sessionId!,
+                ),
+                detail: await clients.user.useSessionDetail.query({
+                  path: {
+                    workflowName: interactiveChatWorkflow.name,
+                    sessionId: ctx.vars.sessionId!,
+                  },
+                }),
+              }),
+              assert: ({ status, detail }) => {
+                assert(status.status === "waiting");
+                expect(streamFn).toHaveBeenCalledTimes(2);
+                expect(consoleError).toHaveBeenCalledTimes(1);
+                expect(consoleError).toHaveBeenCalledWith(
+                  "Pi interactive chat model operation failed.",
+                  expect.objectContaining({
+                    workflowName: interactiveChatWorkflow.name,
+                    commandKind: "prompt",
+                    provider: "openai",
+                    model: "test-model",
+                  }),
+                );
+                expect(consoleError.mock.calls[0]?.[1]).not.toHaveProperty("errorMessage");
+                assert(detail && !Array.isArray(detail), "expected session detail response");
+                expect(detail.agent.state.messages).toMatchObject([
+                  { role: "user", content: [{ type: "text", text: "fail" }] },
+                  {
+                    role: "assistant",
+                    stopReason: "error",
+                  },
+                  { role: "user", content: [{ type: "text", text: "continue" }] },
+                  {
+                    role: "assistant",
+                    stopReason: "stop",
+                    content: [{ type: "text", text: "continued after provider error" }],
+                  },
+                ]);
+                expect(detail.agent.state.messages[1]).not.toHaveProperty("errorMessage");
+              },
+            }),
+          ],
+        }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   test("keeps the session alive when there is nothing to compact", async () => {
@@ -4239,9 +4383,11 @@ describe("Interactive chat workflow scenarios", () => {
             }),
             assert: ({ status, detail }) => {
               assert(detail && !Array.isArray(detail), "expected session detail response");
-              expect(status).toMatchObject({
-                status: "errored",
-                error: { message: "Pi harness agent stream failed: provider failed" },
+              assert(status.status === "waiting");
+              expect(detail.agent.state.messages.at(-1)).toMatchObject({
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "provider failed",
               });
               expect(onOperationCompleted).toHaveBeenCalledTimes(2);
               expect(onOperationCompleted).toHaveBeenLastCalledWith(

--- a/packages/pi-harness/src/pi/workflows/interactive-chat-workflow.ts
+++ b/packages/pi-harness/src/pi/workflows/interactive-chat-workflow.ts
@@ -11,6 +11,7 @@ import {
   type AgentMessage,
   type ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 
 import { schedulePiOperationCompletedHook } from "../harness/pi-operation-completed";
 import { agentMessageSchema, piSessionCommandPayloadSchema } from "../route-schemas";
@@ -50,6 +51,27 @@ export const interactiveChatWorkflowParamsSchema: z.ZodType<InteractiveChatWorkf
     systemPrompt: z.string().optional(),
     thinkingLevel: z.enum(["off", "minimal", "low", "medium", "high", "xhigh", "max"]).optional(),
   });
+
+const logInteractiveChatAssistantError = (
+  assistant: AssistantMessage,
+  context: {
+    workflowName: string;
+    sessionId: string;
+    commandId: string;
+    commandKind: "prompt" | "skill" | "promptFromTemplate";
+  },
+): void => {
+  if (assistant.stopReason !== "error") {
+    return;
+  }
+
+  console.error("Pi interactive chat model operation failed.", {
+    ...context,
+    provider: assistant.provider,
+    model: assistant.model,
+    ...(assistant.errorMessage !== undefined ? { errorMessage: assistant.errorMessage } : {}),
+  });
+};
 
 export type CreateInteractiveChatWorkflowOptions = {
   name?: string;
@@ -168,25 +190,50 @@ export const createInteractiveChatWorkflow = (config: CreateInteractiveChatWorkf
                 }
               });
             },
+            checkpointTerminalAssistantError: true,
             runDurableStep: async () => {
               tx.emit({
                 kind: "pi-session-command-start",
                 command: { commandId: command.commandId, kind: command.kind },
               } satisfies PiSessionCommandStartEmission);
 
+              const logAssistantError = (
+                commandKind: "prompt" | "skill" | "promptFromTemplate",
+                assistant: AssistantMessage,
+              ) => {
+                logInteractiveChatAssistantError(assistant, {
+                  workflowName,
+                  sessionId: event.instanceId,
+                  commandId: command.commandId,
+                  commandKind,
+                });
+              };
+
               switch (command.kind) {
-                case "prompt":
-                  return await harness.prompt(
+                case "prompt": {
+                  const assistant = await harness.prompt(
                     command.input.text,
                     command.input.images ? { images: command.input.images } : undefined,
                   );
-                case "skill":
-                  return await harness.skill(
+                  logAssistantError("prompt", assistant);
+                  return assistant;
+                }
+                case "skill": {
+                  const assistant = await harness.skill(
                     command.input.name,
                     command.input.additionalInstructions,
                   );
-                case "promptFromTemplate":
-                  return await harness.promptFromTemplate(command.input.name, command.input.args);
+                  logAssistantError("skill", assistant);
+                  return assistant;
+                }
+                case "promptFromTemplate": {
+                  const assistant = await harness.promptFromTemplate(
+                    command.input.name,
+                    command.input.args,
+                  );
+                  logAssistantError("promptFromTemplate", assistant);
+                  return assistant;
+                }
                 case "compact": {
                   const preparationResult = prepareCompaction(
                     await session.getBranch(),

--- a/packages/pi-harness/src/pi/workflows/workflow-agent-harness.ts
+++ b/packages/pi-harness/src/pi/workflows/workflow-agent-harness.ts
@@ -495,6 +495,8 @@ export type WithWorkflowAgentHarnessOptions<TResult = unknown> = {
   /** Configure observation of workflow events delivered live while the durable step is running. */
   observeLiveEvents?: (onLiveEvent: WorkflowAgentHarnessOnLiveEvent) => void;
   runDurableStep: () => Promise<TResult>;
+  /** Persist terminal provider errors as completed operations instead of failing the workflow step. */
+  checkpointTerminalAssistantError?: boolean;
   /** May run more than once before the enclosing workflow step commits. */
   onTerminalOutcome?: (
     outcome: WorkflowAgentHarnessTerminalOutcome<TResult>,
@@ -557,6 +559,7 @@ export const withWorkflowAgentHarness = async <TResult>({
   tx,
   observeLiveEvents,
   runDurableStep,
+  checkpointTerminalAssistantError = false,
   onTerminalOutcome,
 }: WithWorkflowAgentHarnessOptions<TResult>): Promise<WorkflowAgentHarnessStepResult<TResult>> => {
   const { operationId, persistedEntryIds, recovery } = storage.workflowMetadata;
@@ -568,6 +571,9 @@ export const withWorkflowAgentHarness = async <TResult>({
       operationEntries: recovery.operationEntries,
       result,
     });
+    if (!checkpointTerminalAssistantError) {
+      assertTerminalAssistantSucceeded(recovery.operationEntries);
+    }
     return result;
   }
 
@@ -676,7 +682,10 @@ export const withWorkflowAgentHarness = async <TResult>({
       operationEntries,
       result,
     });
-    assertTerminalAssistantSucceeded(operationEntries);
+
+    if (!checkpointTerminalAssistantError) {
+      assertTerminalAssistantSucceeded(operationEntries);
+    }
 
     tx.emit({
       kind: "harness-operation-complete",


### PR DESCRIPTION
Allow interactive chat workflows to checkpoint terminal assistant errors so
a provider failure does not permanently error the session. Preserve
fail-fast behavior for custom workflow harnesses unless they opt in, log
provider error context, and cover execution, replay, accounting, and
continuation behavior.

Fixes #435.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interactive chat sessions now remain available after terminal provider stream errors.
  - Provider errors are persisted and replayed without triggering duplicate provider calls.
  - Sessions can accept subsequent prompts after recovering from a provider failure.
  - Workflow status correctly returns to waiting with an assistant error message instead of being marked as failed.
  - Assistant errors from prompt, skill, and template commands are now logged with relevant details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->