### PR TITLE
wilco/bo various 2

### DIFF
--- a/.changeset/pi-operation-authorization.md
+++ b/.changeset/pi-operation-authorization.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/pi-harness": patch
+---
+
+feat: add a pre-operation lifecycle callback to interactive chat workflows.

--- a/apps/backoffice/app/backoffice-runtime/authority-roles.test.ts
+++ b/apps/backoffice/app/backoffice-runtime/authority-roles.test.ts
@@ -153,9 +153,19 @@ describe("Backoffice authority role grants", () => {
       "system-administrator",
     ],
     [
-      { userId: "admin-1", role: "admin" as const, organizationIds: [] },
+      { userId: "admin-1", role: "admin" as const, organizationIds: ["org-1"] },
       { kind: "org" as const, orgId: "org-1" },
       "system-administrator",
+    ],
+    [
+      { userId: "admin-1", role: "admin" as const, organizationIds: [] },
+      { kind: "org" as const, orgId: "org-1" },
+      null,
+    ],
+    [
+      { userId: "admin-1", role: "admin" as const, organizationIds: ["org-1"] },
+      { kind: "project" as const, orgId: "org-2", projectId: "project-1" },
+      null,
     ],
     [
       { userId: "admin-1", role: "admin" as const, organizationIds: [] },

--- a/apps/backoffice/app/backoffice-runtime/authority-roles.ts
+++ b/apps/backoffice/app/backoffice-runtime/authority-roles.ts
@@ -145,7 +145,6 @@ export const resolveBackofficeUserAuthorityRole = (
   }>,
   scope: BackofficeContextScope,
 ): BackofficeUserAuthorityRole | null => {
-  // A system administrator may administer shared scopes, but not another user's private scope.
   if (scope.kind === "user") {
     if (scope.userId !== authority.userId) {
       return null;
@@ -154,15 +153,15 @@ export const resolveBackofficeUserAuthorityRole = (
     return authority.role === "admin" ? "system-administrator" : "user-owner";
   }
 
-  if (authority.role === "admin") {
-    return "system-administrator";
+  if (scope.kind === "system") {
+    return authority.role === "admin" ? "system-administrator" : null;
   }
 
-  if (scope.kind === "system") {
+  if (!authority.organizationIds.includes(scope.orgId)) {
     return null;
   }
 
-  return authority.organizationIds.includes(scope.orgId) ? "organization-member" : null;
+  return authority.role === "admin" ? "system-administrator" : "organization-member";
 };
 
 export const resolveBackofficeInternalServiceAuthorityRole = ({

--- a/apps/backoffice/app/backoffice-runtime/object-registry.ts
+++ b/apps/backoffice/app/backoffice-runtime/object-registry.ts
@@ -46,6 +46,8 @@ import type {
 import type {
   BillingEventInput,
   BillingRecordEventResult,
+  BillingStatement,
+  BillingStatementInput,
   BillingTrackerPage,
   BillingTrackerPageInput,
 } from "@/fragno/billing";
@@ -162,6 +164,7 @@ export type BillingObject = FetchObject &
       input: BillingEventInput,
       context?: BackofficeRpcContext,
     ): Promise<BillingRecordEventResult>;
+    getStatement(input: BillingStatementInput): Promise<BillingStatement>;
     getTrackers(input: BillingTrackerPageInput): Promise<BillingTrackerPage>;
   };
 

--- a/apps/backoffice/app/fragno/automation/automations.ts
+++ b/apps/backoffice/app/fragno/automation/automations.ts
@@ -3,6 +3,7 @@ import {
   type DurableHooksDispatcherDurableObjectHandler,
 } from "@fragno-dev/db/dispatchers/cloudflare-do";
 import type { DurableHooksInstrumentation } from "@fragno-dev/db/hooks";
+import type { PiSessionMetadata } from "@fragno-dev/pi-harness/types";
 
 import { defaultFragnoRuntime } from "@fragno-dev/core";
 import { createWorkflowsFragment } from "@fragno-dev/workflows";
@@ -25,6 +26,7 @@ import {
   type PiFragment,
   type PiRuntimeToolContext,
 } from "@/fragno/pi/pi";
+import { piSessionBillingOrganizationId } from "@/fragno/pi/pi-shared";
 import {
   createPiFragmentRuntime,
   type PiRuntime,
@@ -128,10 +130,15 @@ export const createAutomationsRuntime = (
   > & {
     kernel: BackofficeKernel;
     pi: Omit<CreatePiRuntimeDefinitionOptions, "scope" | "kernel" | "runtimeToolContext"> & {
-      createRuntime?(execution: BackofficeExecutionContext, fragment: PiFragment): PiRuntime;
+      createRuntime?(
+        execution: BackofficeExecutionContext,
+        fragment: PiFragment,
+        inheritedBillingOrganizationId?: string,
+      ): PiRuntime;
       createRuntimeToolContext(
         execution: BackofficeExecutionContext,
         pi: PiRuntime,
+        metadata: PiSessionMetadata | null,
       ): PiRuntimeToolContext;
     };
   },
@@ -141,20 +148,35 @@ export const createAutomationsRuntime = (
   });
   let automationFragment: AutomationFragmentWithExecutionContext | undefined;
   let piFragment: PiFragment | undefined;
-  const createHostedPiRuntime = (execution: BackofficeExecutionContext): PiRuntime => {
+  const createHostedPiRuntime = (
+    execution: BackofficeExecutionContext,
+    parentSessionMetadata: PiSessionMetadata | null = null,
+  ): PiRuntime => {
     if (!piFragment) {
       throw new Error("Pi fragment is not ready.");
     }
+
+    const inheritedBillingOrganizationId =
+      piSessionBillingOrganizationId(parentSessionMetadata) ?? undefined;
+
     return config.pi.createRuntime
-      ? config.pi.createRuntime(execution, piFragment)
-      : createPiFragmentRuntime({ fragment: piFragment, execution });
+      ? config.pi.createRuntime(execution, piFragment, inheritedBillingOrganizationId)
+      : createPiFragmentRuntime({
+          fragment: piFragment,
+          execution,
+          inheritedBillingOrganizationId,
+        });
   };
   const pi = createPiRuntimeDefinition({
     ...config.pi,
     scope: config.ownerScope,
     kernel: config.kernel,
-    runtimeToolContext: (execution) => {
-      return config.pi.createRuntimeToolContext(execution, createHostedPiRuntime(execution));
+    runtimeToolContext: (execution, metadata) => {
+      return config.pi.createRuntimeToolContext(
+        execution,
+        createHostedPiRuntime(execution, metadata),
+        metadata,
+      );
     },
   });
   const workflowsFragment = createWorkflowsFragment<BackofficeExecutionContext>(

--- a/apps/backoffice/app/fragno/automation/scenario-auth-authority.test.ts
+++ b/apps/backoffice/app/fragno/automation/scenario-auth-authority.test.ts
@@ -124,7 +124,7 @@ describe("scenario auth authority fixtures", () => {
           then.auth.permissions({
             userId: "member-1",
             scope: { kind: "org", orgId: "org-1" },
-            include: [
+            exclude: [
               BACKOFFICE_PERMISSION.connections.read,
               BACKOFFICE_PERMISSION.internal.manage,
               BACKOFFICE_PERMISSION.pi.read,

--- a/apps/backoffice/app/fragno/automation/scenario-authority-modes.test.ts
+++ b/apps/backoffice/app/fragno/automation/scenario-authority-modes.test.ts
@@ -223,7 +223,7 @@ describe("automation route authority modes", () => {
             name: "Ada Labs",
             ownerUserId: "owner-1",
           }),
-          given.pi.configured({ orgId: "org-1" }),
+          given.pi.configured({ scope: { kind: "org", orgId: "org-1" } }),
           given.direct.file({
             orgId: "org-1",
             path: "/workspace/automations/authority-mode-pi-session.workflow.js",

--- a/apps/backoffice/app/fragno/automation/scenario-pi-billing.test.ts
+++ b/apps/backoffice/app/fragno/automation/scenario-pi-billing.test.ts
@@ -1,0 +1,220 @@
+import { describe, test, vi } from "vitest";
+
+import type { PiOperationCompletedHookPayload } from "@fragno-dev/pi-harness/types";
+
+import { PI_BILLING_ORGANIZATION_ID_METADATA_KEY } from "@/fragno/pi/pi-shared";
+
+const { DurableObject, RpcTarget, WorkerEntrypoint } = vi.hoisted(() => ({
+  DurableObject: class MockDurableObject {
+    constructor(_state: unknown, _env: unknown) {}
+  },
+  RpcTarget: class MockRpcTarget {},
+  WorkerEntrypoint: class MockWorkerEntrypoint {},
+}));
+
+vi.mock("cloudflare:workers", () => ({ DurableObject, RpcTarget, WorkerEntrypoint }));
+
+import { defineBackofficeScenario, runBackofficeScenario } from "./scenario";
+
+const operationPayload = (
+  sessionId: string,
+  metadata: Record<string, unknown> = {},
+): PiOperationCompletedHookPayload => ({
+  actor: { userId: "user-1" },
+  workflowName: "interactive-chat-workflow",
+  sessionId,
+  metadata: {
+    model: { provider: "openai", name: "gpt-5.6-luna" },
+    ...metadata,
+  },
+  stepName: "command:command-1",
+  operationId: `interactive-chat-workflow:${sessionId}:command:command-1`,
+  operation: "prompt",
+  modelCalls: [
+    {
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      usage: {
+        input: 80,
+        output: 20,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 100,
+        cost: {
+          input: 0.00008,
+          output: 0.00002,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0.0001,
+        },
+      },
+      stopReason: "stop",
+      timestamp: Date.parse("2026-08-17T10:00:00.000Z"),
+    },
+  ],
+  usage: {
+    input: 80,
+    output: 20,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 100,
+    cost: {
+      input: 0.00008,
+      output: 0.00002,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0.0001,
+    },
+  },
+});
+
+type RevokedMembershipScenarioVars = {
+  sessionId?: string;
+};
+
+describe("scenario Pi billing", () => {
+  test("terminally errors a user workflow when billing organization membership is revoked", async () => {
+    await runBackofficeScenario(
+      defineBackofficeScenario<RevokedMembershipScenarioVars>({
+        name: "Pi user session reauthorizes its billing organization before model execution",
+        vars: () => ({}),
+        options: { allowErroredWorkflows: true },
+        setup: ({ given }) => [
+          given.auth.user({ id: "owner", role: "admin" }),
+          given.auth.user({ id: "member", role: "user" }),
+          given.auth.organization({
+            id: "org-1",
+            name: "Pi Billing Org",
+            ownerUserId: "owner",
+            ownerRoles: ["owner"],
+          }),
+          given.auth.member({ orgId: "org-1", userId: "member", roles: ["member"] }),
+          given.pi.configured({ scope: { kind: "user", userId: "member" } }),
+        ],
+        steps: ({ when, then }) => [
+          when.pi.createSession({
+            scope: { kind: "user", userId: "member" },
+            userId: "member",
+            billingOrganizationId: "org-1",
+            captureSessionIdAs: "sessionId",
+          }),
+          then.pi.session({
+            scope: { kind: "user", userId: "member" },
+            userId: "member",
+            sessionId: (ctx) => ctx.vars.sessionId!,
+            workflow: { status: "waiting" },
+          }),
+          when.auth.removeMember({ orgId: "org-1", userId: "member" }),
+          when.pi.promptSession({
+            scope: { kind: "user", userId: "member" },
+            userId: "member",
+            sessionId: (ctx) => ctx.vars.sessionId!,
+            text: "run",
+          }),
+          then.pi.session({
+            scope: { kind: "user", userId: "member" },
+            userId: "member",
+            sessionId: (ctx) => ctx.vars.sessionId!,
+            workflow: {
+              status: "errored",
+              error: { name: "PiSessionBillingOrganizationAccessDeniedError" },
+            },
+          }),
+        ],
+      }),
+    );
+  });
+
+  test("routes Pi operation usage to the organization that owns the scope", async () => {
+    await runBackofficeScenario(
+      defineBackofficeScenario({
+        name: "Pi operation billing follows scope ownership",
+        setup: ({ given }) => [
+          given.auth.user({ id: "user-1", email: "user@example.com" }),
+          given.auth.organization({
+            id: "org-1",
+            name: "Ada Labs",
+            ownerUserId: "user-1",
+            ownerRoles: ["owner"],
+          }),
+        ],
+        steps: ({ when, then }) => [
+          when.pi.operationCompleted({
+            scope: { kind: "org", orgId: "org-1" },
+            payload: operationPayload("org-session"),
+            hookId: "org-hook",
+            idempotencyKey: "billing:org-hook",
+          }),
+          then.pi.operationBilling({
+            hookId: "org-hook",
+            recorded: true,
+            billingOrganizationId: "org-1",
+          }),
+          then.billing.tracker({
+            organizationId: "org-1",
+            scope: { kind: "org", orgId: "org-1" },
+            period: "2026-08",
+            meter: "ai.tokens.total",
+            quantity: "100",
+            eventCount: "1",
+          }),
+
+          when.pi.operationCompleted({
+            scope: { kind: "project", orgId: "org-1", projectId: "project-1" },
+            payload: operationPayload("project-session"),
+            hookId: "project-hook",
+            idempotencyKey: "billing:project-hook",
+          }),
+          then.pi.operationBilling({
+            hookId: "project-hook",
+            recorded: true,
+            billingOrganizationId: "org-1",
+          }),
+          then.billing.tracker({
+            organizationId: "org-1",
+            scope: { kind: "project", orgId: "org-1", projectId: "project-1" },
+            period: "2026-08",
+            meter: "ai.tokens.total",
+            quantity: "100",
+            eventCount: "1",
+          }),
+
+          when.pi.operationCompleted({
+            scope: { kind: "user", userId: "user-1" },
+            payload: operationPayload("user-session", {
+              [PI_BILLING_ORGANIZATION_ID_METADATA_KEY]: "org-1",
+            }),
+            hookId: "user-hook",
+            idempotencyKey: "billing:user-hook",
+          }),
+          then.pi.operationBilling({
+            hookId: "user-hook",
+            recorded: true,
+            billingOrganizationId: "org-1",
+          }),
+          then.billing.tracker({
+            organizationId: "org-1",
+            scope: { kind: "user", userId: "user-1" },
+            period: "2026-08",
+            meter: "ai.tokens.total",
+            quantity: "100",
+            eventCount: "1",
+          }),
+
+          when.pi.operationCompleted({
+            scope: { kind: "system" },
+            payload: operationPayload("system-session"),
+            hookId: "system-hook",
+            idempotencyKey: "billing:system-hook",
+          }),
+          then.pi.operationBilling({
+            hookId: "system-hook",
+            recorded: false,
+            billingOrganizationId: null,
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/apps/backoffice/app/fragno/automation/scenario-pi-boundary.test.ts
+++ b/apps/backoffice/app/fragno/automation/scenario-pi-boundary.test.ts
@@ -242,7 +242,7 @@ describe("scenario Pi boundary", () => {
             userId: "attacker",
             roles: ["member"],
           }),
-          given.pi.configured({ orgId: "org-1" }),
+          given.pi.configured({ scope: { kind: "org", orgId: "org-1" } }),
         ],
         steps: ({ then }) => [
           then.assert("caller-authored actors are overwritten", async (ctx) => {
@@ -326,11 +326,12 @@ describe("scenario Pi boundary", () => {
             ownerUserId: "user-1",
             ownerRoles: ["owner"],
           }),
-          given.pi.configured({ orgId: "org-1" }),
+          given.pi.configured({ scope: { kind: "org", orgId: "org-1" } }),
         ],
         steps: ({ when, then, runner }) => [
           when.pi.createSession({
-            orgId: "org-1",
+            scope: { kind: "org", orgId: "org-1" },
+            userId: "user-1",
             captureSessionIdAs: "sessionId",
           }),
           then.assert("the Pi codemode tool schedules the durable workflow", async (ctx) => {
@@ -437,7 +438,7 @@ describe("scenario Pi boundary", () => {
             ownerUserId: "user-1",
             ownerRoles: ["owner"],
           }),
-          given.pi.configured({ orgId: "org-1" }),
+          given.pi.configured({ scope: { kind: "org", orgId: "org-1" } }),
         ],
         steps: ({ when, then }) => [
           then.assert("configure the database-backed workspace", async (ctx) => {
@@ -446,7 +447,8 @@ describe("scenario Pi boundary", () => {
               .setAdminConfig({ provider: "database" }, "org-1");
           }),
           when.pi.createSession({
-            orgId: "org-1",
+            scope: { kind: "org", orgId: "org-1" },
+            userId: "user-1",
             captureSessionIdAs: "sessionId",
           }),
           then.assert(
@@ -527,7 +529,7 @@ describe("scenario Pi boundary", () => {
             ownerRoles: ["owner"],
           }),
           given.auth.member({ orgId: "org-1", userId: "member", roles: ["member"] }),
-          given.pi.configured({ orgId: "org-1" }),
+          given.pi.configured({ scope: { kind: "org", orgId: "org-1" } }),
         ],
         steps: ({ when, then }) => [
           then.assert("configure the database-backed workspace", async (ctx) => {
@@ -612,7 +614,7 @@ describe("scenario Pi boundary", () => {
             ownerUserId: "creator",
             ownerRoles: ["owner"],
           }),
-          given.pi.configured({ orgId: "org-1" }),
+          given.pi.configured({ scope: { kind: "org", orgId: "org-1" } }),
         ],
         steps: ({ when, then }) => [
           then.assert("capture a durable actor envelope from the running session", async (ctx) => {

--- a/apps/backoffice/app/fragno/automation/scenario-pi-boundary.test.ts
+++ b/apps/backoffice/app/fragno/automation/scenario-pi-boundary.test.ts
@@ -237,6 +237,11 @@ describe("scenario Pi boundary", () => {
             ownerUserId: "owner",
             ownerRoles: ["owner"],
           }),
+          given.auth.member({
+            orgId: "org-1",
+            userId: "attacker",
+            roles: ["member"],
+          }),
           given.pi.configured({ orgId: "org-1" }),
         ],
         steps: ({ then }) => [

--- a/apps/backoffice/app/fragno/automation/scenario.ts
+++ b/apps/backoffice/app/fragno/automation/scenario.ts
@@ -1,3 +1,7 @@
+import type {
+  PiOperationCompletedHookPayload,
+  PiSessionDetail,
+} from "@fragno-dev/pi-harness/types";
 import { workflowsSchema } from "@fragno-dev/workflows/schema";
 
 import type { UserAuthorityFacts } from "@fragno-dev/auth";
@@ -49,13 +53,18 @@ import {
   createAutomationCollections,
   type AutomationCollections,
 } from "@/fragno/automation/tanstack/collections";
+import { recordPiOperationBilling } from "@/fragno/billing/pi";
 import {
   runBackofficeCodemode,
   type BackofficeCodemodeExecuteResult,
 } from "@/fragno/codemode/execute";
 import type { MarketplaceStaticEntry } from "@/fragno/marketplace/contracts";
 import { marketplaceListingId } from "@/fragno/marketplace/owner";
-import { BACKOFFICE_PI_WORKFLOW_NAME, type PiModel } from "@/fragno/pi/pi-shared";
+import {
+  BACKOFFICE_PI_WORKFLOW_NAME,
+  PI_BILLING_ORGANIZATION_ID_METADATA_KEY,
+  type PiModel,
+} from "@/fragno/pi/pi-shared";
 import { createPiCollections, type PiCollections } from "@/fragno/pi/tanstack/collections";
 import { createPiRouteRuntime } from "@/fragno/runtime-tools/families/pi-runtime";
 import type { TelegramAutomationFileMetadata } from "@/fragno/runtime-tools/families/telegram-runtime";
@@ -453,6 +462,30 @@ type PiRanTurnInput = {
   assistantText?: string | RegExp;
 };
 
+type PiOperationCompletedInput = {
+  scope: BackofficeContextScope;
+  payload: PiOperationCompletedHookPayload;
+  hookId: string;
+  idempotencyKey: string;
+};
+
+type PiOperationBillingAssertionInput = {
+  hookId: string;
+  recorded: boolean;
+  billingOrganizationId: string | null;
+};
+
+type BillingTrackerAssertionInput = {
+  organizationId: string;
+  scope: BackofficeContextScope;
+  period: string;
+  meter: string;
+  quantity: string;
+  eventCount?: string;
+};
+
+const piOperationBillingVarKey = (hookId: string) => `pi-operation-billing:${hookId}`;
+
 type ResendRepliedToThreadInput = {
   threadId?: string;
   body?: string | RegExp;
@@ -506,15 +539,33 @@ type PiDefaultAgentInput = {
 };
 
 type PiConfiguredInput = {
-  orgId: string;
+  scope: BackofficeContextScope;
 };
 
 type PiCreateStoredSessionInput = {
-  orgId: string;
+  scope: BackofficeContextScope;
+  userId: string;
+  billingOrganizationId?: string;
   workflowName?: string;
   model?: PiModel;
   name?: string;
   captureSessionIdAs?: string;
+};
+
+type PiPromptStoredSessionInput<TVars extends ScenarioVars = ScenarioVars> = {
+  scope: BackofficeContextScope;
+  userId: string;
+  sessionId: ScenarioValue<TVars, string>;
+  text: string;
+  workflowName?: string;
+};
+
+type PiStoredSessionAssertionInput<TVars extends ScenarioVars = ScenarioVars> = {
+  scope: BackofficeContextScope;
+  userId: string;
+  sessionId: ScenarioValue<TVars, string>;
+  workflowName?: string;
+  workflow: DeepPartial<PiSessionDetail["workflow"]>;
 };
 
 type ConnectionConfiguredInput = {
@@ -786,6 +837,8 @@ export type BackofficeScenarioStepBuilders<TVars extends ScenarioVars = Scenario
     };
     pi: {
       createSession(input: PiCreateStoredSessionInput): BackofficeScenarioStep;
+      promptSession(input: PiPromptStoredSessionInput<TVars>): BackofficeScenarioStep;
+      operationCompleted(input: PiOperationCompletedInput): BackofficeScenarioStep;
     };
     router: {
       seedStarter(input: RouterSeedStarterInput): BackofficeScenarioStep;
@@ -839,6 +892,11 @@ export type BackofficeScenarioStepBuilders<TVars extends ScenarioVars = Scenario
     pi: {
       createdSession(input: PiCreatedSessionInput): BackofficeScenarioStep;
       ranTurn(input: PiRanTurnInput): BackofficeScenarioStep;
+      session(input: PiStoredSessionAssertionInput<TVars>): BackofficeScenarioStep;
+      operationBilling(input: PiOperationBillingAssertionInput): BackofficeScenarioStep;
+    };
+    billing: {
+      tracker(input: BillingTrackerAssertionInput): BackofficeScenarioStep;
     };
     resend: {
       queuedEmail(input: ResendQueuedEmailInput): BackofficeScenarioStep;
@@ -1568,6 +1626,24 @@ const createStep = (
   label,
   drain: options.drain ?? kind === "when",
   run,
+});
+
+const createScenarioPiRouteUrl = (scope: BackofficeContextScope, pathname: string) => {
+  const url = new URL(`http://scenario.local${pathname}`);
+  appendBackofficeScopeQuery(url, scope);
+  return url;
+};
+
+const getScenarioPiRouteTarget = (
+  ctx: BackofficeScenarioContext,
+  scope: BackofficeContextScope,
+  userId: string,
+) => ({
+  object: ctx.runtime.objects.automations.for(scope),
+  context: {
+    execution: createBackofficeUserExecution({ scope, userId }),
+    propagationContext: null,
+  } satisfies BackofficeActionRpcContext,
 });
 
 const getStore = (ctx: BackofficeScenarioContext, orgId: string) => {
@@ -2316,13 +2392,15 @@ const buildStepBuilders = <
         createStep(
           "given",
           "pi.configured",
-          `configure persisted Pi runtime for ${input.orgId}`,
+          `configure persisted Pi runtime for ${backofficeContextScopeRoutePath(input.scope)}`,
           async (ctx) => {
             if (ctx.fakes.pi) {
               throw new Error("Persisted Pi scenarios cannot use fake.pi().");
             }
-            ctx.rememberOrg(input.orgId);
-            await ctx.runtime.objects.automations.forOrg(input.orgId).getPiRuntimeState();
+            if (input.scope.kind === "org" || input.scope.kind === "project") {
+              ctx.rememberOrg(input.scope.orgId);
+            }
+            await ctx.runtime.objects.automations.for(input.scope).getPiRuntimeState();
           },
         ),
       defaultAgent: (input) =>
@@ -2625,37 +2703,42 @@ const buildStepBuilders = <
         createStep(
           "when",
           "pi.createSession",
-          `create persisted Pi session for ${input.orgId}`,
+          `create persisted Pi session for ${backofficeContextScopeRoutePath(input.scope)}`,
           async (ctx) => {
             if (ctx.fakes.pi) {
               throw new Error("Persisted Pi scenarios cannot use fake.pi().");
             }
-            ctx.rememberOrg(input.orgId);
-            const scope = { kind: "org" as const, orgId: input.orgId };
+            if (input.scope.kind === "org" || input.scope.kind === "project") {
+              ctx.rememberOrg(input.scope.orgId);
+            }
+
             const workflowName = input.workflowName ?? BACKOFFICE_PI_WORKFLOW_NAME;
-            const url = new URL(
-              `http://scenario.local/api/pi/workflows/${encodeURIComponent(workflowName)}/sessions`,
-            );
-            appendBackofficeScopeQuery(url, scope);
-            const response = await ctx.runtime.objects.automations
-              .forOrg(input.orgId)
-              .fetchWithContext(
-                new Request(url, {
+            const { object, context } = getScenarioPiRouteTarget(ctx, input.scope, input.userId);
+            const response = await object.fetchWithContext(
+              new Request(
+                createScenarioPiRouteUrl(
+                  input.scope,
+                  `/api/pi/workflows/${encodeURIComponent(workflowName)}/sessions`,
+                ),
+                {
                   method: "POST",
                   headers: { "content-type": "application/json" },
                   body: JSON.stringify({
                     name: input.name,
                     metadata: {
+                      ...(input.billingOrganizationId
+                        ? {
+                            [PI_BILLING_ORGANIZATION_ID_METADATA_KEY]: input.billingOrganizationId,
+                          }
+                        : {}),
                       model: input.model ?? { provider: "openai", name: "gpt-5.6-luna" },
                     },
                     input: {},
                   }),
-                }),
-                {
-                  execution: createBackofficeUserExecution({ scope, userId: "user-1" }),
-                  propagationContext: null,
                 },
-              );
+              ),
+              context,
+            );
             if (!response.ok) {
               throw new Error(
                 `Pi session creation failed (${response.status}): ${await response.text()}`,
@@ -2665,6 +2748,56 @@ const buildStepBuilders = <
             if (input.captureSessionIdAs) {
               ctx.vars[input.captureSessionIdAs] = session.id;
             }
+          },
+        ),
+      promptSession: (input) =>
+        createStep(
+          "when",
+          "pi.promptSession",
+          `prompt persisted Pi session in ${backofficeContextScopeRoutePath(input.scope)}`,
+          async (ctx) => {
+            const sessionId = await resolveScenarioValue(
+              ctx as BackofficeScenarioContext<TVars>,
+              input.sessionId,
+            );
+            const workflowName = input.workflowName ?? BACKOFFICE_PI_WORKFLOW_NAME;
+            const { object, context } = getScenarioPiRouteTarget(ctx, input.scope, input.userId);
+            const response = await object.fetchWithContext(
+              new Request(
+                createScenarioPiRouteUrl(
+                  input.scope,
+                  `/api/pi/workflows/${encodeURIComponent(workflowName)}/sessions/${encodeURIComponent(sessionId)}/command`,
+                ),
+                {
+                  method: "POST",
+                  headers: { "content-type": "application/json" },
+                  body: JSON.stringify({ kind: "prompt", input: { text: input.text } }),
+                },
+              ),
+              context,
+            );
+            if (!response.ok) {
+              throw new Error(
+                `Pi session prompt failed (${response.status}): ${await response.text()}`,
+              );
+            }
+          },
+        ),
+      operationCompleted: (input) =>
+        createStep(
+          "when",
+          "pi.operationCompleted",
+          `complete Pi operation ${input.payload.operationId}`,
+          async (ctx) => {
+            ctx.vars[piOperationBillingVarKey(input.hookId)] = await recordPiOperationBilling({
+              ...input,
+              recordEvent: async (organizationId, event) => {
+                ctx.rememberOrg(organizationId);
+                const billing = ctx.runtime.objects.billing.forOrg(organizationId);
+                await ctx.runtime.drain();
+                await billing.recordEvent(event);
+              },
+            });
           },
         ),
     },
@@ -3204,6 +3337,90 @@ const buildStepBuilders = <
             }
           },
           { drain: false },
+        ),
+      session: (input) =>
+        createStep(
+          "then",
+          "pi.session",
+          `assert persisted Pi session in ${backofficeContextScopeRoutePath(input.scope)}`,
+          async (ctx) => {
+            const sessionId = await resolveScenarioValue(
+              ctx as BackofficeScenarioContext<TVars>,
+              input.sessionId,
+            );
+            const workflowName = input.workflowName ?? BACKOFFICE_PI_WORKFLOW_NAME;
+            const { object, context } = getScenarioPiRouteTarget(ctx, input.scope, input.userId);
+            const response = await object.fetchWithContext(
+              new Request(
+                createScenarioPiRouteUrl(
+                  input.scope,
+                  `/api/pi/workflows/${encodeURIComponent(workflowName)}/sessions/${encodeURIComponent(sessionId)}`,
+                ),
+              ),
+              context,
+            );
+            if (!response.ok) {
+              throw new Error(
+                `Pi session lookup failed (${response.status}): ${await response.text()}`,
+              );
+            }
+
+            const session = (await response.json()) as PiSessionDetail;
+            assertPartialMatch(session.workflow, input.workflow, "pi.session.workflow");
+          },
+          { drain: false },
+        ),
+      operationBilling: (input) =>
+        createStep(
+          "then",
+          "pi.operationBilling",
+          `assert Pi operation billing ${input.hookId}`,
+          (ctx) => {
+            const actual = ctx.vars[piOperationBillingVarKey(input.hookId)];
+            assertPartialMatch(
+              actual,
+              {
+                recorded: input.recorded,
+                billingOrganizationId: input.billingOrganizationId,
+              },
+              `pi.operationBilling.${input.hookId}`,
+            );
+          },
+          { drain: false },
+        ),
+    },
+    billing: {
+      tracker: (input) =>
+        createStep(
+          "then",
+          "billing.tracker",
+          `assert ${input.meter} billing tracker for ${input.organizationId}`,
+          async (ctx) => {
+            ctx.rememberOrg(input.organizationId);
+            const billing = ctx.runtime.objects.billing.forOrg(input.organizationId);
+            await ctx.runtime.drain();
+            const page = await billing.getTrackers({
+              scope: input.scope,
+              period: input.period,
+              pageSize: 100,
+            });
+            const tracker = page.trackers.find((candidate) => candidate.meter === input.meter);
+            if (!tracker) {
+              throw new Error(
+                `Expected billing tracker ${input.meter}, got ${JSON.stringify(page.trackers)}.`,
+              );
+            }
+            if (tracker.quantity !== input.quantity) {
+              throw new Error(
+                `Expected billing tracker ${input.meter} quantity ${input.quantity}, got ${tracker.quantity}.`,
+              );
+            }
+            if (input.eventCount && tracker.eventCount !== input.eventCount) {
+              throw new Error(
+                `Expected billing tracker ${input.meter} event count ${input.eventCount}, got ${tracker.eventCount}.`,
+              );
+            }
+          },
         ),
     },
     resend: {

--- a/apps/backoffice/app/fragno/billing/billing.test.ts
+++ b/apps/backoffice/app/fragno/billing/billing.test.ts
@@ -127,6 +127,80 @@ describe("billing fragment", async () => {
     expect(august.trackers.map((tracker) => tracker.quantity)).toEqual(["25000", "100"]);
   });
 
+  test("builds an organization statement across scoped trackers without writing rollups", async () => {
+    const statementOrgScope = { kind: "org" as const, orgId: "org-statement" };
+    const statementEvents: BillingEventInput[] = [
+      usageEvent({
+        id: "statement-org-event",
+        scope: statementOrgScope,
+        occurredAt: "2026-09-01T10:00:00.000Z",
+        measurements: [
+          { meter: "ai.tokens.total", unit: "token", quantity: 10 },
+          { meter: "ai.cost.total", unit: "nano-usd", quantity: 100 },
+        ],
+      }),
+      usageEvent({
+        id: "statement-project-event",
+        scope: { kind: "project", orgId: "org-statement", projectId: "project-1" },
+        occurredAt: "2026-09-01T11:00:00.000Z",
+        measurements: [
+          { meter: "ai.tokens.total", unit: "token", quantity: 20 },
+          { meter: "ai.cost.total", unit: "nano-usd", quantity: 200 },
+        ],
+      }),
+      usageEvent({
+        id: "statement-user-event",
+        scope: { kind: "user", userId: "user-1" },
+        occurredAt: "2026-09-01T12:00:00.000Z",
+        measurements: [
+          { meter: "ai.tokens.total", unit: "token", quantity: 30 },
+          { meter: "ai.cost.total", unit: "nano-usd", quantity: 300 },
+        ],
+      }),
+    ];
+
+    for (const statementEvent of statementEvents) {
+      await callServices(() => billing.services.recordEvent(statementEvent));
+    }
+
+    await expect(
+      callServices(() => billing.services.getStatement({ period: "2026-09" })),
+    ).resolves.toMatchObject({
+      period: "2026-09",
+      trackers: [
+        {
+          meter: "ai.cost.total",
+          unit: "nano-usd",
+          quantity: "600",
+          eventCount: "3",
+          firstOccurredAt: "2026-09-01T10:00:00.000Z",
+          lastOccurredAt: "2026-09-01T12:00:00.000Z",
+          updatedAt: expect.any(String),
+        },
+        {
+          meter: "ai.tokens.total",
+          unit: "token",
+          quantity: "60",
+          eventCount: "3",
+          firstOccurredAt: "2026-09-01T10:00:00.000Z",
+          lastOccurredAt: "2026-09-01T12:00:00.000Z",
+          updatedAt: expect.any(String),
+        },
+      ],
+    });
+
+    await expect(
+      callServices(() =>
+        billing.services.getTrackers({ scope: statementOrgScope, period: "2026-09" }),
+      ),
+    ).resolves.toMatchObject({
+      trackers: [
+        expect.objectContaining({ meter: "ai.cost.total", quantity: "100", eventCount: "1" }),
+        expect.objectContaining({ meter: "ai.tokens.total", quantity: "10", eventCount: "1" }),
+      ],
+    });
+  });
+
   test("paginates trackers in ascending meter order", async () => {
     const paginationScope = { kind: "org" as const, orgId: "org-pagination" };
     await callServices(() =>

--- a/apps/backoffice/app/fragno/billing/contracts.ts
+++ b/apps/backoffice/app/fragno/billing/contracts.ts
@@ -88,3 +88,16 @@ export type BillingTrackerPage = {
   hasNextPage: boolean;
   summaryTracker: BillingTracker | null;
 };
+
+export const billingStatementInputSchema = z.object({
+  period: billingPeriodSchema,
+});
+
+export type BillingStatementInput = z.infer<typeof billingStatementInputSchema>;
+
+export type BillingStatementTracker = Omit<BillingTracker, "scope" | "period">;
+
+export type BillingStatement = {
+  period: string;
+  trackers: BillingStatementTracker[];
+};

--- a/apps/backoffice/app/fragno/billing/definition.ts
+++ b/apps/backoffice/app/fragno/billing/definition.ts
@@ -6,15 +6,19 @@ import { backofficeContextScopeSinglePathSegment } from "@/backoffice-runtime/sc
 import {
   billingEventInputSchema,
   billingPeriodSchema,
+  billingStatementInputSchema,
   billingTrackerPageInputSchema,
   type BillingEventInput,
   type BillingRecordEventResult,
+  type BillingStatement,
+  type BillingStatementInput,
+  type BillingStatementTracker,
   type BillingTracker,
   type BillingTrackerPage,
   type BillingTrackerPageInput,
 } from "./contracts";
 import { BILLING_TRACKER_INDEX_NAME, decodeBillingTrackerCursor } from "./pagination";
-import { billingFragmentSchema } from "./schema";
+import { BILLING_STATEMENT_TRACKER_INDEX_NAME, billingFragmentSchema } from "./schema";
 
 const billingPeriodForDate = (date: Date) => date.toISOString().slice(0, 7);
 
@@ -61,7 +65,7 @@ const assertIdempotentEventMatches = (
   }
 };
 
-const normalizeTracker = (tracker: {
+type StoredBillingTracker = {
   scope: BillingTracker["scope"];
   period: string;
   meter: string;
@@ -71,7 +75,9 @@ const normalizeTracker = (tracker: {
   firstOccurredAt: unknown;
   lastOccurredAt: unknown;
   updatedAt: unknown;
-}): BillingTracker => ({
+};
+
+const normalizeTracker = (tracker: StoredBillingTracker): BillingTracker => ({
   scope: tracker.scope,
   period: tracker.period,
   meter: tracker.meter,
@@ -82,6 +88,69 @@ const normalizeTracker = (tracker: {
   lastOccurredAt: timestampToIsoString(tracker.lastOccurredAt),
   updatedAt: timestampToIsoString(tracker.updatedAt),
 });
+
+const aggregateStatementTrackers = (
+  trackers: StoredBillingTracker[],
+): BillingStatementTracker[] => {
+  const aggregates = new Map<
+    string,
+    {
+      meter: string;
+      unit: string;
+      quantity: bigint;
+      eventCount: bigint;
+      firstOccurredAt: string;
+      lastOccurredAt: string;
+      updatedAt: string;
+    }
+  >();
+
+  for (const tracker of trackers) {
+    const firstOccurredAt = timestampToIsoString(tracker.firstOccurredAt);
+    const lastOccurredAt = timestampToIsoString(tracker.lastOccurredAt);
+    const updatedAt = timestampToIsoString(tracker.updatedAt);
+    const aggregate = aggregates.get(tracker.meter);
+
+    if (!aggregate) {
+      aggregates.set(tracker.meter, {
+        meter: tracker.meter,
+        unit: tracker.unit,
+        quantity: tracker.quantity,
+        eventCount: tracker.eventCount,
+        firstOccurredAt,
+        lastOccurredAt,
+        updatedAt,
+      });
+      continue;
+    }
+
+    if (aggregate.unit !== tracker.unit) {
+      throw new Error(
+        `BILLING_STATEMENT_METER_UNIT_CONFLICT:${tracker.meter}:${aggregate.unit}:${tracker.unit}`,
+      );
+    }
+
+    aggregate.quantity += tracker.quantity;
+    aggregate.eventCount += tracker.eventCount;
+    if (firstOccurredAt < aggregate.firstOccurredAt) {
+      aggregate.firstOccurredAt = firstOccurredAt;
+    }
+    if (lastOccurredAt > aggregate.lastOccurredAt) {
+      aggregate.lastOccurredAt = lastOccurredAt;
+    }
+    if (updatedAt > aggregate.updatedAt) {
+      aggregate.updatedAt = updatedAt;
+    }
+  }
+
+  return [...aggregates.values()]
+    .sort((left, right) => left.meter.localeCompare(right.meter))
+    .map((tracker) => ({
+      ...tracker,
+      quantity: tracker.quantity.toString(),
+      eventCount: tracker.eventCount.toString(),
+    }));
+};
 
 export const billingFragmentDefinition = defineFragment("billing")
   .extend(withDatabase(billingFragmentSchema))
@@ -177,6 +246,29 @@ export const billingFragmentDefinition = defineFragment("billing")
 
             return { accepted: true, eventId: input.id } satisfies BillingRecordEventResult;
           })
+          .build();
+      },
+
+      getStatement: function (rawInput: BillingStatementInput) {
+        const input = billingStatementInputSchema.parse(rawInput);
+
+        return this.serviceTx(billingFragmentSchema)
+          .retrieve((uow) =>
+            uow.find("billing_tracker", (b) =>
+              b
+                .whereIndex(BILLING_STATEMENT_TRACKER_INDEX_NAME, (eb) =>
+                  eb("period", "=", input.period),
+                )
+                .orderByIndex(BILLING_STATEMENT_TRACKER_INDEX_NAME, "asc"),
+            ),
+          )
+          .transformRetrieve(
+            ([trackers]) =>
+              ({
+                period: input.period,
+                trackers: aggregateStatementTrackers(trackers),
+              }) satisfies BillingStatement,
+          )
           .build();
       },
 

--- a/apps/backoffice/app/fragno/billing/index.ts
+++ b/apps/backoffice/app/fragno/billing/index.ts
@@ -12,6 +12,9 @@ export type {
   BillingEventInput,
   BillingMeasurementInput,
   BillingRecordEventResult,
+  BillingStatement,
+  BillingStatementInput,
+  BillingStatementTracker,
   BillingTracker,
   BillingTrackerPage,
   BillingTrackerPageInput,
@@ -21,5 +24,6 @@ export {
   BILLING_TRACKER_MAX_PAGE_SIZE,
   billingEventInputSchema,
   billingPeriodSchema,
+  billingStatementInputSchema,
   billingTrackerPageInputSchema,
 } from "./contracts";

--- a/apps/backoffice/app/fragno/billing/pi.test.ts
+++ b/apps/backoffice/app/fragno/billing/pi.test.ts
@@ -2,7 +2,12 @@ import { assert, describe, expect, test } from "vitest";
 
 import type { PiOperationCompletedHookPayload } from "@fragno-dev/pi-harness/types";
 
-import { createPiOperationBillingEvent, PiOperationBillingEventValidationError } from "./pi";
+import {
+  createPiOperationBillingEvent,
+  PiOperationBillingEventValidationError,
+  PiOperationBillingOwnerMissingError,
+  resolvePiOperationBillingOrganizationId,
+} from "./pi";
 
 const payload: PiOperationCompletedHookPayload = {
   actor: { userId: "user-1" },
@@ -52,6 +57,28 @@ const payload: PiOperationCompletedHookPayload = {
 };
 
 describe("createPiOperationBillingEvent", () => {
+  test("resolves the organization that owns scoped usage", () => {
+    assert(
+      resolvePiOperationBillingOrganizationId({ kind: "org", orgId: "org-1" }, null) === "org-1",
+    );
+    assert(
+      resolvePiOperationBillingOrganizationId(
+        { kind: "project", orgId: "org-1", projectId: "project-1" },
+        null,
+      ) === "org-1",
+    );
+    assert(
+      resolvePiOperationBillingOrganizationId(
+        { kind: "user", userId: "user-1" },
+        { __backofficeBillingOrganizationId: "org-2" },
+      ) === "org-2",
+    );
+    expect(() =>
+      resolvePiOperationBillingOrganizationId({ kind: "user", userId: "user-1" }, null),
+    ).toThrow(PiOperationBillingOwnerMissingError);
+    expect(resolvePiOperationBillingOrganizationId({ kind: "system" }, null)).toBeNull();
+  });
+
   test("rejects operations without model calls", () => {
     expect(() =>
       createPiOperationBillingEvent({

--- a/apps/backoffice/app/fragno/billing/pi.ts
+++ b/apps/backoffice/app/fragno/billing/pi.ts
@@ -2,6 +2,7 @@ import type { PiOperationCompletedHookPayload } from "@fragno-dev/pi-harness/typ
 
 import type { BackofficeContextScope } from "@/backoffice-runtime/context";
 import { backofficeContextScopeSinglePathSegment } from "@/backoffice-runtime/scope-codec";
+import { piSessionBillingOrganizationId } from "@/fragno/pi/pi-shared";
 
 import type { BillingEventInput, BillingMeasurementInput } from "./contracts";
 
@@ -11,6 +12,13 @@ export class PiOperationBillingEventValidationError extends Error {
   constructor() {
     super("Pi operation billing events require at least one model call.");
     this.name = "PiOperationBillingEventValidationError";
+  }
+}
+
+export class PiOperationBillingOwnerMissingError extends Error {
+  constructor(readonly userId: string) {
+    super(`PI_SESSION_BILLING_OWNER_MISSING:${userId}`);
+    this.name = "PiOperationBillingOwnerMissingError";
   }
 }
 
@@ -28,6 +36,28 @@ const piUsageMeasurements = (
   { meter: "ai.cost.cache-write", unit: "nano-usd", quantity: toNanoUsd(usage.cost.cacheWrite) },
   { meter: "ai.cost.total", unit: "nano-usd", quantity: toNanoUsd(usage.cost.total) },
 ];
+
+export const resolvePiOperationBillingOrganizationId = (
+  scope: BackofficeContextScope,
+  metadata: Record<string, unknown> | null | undefined,
+): string | null => {
+  switch (scope.kind) {
+    case "org":
+    case "project":
+      return scope.orgId;
+    case "user": {
+      const organizationId = piSessionBillingOrganizationId(metadata);
+      if (!organizationId) {
+        throw new PiOperationBillingOwnerMissingError(scope.userId);
+      }
+      return organizationId;
+    }
+    case "system":
+      return null;
+  }
+
+  throw new Error("Unsupported Backoffice context scope kind.");
+};
 
 export const createPiOperationBillingEvent = (input: {
   scope: BackofficeContextScope;
@@ -62,4 +92,33 @@ export const createPiOperationBillingEvent = (input: {
       modelCalls: input.payload.modelCalls,
     },
   };
+};
+
+export const recordPiOperationBilling = async (input: {
+  scope: BackofficeContextScope;
+  payload: PiOperationCompletedHookPayload;
+  hookId: string;
+  idempotencyKey: string;
+  recordEvent: (organizationId: string, event: BillingEventInput) => Promise<void>;
+}): Promise<{ recorded: boolean; billingOrganizationId: string | null }> => {
+  let event: BillingEventInput;
+  try {
+    event = createPiOperationBillingEvent(input);
+  } catch (error) {
+    if (error instanceof PiOperationBillingEventValidationError) {
+      return { recorded: false, billingOrganizationId: null };
+    }
+    throw error;
+  }
+
+  const billingOrganizationId = resolvePiOperationBillingOrganizationId(
+    input.scope,
+    input.payload.metadata,
+  );
+  if (!billingOrganizationId) {
+    return { recorded: false, billingOrganizationId: null };
+  }
+
+  await input.recordEvent(billingOrganizationId, event);
+  return { recorded: true, billingOrganizationId };
 };

--- a/apps/backoffice/app/fragno/billing/schema.ts
+++ b/apps/backoffice/app/fragno/billing/schema.ts
@@ -6,6 +6,8 @@ import type { BillingMeasurementInput } from "./contracts";
 
 const jsonColumn = <T>() => column("json") as Column<"json", T, T>;
 
+export const BILLING_STATEMENT_TRACKER_INDEX_NAME = "idx_billing_tracker_period_meter_scopeKey";
+
 export const billingFragmentSchema = schema("billing", (s) =>
   s
     .addTable("billing_event", (t) =>
@@ -80,6 +82,7 @@ export const billingFragmentSchema = schema("billing", (s) =>
         )
         .createIndex("idx_billing_tracker_scope_period_meter", ["scopeKey", "period", "meter"], {
           unique: true,
-        }),
+        })
+        .createIndex(BILLING_STATEMENT_TRACKER_INDEX_NAME, ["period", "meter", "scopeKey"]),
     ),
 );

--- a/apps/backoffice/app/fragno/codemode/static-codemode-artifacts.test.ts
+++ b/apps/backoffice/app/fragno/codemode/static-codemode-artifacts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { createBackofficeUserExecution } from "@/backoffice-runtime/context";
+import type { BackofficeObjectRegistry } from "@/backoffice-runtime/object-registry";
+import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
+
+import { createCodemodeStaticArtifactsResolver } from "./static-codemode-artifacts";
+
+describe("createCodemodeStaticArtifactsResolver", () => {
+  test("provides codemode declarations for user-scoped sessions", async () => {
+    const resolveArtifacts = createCodemodeStaticArtifactsResolver({
+      objects: {} as BackofficeObjectRegistry,
+      config: {} as BackofficeRuntimeConfig,
+      execution: createBackofficeUserExecution({
+        scope: { kind: "user", userId: "user-1" },
+        userId: "user-1",
+      }),
+      families: [],
+    });
+
+    await expect(resolveArtifacts()).resolves.toMatchObject({
+      "codemode/system.d.ts": expect.any(String),
+      "codemode/workflow-authoring.d.ts": expect.any(String),
+    });
+  });
+});

--- a/apps/backoffice/app/fragno/codemode/static-codemode-artifacts.ts
+++ b/apps/backoffice/app/fragno/codemode/static-codemode-artifacts.ts
@@ -1,7 +1,7 @@
 import type { BackofficeExecutionContext } from "@/backoffice-runtime/context";
 import type { BackofficeObjectRegistry } from "@/backoffice-runtime/object-registry";
 import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
-import { emptyStaticFileArtifacts, type StaticFileArtifactsResolver } from "@/files/types";
+import type { StaticFileArtifactsResolver } from "@/files/types";
 import {
   backofficeCapabilities,
   type BackofficeCapabilityId,
@@ -104,8 +104,11 @@ export const createCodemodeStaticArtifactsResolver = ({
   origin?: string;
   families?: readonly BackofficeRuntimeToolFamily[];
 }): StaticFileArtifactsResolver => {
-  if (execution.scope.kind !== "org" && execution.scope.kind !== "project") {
-    return emptyStaticFileArtifacts;
+  if (execution.scope.kind === "user" || execution.scope.kind === "system") {
+    return async () =>
+      codemodeTypeFilesToStaticArtifacts(
+        createCodemodeTypeFiles({ families: families ?? runtimeToolFamilies }),
+      );
   }
 
   const orgId = execution.scope.orgId;

--- a/apps/backoffice/app/fragno/pi/pi-shared.ts
+++ b/apps/backoffice/app/fragno/pi/pi-shared.ts
@@ -71,6 +71,8 @@ export const PI_SUPPORTED_MODELS: PiModelOption[] = [
 
 export const PI_TOOL_IDS = ["execCodeMode", "read", "search"] as const;
 export type PiToolId = (typeof PI_TOOL_IDS)[number];
+
+export const PI_BILLING_ORGANIZATION_ID_METADATA_KEY = "__backofficeBillingOrganizationId";
 export const PI_SYSTEM_PROMPT = STATIC_FILE_CONTENT["SYSTEM.md"];
 export const PI_THINKING_LEVEL: PiThinkingLevel = "low";
 
@@ -90,6 +92,13 @@ export const piSessionModel = (
     return null;
   }
   return { provider, name };
+};
+
+export const piSessionBillingOrganizationId = (
+  metadata: Record<string, unknown> | null | undefined,
+): string | null => {
+  const organizationId = metadata?.[PI_BILLING_ORGANIZATION_ID_METADATA_KEY];
+  return typeof organizationId === "string" && organizationId.trim() ? organizationId.trim() : null;
 };
 
 export const findPiModelOption = (provider: PiModelProvider, name: string) => {

--- a/apps/backoffice/app/fragno/pi/pi.test.ts
+++ b/apps/backoffice/app/fragno/pi/pi.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test, assert } from "vitest";
 
+import { NonRetryableError } from "@fragno-dev/workflows/workflow";
+
 import { defaultFragnoRuntime } from "@fragno-dev/core";
 import { InMemoryAdapter } from "@fragno-dev/db";
 import { createWorkflowsFragment } from "@fragno-dev/workflows";
@@ -7,6 +9,7 @@ import { createWorkflowsFragment } from "@fragno-dev/workflows";
 import { unavailableBackofficeAuthorityResolver } from "@/backoffice-runtime/authority-resolver";
 import { createBackofficeUserExecution } from "@/backoffice-runtime/context";
 import { BackofficeKernel, noopBackofficeKernelObserver } from "@/backoffice-runtime/kernel";
+import { BACKOFFICE_PERMISSION } from "@/backoffice-runtime/permissions";
 import type { BackofficeRuntimeConfig } from "@/backoffice-runtime/runtime-services";
 import type { FileSearchMatch } from "@/file-collection/file-collection";
 import * as files from "@/files";
@@ -18,6 +21,7 @@ import type { UploadFileRecord } from "@/fragno/upload/file-record";
 import { createTestMasterFileSystem } from "../automation/engine/test-master-file-system.test-utils";
 import { createTestStateBackend, MemoryUploadObject } from "../codemode/state-backend.test-utils";
 import {
+  createBackofficePiSessionExecution,
   createPiRuntimeDefinition,
   createPiToolFactory,
   createPiToolRegistry,
@@ -141,6 +145,100 @@ const createMockRuntimeToolContext = (): PiRuntimeToolContext => ({
 });
 
 describe("Backoffice Pi fragment", () => {
+  test("authorizes billing organizations for immediate and deferred user sessions", async () => {
+    const baseContext = createContext();
+    const scope = { kind: "user" as const, userId: "test-user" };
+    const execution = createBackofficeUserExecution({
+      scope,
+      userId: scope.userId,
+      verifiedAccessToken: {
+        role: "user",
+        organizationIds: ["org-1"],
+        expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      },
+    });
+    const kernel = new BackofficeKernel({
+      authorityResolver: {
+        async resolvePrincipalPermissions({ execution: currentExecution }) {
+          if (
+            currentExecution.scope.kind === "user" ||
+            (currentExecution.scope.kind === "org" && currentExecution.scope.orgId === "org-1")
+          ) {
+            return [BACKOFFICE_PERMISSION.pi.modify];
+          }
+          return [];
+        },
+        async resolveActorCapabilityGrants() {
+          return [];
+        },
+      },
+      kernelObserver: noopBackofficeKernelObserver,
+    });
+    const context = { ...baseContext, scope, execution, kernel };
+    const adapter = new InMemoryAdapter({ idSeed: "pi-user-billing-test" });
+    const definition = createPiRuntimeDefinition({
+      scope,
+      kernel: context.kernel,
+      apiKeys: { openai: "test-key" },
+      sessionFileSystems: new Map(),
+      sessionFileSystemContext: context,
+      runtimeToolContext: createMockRuntimeToolContext(),
+      codemode: {
+        execute: async () => {
+          throw new Error("codemode not available in test");
+        },
+      },
+    });
+    const workflowsFragment = createWorkflowsFragment(
+      { workflows: definition.workflows, runtime: defaultFragnoRuntime },
+      { databaseAdapter: adapter },
+    );
+    const piFragment = definition.createFragment({
+      databaseAdapter: adapter,
+      workflows: workflowsFragment.services,
+    });
+    const createRequest = (billingOrganizationId?: string) =>
+      new Request(`http://test.local/api/pi/workflows/${BACKOFFICE_PI_WORKFLOW_NAME}/sessions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          metadata: {
+            model: { provider: "openai", name: "gpt-5.6-luna" },
+            ...(billingOrganizationId
+              ? { __backofficeBillingOrganizationId: billingOrganizationId }
+              : {}),
+          },
+          input: {},
+        }),
+      });
+
+    const missingResponse = await piFragment.handler(createRequest(), {
+      requestContext: execution,
+    });
+    assert(missingResponse.status === 400);
+
+    const unavailableResponse = await piFragment.handler(createRequest("org-2"), {
+      requestContext: execution,
+    });
+    assert(unavailableResponse.status === 403);
+
+    const response = await piFragment.handler(createRequest("org-1"), {
+      requestContext: execution,
+    });
+    assert(response.ok);
+    await expect(response.json()).resolves.toMatchObject({
+      metadata: { __backofficeBillingOrganizationId: "org-1" },
+    });
+
+    const deferredResponse = await piFragment.handler(createRequest("org-1"), {
+      requestContext: createBackofficeUserExecution({
+        scope,
+        userId: scope.userId,
+      }),
+    });
+    assert(deferredResponse.ok);
+  });
+
   test("rejects unknown model names before creating the session", async () => {
     const context = createContext();
     const adapter = new InMemoryAdapter({ idSeed: "pi-invalid-model-test" });
@@ -322,25 +420,45 @@ describe("Backoffice Pi search output", () => {
 });
 
 describe("Backoffice Pi execution", () => {
+  test("treats invalid session actor metadata as non-retryable", () => {
+    try {
+      createBackofficePiSessionExecution({ kind: "user", userId: "user-1" }, null);
+      assert.fail("expected invalid actor metadata to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(NonRetryableError);
+      expect(error).toMatchObject({
+        name: "PiSessionActorMetadataInvalidError",
+        message: "PI_SESSION_ACTOR_METADATA_INVALID",
+      });
+    }
+  });
+
   test("builds runtime tools from the session creator execution", async () => {
     const sessionExecution = createBackofficeUserExecution({
       scope: { kind: "org", orgId: "acme-org" },
       userId: "session-creator",
     });
     let receivedExecution: typeof sessionExecution | undefined;
+    let receivedMetadata: Record<string, unknown> | null | undefined;
     const sessionId = "session-execution";
     const createTools = createPiToolFactory({
       sessionFileSystems: new Map([[sessionId, Promise.resolve(createTestMasterFileSystem({}))]]),
       sessionFileSystemContext: createContext(),
-      runtimeToolContext: (execution) => {
+      runtimeToolContext: (execution, metadata) => {
         receivedExecution = execution;
+        receivedMetadata = metadata;
         return createMockRuntimeToolContext();
       },
     });
 
-    await createTools({ sessionId, execution: sessionExecution });
+    await createTools({
+      sessionId,
+      execution: sessionExecution,
+      metadata: { __backofficeBillingOrganizationId: "org-1" },
+    });
 
     expect(receivedExecution).toEqual(sessionExecution);
+    expect(receivedMetadata).toEqual({ __backofficeBillingOrganizationId: "org-1" });
   });
 });
 

--- a/apps/backoffice/app/fragno/pi/pi.ts
+++ b/apps/backoffice/app/fragno/pi/pi.ts
@@ -1,8 +1,12 @@
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { createPiHarness, createPiWorkflows } from "@fragno-dev/pi-harness/factory";
-import type { PiFragmentConfig } from "@fragno-dev/pi-harness/types";
+import type { PiFragmentConfig, PiSessionMetadata } from "@fragno-dev/pi-harness/types";
 import { createInteractiveChatWorkflow } from "@fragno-dev/pi-harness/workflows/interactive-chat-workflow";
-import type { WorkflowRegistryEntry, WorkflowsRegistry } from "@fragno-dev/workflows/workflow";
+import {
+  NonRetryableError,
+  type WorkflowRegistryEntry,
+  type WorkflowsRegistry,
+} from "@fragno-dev/workflows/workflow";
 import { Type, type TSchema } from "typebox";
 
 import { visualizeWorkflowSource } from "@fragno-dev/workflow-visualizer-tokens";
@@ -59,7 +63,9 @@ import {
 } from "../runtime-tools/tool-families";
 import {
   BACKOFFICE_PI_WORKFLOW_NAME,
+  piSessionBillingOrganizationId,
   piSessionModel,
+  PI_BILLING_ORGANIZATION_ID_METADATA_KEY,
   PI_SUPPORTED_MODELS,
   PI_PROVIDER_TO_MODEL_PROVIDER,
   PI_SYSTEM_PROMPT,
@@ -618,11 +624,15 @@ const getSessionFs = async (
 type BackofficePiToolFactory = (input: {
   sessionId: string;
   execution: BackofficeExecutionContext;
+  metadata?: PiSessionMetadata | null;
 }) => Promise<Partial<Record<PiToolId, AgentTool>>>;
 
 type PiRuntimeToolContextSource =
   | PiRuntimeToolContext
-  | ((execution: BackofficeExecutionContext) => PiRuntimeToolContext);
+  | ((
+      execution: BackofficeExecutionContext,
+      metadata: PiSessionMetadata | null,
+    ) => PiRuntimeToolContext);
 
 type CreatePiToolFactoryOptions = {
   sessionFileSystems: Map<string, Promise<MasterFileSystem>>;
@@ -634,15 +644,20 @@ type CreatePiToolFactoryOptions = {
 const resolvePiRuntimeToolContext = (
   source: PiRuntimeToolContextSource | undefined,
   execution: BackofficeExecutionContext,
-) => (typeof source === "function" ? source(execution) : source);
+  metadata: PiSessionMetadata | null,
+) => (typeof source === "function" ? source(execution, metadata) : source);
 
 export const createPiToolFactory =
   ({
     codemode,
     runtimeToolContext: runtimeToolContextSource,
   }: CreatePiToolFactoryOptions): BackofficePiToolFactory =>
-  async ({ sessionId, execution }) => {
-    const runtimeToolContext = resolvePiRuntimeToolContext(runtimeToolContextSource, execution);
+  async ({ sessionId, execution, metadata = null }) => {
+    const runtimeToolContext = resolvePiRuntimeToolContext(
+      runtimeToolContextSource,
+      execution,
+      metadata,
+    );
     if (!runtimeToolContext?.stateBackend) {
       throw new Error("Pi tools require a state backend.");
     }
@@ -663,6 +678,7 @@ export const createPiToolRegistry = (options: CreatePiToolFactoryOptions) => {
         await createTools({
           sessionId: context.session.id,
           execution: options.sessionFileSystemContext.execution,
+          metadata: null,
         })
       )[toolId];
       if (!tool) {
@@ -781,14 +797,71 @@ const validateBackofficePiModel = (models: Models, selection: PiModel): string |
   return model ? null : `Model ${selection.provider}/${selection.name} not found.`;
 };
 
+class PiSessionBillingOwnerMissingError extends NonRetryableError {
+  constructor(readonly userId: string) {
+    super(`User-scoped Pi session ${userId} has no billing organization.`);
+    this.name = "PiSessionBillingOwnerMissingError";
+  }
+}
+
+class PiSessionBillingOrganizationAccessDeniedError extends NonRetryableError {
+  constructor(readonly organizationId: string) {
+    super(`Pi session billing organization ${organizationId} is no longer available.`);
+    this.name = "PiSessionBillingOrganizationAccessDeniedError";
+  }
+}
+
+const authorizePiBillingOrganization = async ({
+  kernel,
+  execution,
+  organizationId,
+  resource,
+}: {
+  kernel: BackofficeKernel;
+  execution: BackofficeExecutionContext;
+  organizationId: string;
+  resource: Record<string, unknown>;
+}): Promise<void> => {
+  await kernel.assertAuthorized({
+    execution: {
+      ...execution,
+      scope: { kind: "org", orgId: organizationId },
+    },
+    operation: BACKOFFICE_PERMISSION.pi.modify,
+    resource,
+  });
+};
+
+class PiSessionActorMetadataInvalidError extends NonRetryableError {
+  constructor() {
+    super("PI_SESSION_ACTOR_METADATA_INVALID", "PiSessionActorMetadataInvalidError");
+  }
+}
+
+export const createBackofficePiSessionExecution = (
+  scope: BackofficeContextScope,
+  metadata: PiSessionMetadata | null,
+): BackofficeExecutionContext => {
+  const actors = automationActorsSchema.safeParse(
+    metadata?.[BACKOFFICE_WORKFLOW_ACTORS_METADATA_KEY],
+  );
+  if (!actors.success) {
+    throw new PiSessionActorMetadataInvalidError();
+  }
+
+  return { scope, actors: actors.data };
+};
+
 const createBackofficeInteractiveChatWorkflow = ({
   config,
+  kernel,
   models,
   createTools,
   skills,
   resolveSystemPrompt,
 }: {
   config: { scope: BackofficeContextScope };
+  kernel: BackofficeKernel;
   models: Models;
   createTools: BackofficePiToolFactory;
   skills: BackofficePiSkillResolver;
@@ -797,6 +870,35 @@ const createBackofficeInteractiveChatWorkflow = ({
   ...createInteractiveChatWorkflow({
     name: BACKOFFICE_PI_WORKFLOW_NAME,
     commandTimeout: "1 hour",
+    beforeOperation: async (input) => {
+      if (config.scope.kind !== "user") {
+        return;
+      }
+
+      const billingOrganizationId = piSessionBillingOrganizationId(input.metadata);
+      if (!billingOrganizationId) {
+        throw new PiSessionBillingOwnerMissingError(config.scope.userId);
+      }
+
+      try {
+        await authorizePiBillingOrganization({
+          kernel,
+          execution: createBackofficePiSessionExecution(config.scope, input.metadata),
+          organizationId: billingOrganizationId,
+          resource: {
+            kind: "pi-session-operation-billing",
+            workflowName: input.workflowName,
+            sessionId: input.sessionId,
+            operationId: input.operationId,
+          },
+        });
+      } catch (error) {
+        if (error instanceof BackofficeForbiddenError && error.reason !== "authority-unavailable") {
+          throw new PiSessionBillingOrganizationAccessDeniedError(billingOrganizationId);
+        }
+        throw error;
+      }
+    },
     options: async (event) => {
       const selectedModel = piSessionModel(event.payload.metadata);
       if (!selectedModel) {
@@ -812,16 +914,12 @@ const createBackofficeInteractiveChatWorkflow = ({
         throw new Error(`API key for provider ${model.provider} is not configured.`);
       }
 
-      const actors = automationActorsSchema.parse(
-        event.payload.metadata?.[BACKOFFICE_WORKFLOW_ACTORS_METADATA_KEY],
-      );
-      const execution: BackofficeExecutionContext = {
-        scope: config.scope,
-        actors,
-      };
+      const metadata = event.payload.metadata ?? null;
+      const execution = createBackofficePiSessionExecution(config.scope, metadata);
       const sessionTools = await createTools({
         sessionId: event.instanceId,
         execution,
+        metadata,
       });
       const activeTools = PI_TOOL_IDS.map((toolId) => {
         const tool = sessionTools[toolId];
@@ -856,6 +954,7 @@ const createBackofficeInteractiveChatWorkflow = ({
 
 const buildPiRuntime = (
   config: { scope: BackofficeContextScope },
+  kernel: BackofficeKernel,
   apiKeys: PiApiKeys,
   createTools: BackofficePiToolFactory,
   skills: BackofficePiSkillResolver,
@@ -868,6 +967,7 @@ const buildPiRuntime = (
   const workflows = [
     createBackofficeInteractiveChatWorkflow({
       config,
+      kernel,
       models,
       createTools,
       skills,
@@ -918,6 +1018,7 @@ export const createPiRuntimeDefinition = (
   });
   const pi = buildPiRuntime(
     { scope: options.scope },
+    options.kernel,
     options.apiKeys,
     createTools,
     skills,
@@ -945,8 +1046,9 @@ export const createPiRuntimeDefinition = (
       const authorize = async (
         operation: typeof BACKOFFICE_PERMISSION.pi.read | typeof BACKOFFICE_PERMISSION.pi.modify,
         resource: Record<string, unknown>,
+        execution = requestContext,
       ) => {
-        if (!requestContext) {
+        if (!execution) {
           return error(
             {
               message: "Pi session routes require trusted action context.",
@@ -958,7 +1060,7 @@ export const createPiRuntimeDefinition = (
 
         try {
           await options.kernel.assertAuthorized({
-            execution: requestContext,
+            execution,
             operation,
             resource,
           });
@@ -1009,11 +1111,46 @@ export const createPiRuntimeDefinition = (
             return authorizationResponse;
           }
 
+          const billingOrganizationId = piSessionBillingOrganizationId(values.metadata);
+          if (requestContext.scope.kind === "user") {
+            if (!billingOrganizationId) {
+              return error(
+                {
+                  message: "User-scoped Pi sessions require a billing organization.",
+                  code: "WORKFLOW_PARAMS_INVALID",
+                },
+                400,
+              );
+            }
+            const billingAuthorizationResponse = await authorize(
+              BACKOFFICE_PERMISSION.pi.modify,
+              {
+                kind: "pi-session-billing-organization",
+                workflowName: pathParams.workflowName,
+                organizationId: billingOrganizationId,
+              },
+              {
+                ...requestContext,
+                scope: { kind: "org", orgId: billingOrganizationId },
+              },
+            );
+            if (billingAuthorizationResponse) {
+              return billingAuthorizationResponse;
+            }
+          }
+
+          const {
+            [PI_BILLING_ORGANIZATION_ID_METADATA_KEY]: _requestedBillingOrganizationId,
+            ...sessionMetadata
+          } = values.metadata ?? {};
           requestState.setBody({
             ...values,
             metadata: {
-              ...values.metadata,
+              ...sessionMetadata,
               model,
+              ...(requestContext.scope.kind === "user" && billingOrganizationId
+                ? { [PI_BILLING_ORGANIZATION_ID_METADATA_KEY]: billingOrganizationId }
+                : {}),
               [BACKOFFICE_WORKFLOW_ACTORS_METADATA_KEY]: automationActorsSchema.parse(
                 requestContext.actors,
               ),

--- a/apps/backoffice/app/fragno/pi/tanstack/use-session-listing.scenario.test.ts
+++ b/apps/backoffice/app/fragno/pi/tanstack/use-session-listing.scenario.test.ts
@@ -44,16 +44,18 @@ describe("usePiSessionListing", () => {
         }),
         setup: ({ given }) => [
           given.organization.exists({ id: "org-1", name: "Ada Labs" }),
-          given.pi.configured({ orgId: "org-1" }),
+          given.pi.configured({ scope: { kind: "org", orgId: "org-1" } }),
         ],
         steps: ({ then, when }) => [
           when.pi.createSession({
-            orgId: "org-1",
+            scope: { kind: "org", orgId: "org-1" },
+            userId: "user-1",
             name: "First session",
             captureSessionIdAs: "firstSessionId",
           }),
           when.pi.createSession({
-            orgId: "org-1",
+            scope: { kind: "org", orgId: "org-1" },
+            userId: "user-1",
             name: "Second session",
             captureSessionIdAs: "secondSessionId",
           }),
@@ -71,7 +73,8 @@ describe("usePiSessionListing", () => {
             );
           }),
           when.pi.createSession({
-            orgId: "org-1",
+            scope: { kind: "org", orgId: "org-1" },
+            userId: "user-1",
             name: "Third session",
             captureSessionIdAs: "thirdSessionId",
           }),

--- a/apps/backoffice/app/fragno/runtime-tools/families/pi-runtime.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/pi-runtime.test.ts
@@ -16,6 +16,7 @@ import type { RegisteredAutomationsRuntime } from "../bash-host";
 import { EMPTY_BASH_HOST_CONTEXT } from "../bash-host.test-utils";
 import { createUnavailableAutomationRouterRuntime } from "./automations-routing";
 import {
+  createPiFragmentRuntime,
   createPiRouteRuntime,
   type PiRuntime,
   type PiSessionCreateArgs,
@@ -888,6 +889,7 @@ describe("createPiRouteRuntime", () => {
     });
 
     const created = await runtime.createSession({
+      billingOrganizationId: "org-billing",
       model: { provider: "openai", name: "gpt-5-mini" },
       name: "route-session",
       metadata: { team: "beta" },
@@ -952,6 +954,7 @@ describe("createPiRouteRuntime", () => {
         body: {
           name: "route-session",
           metadata: {
+            __backofficeBillingOrganizationId: "org-billing",
             model: { provider: "openai", name: "gpt-5-mini" },
             team: "beta",
           },
@@ -979,6 +982,55 @@ describe("createPiRouteRuntime", () => {
         body: {
           kind: "prompt",
           input: { text: "route turn" },
+        },
+      },
+    ]);
+  });
+
+  it("protects billing ownership inherited from the parent Pi session", async () => {
+    const requests: unknown[] = [];
+    const fragment = {
+      callRoute: async (_method: string, _path: string, input: unknown) => {
+        requests.push(input);
+        return {
+          type: "json" as const,
+          status: 200,
+          data: {
+            id: "child-session",
+            name: null,
+            metadata: null,
+            workflowName: "interactive-chat-workflow",
+            createdAt: now,
+            updatedAt: now,
+          },
+        };
+      },
+    } as unknown as Parameters<typeof createPiFragmentRuntime>[0]["fragment"];
+    const scope = { kind: "user", userId: "user-1" } as const;
+    const runtime = createPiFragmentRuntime({
+      fragment,
+      execution: createPiTestExecution(scope),
+      inheritedBillingOrganizationId: "org-parent",
+    });
+
+    await runtime.createSession({
+      billingOrganizationId: "org-requested",
+      metadata: {
+        __backofficeBillingOrganizationId: "org-metadata",
+        purpose: "delegated-task",
+      },
+    });
+
+    expect(requests).toEqual([
+      {
+        pathParams: { workflowName: "interactive-chat-workflow" },
+        body: {
+          name: undefined,
+          metadata: {
+            __backofficeBillingOrganizationId: "org-parent",
+            purpose: "delegated-task",
+          },
+          input: { systemPrompt: undefined },
         },
       },
     ]);

--- a/apps/backoffice/app/fragno/runtime-tools/families/pi-runtime.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/pi-runtime.ts
@@ -8,13 +8,18 @@ import type {
 } from "@/backoffice-runtime/context";
 import type { AutomationsObject } from "@/backoffice-runtime/object-registry";
 import { backofficeContextScopeSinglePathSegment } from "@/backoffice-runtime/scope-codec";
-import { BACKOFFICE_PI_WORKFLOW_NAME, type PiModel } from "@/fragno/pi/pi-shared";
+import {
+  BACKOFFICE_PI_WORKFLOW_NAME,
+  PI_BILLING_ORGANIZATION_ID_METADATA_KEY,
+  type PiModel,
+} from "@/fragno/pi/pi-shared";
 
 import { isSuccessStatus, throwOnRouteRuntimeError } from "../runtime-errors";
 
 type PiFragment = ReturnType<typeof createPiHarness<BackofficeExecutionContext>>;
 
 export type PiSessionCreateArgs = {
+  billingOrganizationId?: string;
   model?: PiModel;
   name?: string;
   systemMessage?: string;
@@ -102,13 +107,29 @@ const createPiRouteCaller = ({
 
 type PiRouteCaller = PiFragment["callRoute"];
 
-const createPiRuntime = (callRoute: PiRouteCaller): PiRuntime => ({
+const createPiRuntime = (
+  callRoute: PiRouteCaller,
+  options: { inheritedBillingOrganizationId?: string } = {},
+): PiRuntime => ({
   createSession: async (args) => {
     const response = await callRoute("POST", "/workflows/:workflowName/sessions", {
       pathParams: { workflowName: BACKOFFICE_PI_WORKFLOW_NAME },
       body: {
         name: args.name,
-        metadata: { ...args.metadata, ...(args.model ? { model: args.model } : {}) },
+        metadata: {
+          ...args.metadata,
+          ...(args.billingOrganizationId
+            ? {
+                [PI_BILLING_ORGANIZATION_ID_METADATA_KEY]: args.billingOrganizationId,
+              }
+            : {}),
+          ...(options.inheritedBillingOrganizationId
+            ? {
+                [PI_BILLING_ORGANIZATION_ID_METADATA_KEY]: options.inheritedBillingOrganizationId,
+              }
+            : {}),
+          ...(args.model ? { model: args.model } : {}),
+        },
         input: {
           systemPrompt: args.systemMessage,
         },
@@ -240,9 +261,11 @@ export const createPiRouteRuntime = ({
 export const createPiFragmentRuntime = ({
   fragment,
   execution,
+  inheritedBillingOrganizationId,
 }: {
   fragment: PiFragment;
   execution: BackofficeExecutionContext;
+  inheritedBillingOrganizationId?: string;
 }): PiRuntime => {
   const callRoute: PiRouteCaller = (method, path, inputOptions) =>
     fragment.callRoute(method, path, inputOptions, {
@@ -250,5 +273,5 @@ export const createPiFragmentRuntime = ({
       propagationContext: null,
     });
 
-  return createPiRuntime(callRoute);
+  return createPiRuntime(callRoute, { inheritedBillingOrganizationId });
 };

--- a/apps/backoffice/app/fragno/runtime-tools/families/pi.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/pi.ts
@@ -65,6 +65,7 @@ const sessionDetailBaseOutputSchema = sessionBaseOutputSchema.extend({
 });
 
 const sessionCreateInputSchema = z.object({
+  billingOrganizationId: z.string().trim().min(1).optional(),
   model: z
     .object({
       provider: z.enum(["openai", "anthropic", "gemini"]),
@@ -130,6 +131,7 @@ const normalizeSteeringMode = (
 };
 
 const parseSessionCreate = defineCliArgsParser<PiSessionCreateArgs>("pi.session.create", {
+  billingOrganizationId: { option: "billing-organization-id" },
   model: { kind: "json", option: "model-json" },
   name: {},
   systemMessage: {},
@@ -181,6 +183,13 @@ const sessionCreateTool = defineBackofficeRuntimeTool({
       help: {
         summary: "pi.session.create creates a new Pi session via the existing Pi session route.",
         options: [
+          {
+            name: "billing-organization-id",
+            valueRequired: true,
+            valueName: "organization-id",
+            description:
+              "Organization billed for a user-scoped session; inherited from the current Pi session when available",
+          },
           {
             name: "model-json",
             valueRequired: true,

--- a/apps/backoffice/app/fragno/runtime-tools/reference.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/reference.test.ts
@@ -212,6 +212,7 @@ describe("runtime tool reference generation", () => {
           outputType: "PiCreateSessionOutput",
           bashCommand: "pi.session.create",
           bashOptions: [
+            "billing-organization-id",
             "model-json",
             "name",
             "system-message",
@@ -2488,6 +2489,7 @@ describe("runtime tool reference generation", () => {
       declare const pi: PiCodemodeProvider;
 
       type PiCreateSessionInput = {
+        billingOrganizationId?: string;
         model?: {
           provider: "openai" | "anthropic" | "gemini";
           name: string;
@@ -5386,6 +5388,7 @@ describe("runtime tool reference generation", () => {
       declare const pi: PiCodemodeProvider;
 
       type PiCreateSessionInput = {
+        billingOrganizationId?: string;
         model?: {
           provider: "openai" | "anthropic" | "gemini";
           name: string;
@@ -5868,6 +5871,7 @@ describe("runtime tool reference generation", () => {
       declare const pi: PiCodemodeProvider;
 
       type PiCreateSessionInput = {
+        billingOrganizationId?: string;
         model?: {
           provider: "openai" | "anthropic" | "gemini";
           name: string;

--- a/apps/backoffice/app/routes/backoffice/files/file-collections.server.test.ts
+++ b/apps/backoffice/app/routes/backoffice/files/file-collections.server.test.ts
@@ -17,7 +17,7 @@ describe("Files overview roots", () => {
   test.each([
     { kind: "user" as const, userId: "user-1" },
     { kind: "project" as const, orgId: "org-1", projectId: "project-1" },
-  ])("shows only workspace files in $kind scope", (scope) => {
-    expect(filesOverviewRootPathsForScope(scope)).toEqual(["/workspace"]);
+  ])("shows static and workspace files in $kind scope", (scope) => {
+    expect(filesOverviewRootPathsForScope(scope)).toEqual(["/static", "/workspace"]);
   });
 });

--- a/apps/backoffice/app/routes/backoffice/files/file-collections.server.ts
+++ b/apps/backoffice/app/routes/backoffice/files/file-collections.server.ts
@@ -28,10 +28,9 @@ export const filesOverviewRootPathsForScope = (
     case "system":
       return ["/system"];
     case "org":
-      return ["/static", "/workspace"];
     case "project":
     case "user":
-      return ["/workspace"];
+      return ["/static", "/workspace"];
   }
 
   throw new Error("Unsupported Backoffice file scope kind.");

--- a/apps/backoffice/app/routes/backoffice/organisation-billing.tsx
+++ b/apps/backoffice/app/routes/backoffice/organisation-billing.tsx
@@ -2,12 +2,7 @@ import { Form, Link } from "react-router";
 
 import { FormContainer } from "@/components/backoffice";
 import { getAuthMe } from "@/fragno/auth/auth-server";
-import {
-  BILLING_TRACKER_DEFAULT_PAGE_SIZE,
-  billingPeriodSchema,
-  type BillingTracker,
-} from "@/fragno/billing";
-import { decodeBillingTrackerCursor } from "@/fragno/billing/pagination";
+import { billingPeriodSchema, type BillingStatementTracker } from "@/fragno/billing";
 import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
 import type { Route } from "./+types/organisation-billing";
@@ -44,7 +39,7 @@ const formatUsd = (quantity: string | undefined) =>
     maximumFractionDigits: 6,
   }).format(Number(BigInt(quantity ?? "0")) / 1_000_000_000);
 
-const formatTrackerQuantity = (tracker: BillingTracker) =>
+const formatTrackerQuantity = (tracker: BillingStatementTracker) =>
   tracker.unit === "nano-usd" ? formatUsd(tracker.quantity) : formatInteger(tracker.quantity);
 
 const formatTimestamp = (value: string) =>
@@ -57,13 +52,7 @@ const formatTimestamp = (value: string) =>
     timeZoneName: "short",
   }).format(new Date(value));
 
-const billingPagePath = (period: string, cursor?: string) => {
-  const search = new URLSearchParams({ period });
-  if (cursor) {
-    search.set("cursor", cursor);
-  }
-  return `?${search.toString()}`;
-};
+const billingPagePath = (period: string) => `?${new URLSearchParams({ period }).toString()}`;
 
 export async function loader({ request, params, context, url }: Route.LoaderArgs) {
   if (!params.orgId) {
@@ -92,31 +81,8 @@ export async function loader({ request, params, context, url }: Route.LoaderArgs
     throw new Response("Invalid billing period.", { status: 400 });
   }
   const period = periodResult.data;
-  const requestedCursor = search.get("cursor");
-  const cursor = requestedCursor === null ? undefined : requestedCursor.trim();
-  const scope = { kind: "org" as const, orgId: params.orgId };
-
-  if (requestedCursor !== null && !cursor) {
-    throw new Response("Invalid billing page cursor.", { status: 400 });
-  }
-  if (cursor) {
-    try {
-      decodeBillingTrackerCursor({ encodedCursor: cursor, scope, period });
-    } catch {
-      throw new Response("Invalid billing page cursor.", { status: 400 });
-    }
-  }
-
   const billing = context.get(BackofficeWorkerContext).runtime.objects.billing.forOrg(params.orgId);
-  const page = await billing.getTrackers({
-    scope,
-    period,
-    pageSize: BILLING_TRACKER_DEFAULT_PAGE_SIZE,
-    cursor,
-    summaryMeter: TOTAL_COST_METER,
-  });
-
-  return { period, cursor: cursor ?? null, ...page };
+  return await billing.getStatement({ period });
 }
 
 export function meta() {
@@ -124,8 +90,8 @@ export function meta() {
 }
 
 export default function BackofficeOrganisationBilling({ loaderData }: Route.ComponentProps) {
-  const { period, cursor, trackers, nextCursor, hasNextPage, summaryTracker } = loaderData;
-  const totalCost = summaryTracker?.quantity;
+  const { period, trackers } = loaderData;
+  const totalCost = trackers.find((tracker) => tracker.meter === TOTAL_COST_METER)?.quantity;
   const previousPeriod = shiftPeriod(period, -1);
   const nextPeriod = shiftPeriod(period, 1);
   const currentPeriod = currentUtcPeriod();
@@ -174,7 +140,7 @@ export default function BackofficeOrganisationBilling({ loaderData }: Route.Comp
       <FormContainer
         eyebrow="Recorded measurements"
         title="Statement ledger"
-        description="Monthly counters maintained by this organisation's Billing object, ordered by meter."
+        description="Monthly totals across organisation, project, and user usage, ordered by meter."
       >
         {trackers.length === 0 ? (
           <div className="border border-dashed border-[color:var(--bo-border-strong)] bg-[var(--bo-panel-2)] px-5 py-8 text-center">
@@ -236,15 +202,6 @@ export default function BackofficeOrganisationBilling({ loaderData }: Route.Comp
             </table>
           </div>
         )}
-
-        {cursor || hasNextPage ? (
-          <div className="mt-4 flex justify-end gap-2">
-            {cursor ? <PageLink to={billingPagePath(period)} label="First page" /> : null}
-            {hasNextPage && nextCursor ? (
-              <PageLink to={billingPagePath(period, nextCursor)} label="Next page →" />
-            ) : null}
-          </div>
-        ) : null}
       </FormContainer>
     </div>
   );

--- a/apps/backoffice/app/routes/backoffice/sessions/create-session-action.ts
+++ b/apps/backoffice/app/routes/backoffice/sessions/create-session-action.ts
@@ -1,9 +1,11 @@
 import { redirect } from "react-router";
 
 import { backofficeContextScopeRoutePath } from "@/backoffice-runtime/scope-codec";
+import { getAuthMe } from "@/fragno/auth/auth-server";
 import { requireBackofficeContext } from "@/fragno/auth/backoffice-principal.server";
 import {
   BACKOFFICE_PI_WORKFLOW_NAME,
+  PI_BILLING_ORGANIZATION_ID_METADATA_KEY,
   findPiModelOption,
   resolvePiModelThinkingLevel,
 } from "@/fragno/pi/pi-shared";
@@ -27,12 +29,19 @@ export async function createSessionAction({ request, params, context }: Route.Ac
   };
   const modelOption = getValue("modelOption");
   const prompt = getValue("prompt");
+  const billingOrganizationId =
+    scope.kind === "user"
+      ? ((await getAuthMe(request, context))?.activeOrganization?.organization.id ?? null)
+      : null;
 
   if (!prompt) {
     return actionError("Write a message to start the session.");
   }
   if (!modelOption) {
     return actionError("Model selection is required.");
+  }
+  if (scope.kind === "user" && !billingOrganizationId) {
+    return actionError("Select an active organization before starting a personal session.");
   }
 
   const [providerRaw, ...modelParts] = modelOption.split("::");
@@ -63,6 +72,9 @@ export async function createSessionAction({ request, params, context }: Route.Ac
     workflowName: BACKOFFICE_PI_WORKFLOW_NAME,
     metadata: {
       model: { provider: modelSelection.provider, name: modelSelection.name },
+      ...(billingOrganizationId
+        ? { [PI_BILLING_ORGANIZATION_ID_METADATA_KEY]: billingOrganizationId }
+        : {}),
     },
     input: {
       thinkingLevel: resolvePiModelThinkingLevel(modelSelection.provider),

--- a/apps/backoffice/app/routes/backoffice/sessions/data.ts
+++ b/apps/backoffice/app/routes/backoffice/sessions/data.ts
@@ -188,7 +188,7 @@ export async function createPiSession(
   scope: BackofficeContextScope,
   payload: {
     workflowName?: string;
-    metadata: { model: PiModel };
+    metadata: { model: PiModel } & Record<string, unknown>;
     input: {
       systemPrompt?: string;
       thinkingLevel?: PiThinkingLevel;

--- a/apps/backoffice/app/routes/backoffice/sessions/new-session-composer.tsx
+++ b/apps/backoffice/app/routes/backoffice/sessions/new-session-composer.tsx
@@ -14,6 +14,7 @@ const INITIAL_HISTORY_COUNT = 2;
 type NewSessionComposerProps = {
   availableModelOptions: PiModelOption[];
   basePath: string;
+  billingOrganization?: { id: string; name: string } | null;
   createError: string | null;
   creating: boolean;
   draftPrompt: string;
@@ -28,6 +29,7 @@ type NewSessionComposerProps = {
 export function NewSessionComposer({
   availableModelOptions,
   basePath,
+  billingOrganization,
   createError,
   creating,
   draftPrompt,
@@ -41,6 +43,11 @@ export function NewSessionComposer({
   const [historyOpen, setHistoryOpen] = useState(true);
   const [showAllHistory, setShowAllHistory] = useState(false);
   const visibleSessions = showAllHistory ? sessions : sessions.slice(0, INITIAL_HISTORY_COUNT);
+  const submissionDisabled =
+    creating ||
+    !draftPrompt.trim() ||
+    availableModelOptions.length === 0 ||
+    billingOrganization === null;
 
   return (
     <div className="backoffice-scroll h-full overflow-y-auto">
@@ -78,7 +85,7 @@ export function NewSessionComposer({
                     event.key !== "Enter" ||
                     event.shiftKey ||
                     event.nativeEvent.isComposing ||
-                    creating
+                    submissionDisabled
                   ) {
                     return;
                   }
@@ -103,11 +110,16 @@ export function NewSessionComposer({
                 value={selectedModelOption}
                 onValueChange={onModelChange}
               />
+              {billingOrganization !== undefined ? (
+                <p className="text-xs text-[var(--bo-muted)] sm:col-start-1 sm:row-start-2">
+                  Billing organization: {billingOrganization?.name ?? "No active organization"}
+                </p>
+              ) : null}
 
               <button
                 type="submit"
-                disabled={creating || !draftPrompt.trim() || availableModelOptions.length === 0}
-                className={`min-h-11 bg-[var(--bo-btn-bg)] px-6 text-xs font-semibold text-[var(--bo-btn-fg)] transition-[background-color,scale] duration-150 ease-out hover:bg-[var(--bo-btn-bg-hover)] disabled:cursor-not-allowed disabled:opacity-35 ${tapScale}`}
+                className={`min-h-11 bg-[var(--bo-btn-bg)] px-6 text-xs font-semibold text-[var(--bo-btn-fg)] transition-[background-color,scale] duration-150 ease-out hover:bg-[var(--bo-btn-bg-hover)] disabled:cursor-not-allowed disabled:opacity-35 sm:col-start-2 sm:row-start-1 sm:self-end ${tapScale}`}
+                disabled={submissionDisabled}
               >
                 {creating ? "Sending…" : "Send"}
               </button>

--- a/apps/backoffice/app/routes/backoffice/sessions/organisation-layout.tsx
+++ b/apps/backoffice/app/routes/backoffice/sessions/organisation-layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "react-router";
 
 import { backofficeContextScopeLabel } from "@/backoffice-runtime/context";
+import { getAuthMe } from "@/fragno/auth/auth-server";
 import { requireBackofficeContext } from "@/fragno/auth/backoffice-principal.server";
 
 import { automationScopeFromRouteParams } from "../automations/scope";
@@ -13,6 +14,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const scope = automationScopeFromRouteParams(params);
   const execution = await requireBackofficeContext(request, context, scope);
 
+  const billingOrganization =
+    scope.kind === "user"
+      ? ((await getAuthMe(request, context))?.activeOrganization?.organization ?? null)
+      : undefined;
   const { runtimeState, runtimeError } = await fetchPiRuntimeState(context, scope);
   let persistenceSource: PiLayoutContext["persistenceSource"] = null;
   let persistenceError: string | null = null;
@@ -29,6 +34,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   return {
     scope,
     scopeLabel: backofficeContextScopeLabel(execution.scope),
+    billingOrganization,
     persistenceSource,
     persistenceError,
     runtimeState,
@@ -45,8 +51,15 @@ export function ErrorBoundary({ error, params }: Route.ErrorBoundaryProps) {
 }
 
 export default function BackofficeScopedPiLayout({ loaderData, matches }: Route.ComponentProps) {
-  const { scope, scopeLabel, persistenceSource, persistenceError, runtimeState, runtimeError } =
-    loaderData;
+  const {
+    scope,
+    scopeLabel,
+    billingOrganization,
+    persistenceSource,
+    persistenceError,
+    runtimeState,
+    runtimeError,
+  } = loaderData;
 
   const currentPath = matches[matches.length - 1]?.pathname ?? "";
   const isSessions = isPiSessionsPath(scope, currentPath);
@@ -64,6 +77,7 @@ export default function BackofficeScopedPiLayout({ loaderData, matches }: Route.
         <Outlet
           context={{
             scope,
+            billingOrganization,
             persistenceSource,
             persistenceError,
             runtimeState,

--- a/apps/backoffice/app/routes/backoffice/sessions/session-workspace.tsx
+++ b/apps/backoffice/app/routes/backoffice/sessions/session-workspace.tsx
@@ -149,6 +149,7 @@ function PiSessionsWorkspaceView({
     <NewSessionComposer
       availableModelOptions={availableModelOptions}
       basePath={basePath}
+      billingOrganization={layoutContext.billingOrganization}
       createError={createError}
       creating={creating}
       draftPrompt={draftPrompt}

--- a/apps/backoffice/app/routes/backoffice/sessions/shared.tsx
+++ b/apps/backoffice/app/routes/backoffice/sessions/shared.tsx
@@ -9,6 +9,7 @@ import { getRouteErrorDebugDetails, getRouteErrorMessage } from "../route-errors
 
 export type PiLayoutContext = {
   scope: BackofficeContextScope;
+  billingOrganization?: { id: string; name: string } | null;
   persistenceSource: AutomationCollectionSource | null;
   persistenceError: string | null;
   runtimeState: PiRuntimeState | null;

--- a/apps/backoffice/workers/automations.do.ts
+++ b/apps/backoffice/workers/automations.do.ts
@@ -80,10 +80,7 @@ import {
   buildMarketplacePublicationWorkflowInstanceId,
   MARKETPLACE_PUBLISH_WORKFLOW_NAME,
 } from "@/fragno/automation/marketplace-publish-workflow";
-import {
-  createPiOperationBillingEvent,
-  PiOperationBillingEventValidationError,
-} from "@/fragno/billing/pi";
+import { recordPiOperationBilling } from "@/fragno/billing/pi";
 import type { DurableHookQueueOptions, DurableHookQueueResponse } from "@/fragno/durable-hooks";
 import type { MarketplaceStaticArtifactEntry } from "@/fragno/marketplace/artifacts";
 import type {
@@ -479,30 +476,22 @@ export class InMemoryAutomationsObject extends RpcTarget implements AutomationsO
           pi: { runtime: pi },
         }),
       onOperationCompleted: async (
-        payload: Parameters<typeof createPiOperationBillingEvent>[0]["payload"],
+        payload: Parameters<NonNullable<PiFragmentConfig["onOperationCompleted"]>>[0],
         context: Parameters<NonNullable<PiFragmentConfig["onOperationCompleted"]>>[1],
       ) => {
-        let event: ReturnType<typeof createPiOperationBillingEvent>;
-        try {
-          event = createPiOperationBillingEvent({
-            scope,
-            payload,
-            hookId: context.hookId.toString(),
-            idempotencyKey: context.idempotencyKey,
-          });
-        } catch (error) {
-          if (error instanceof PiOperationBillingEventValidationError) {
-            return;
-          }
-          throw error;
-        }
-
-        if (scope.kind === "org" || scope.kind === "project") {
-          await this.#runtimeServices.objects.billing.forOrg(scope.orgId).recordEvent(event, {
-            propagationContext: context.capturePropagationContext(),
-          });
-        }
-        // System and user Automations objects have no authoritative organization billing owner.
+        await recordPiOperationBilling({
+          scope,
+          payload,
+          hookId: context.hookId.toString(),
+          idempotencyKey: context.idempotencyKey,
+          recordEvent: async (billingOrganizationId, event) => {
+            await this.#runtimeServices.objects.billing
+              .forOrg(billingOrganizationId)
+              .recordEvent(event, {
+                propagationContext: context.capturePropagationContext(),
+              });
+          },
+        });
       },
     };
   }

--- a/apps/backoffice/workers/billing.do.test.ts
+++ b/apps/backoffice/workers/billing.do.test.ts
@@ -73,6 +73,13 @@ describe("Billing Durable Object", () => {
         scope: userScope,
       }),
     );
+    await billing.recordEvent(
+      event({
+        id: "pi:org-1:project-1:hook-1",
+        scope: { kind: "project", orgId: "org-1", projectId: "project-1" },
+        measurements: [{ meter: "ai.tokens.total", unit: "token", quantity: 40 }],
+      }),
+    );
 
     await expect(
       billing.getTrackers({ scope: userScope, period: "2026-07" }),
@@ -85,6 +92,16 @@ describe("Billing Durable Object", () => {
         }),
       ],
       hasNextPage: false,
+    });
+    await expect(billing.getStatement({ period: "2026-07" })).resolves.toMatchObject({
+      period: "2026-07",
+      trackers: [
+        expect.objectContaining({
+          meter: "ai.tokens.total",
+          quantity: "140",
+          eventCount: "2",
+        }),
+      ],
     });
   });
 

--- a/apps/backoffice/workers/billing.do.ts
+++ b/apps/backoffice/workers/billing.do.ts
@@ -18,6 +18,8 @@ import type {
   BillingEventInput,
   BillingFragment,
   BillingRecordEventResult,
+  BillingStatement,
+  BillingStatementInput,
   BillingTrackerPage,
   BillingTrackerPageInput,
 } from "@/fragno/billing";
@@ -117,6 +119,12 @@ export class InMemoryBillingObject extends RpcTarget implements BillingObject {
     return await fragment.callServices(() => fragment.services.recordEvent(input), context);
   }
 
+  async getStatement(input: BillingStatementInput): Promise<BillingStatement> {
+    this.#requireOwnerScope();
+    const fragment = this.#getFragment();
+    return await fragment.callServices(() => fragment.services.getStatement(input));
+  }
+
   async getTrackers(input: BillingTrackerPageInput): Promise<BillingTrackerPage> {
     await this.#assertScopeAllowed(input.scope, "billing.read-trackers");
     const fragment = this.#getFragment();
@@ -152,6 +160,10 @@ export class Billing extends DurableObject<CloudflareEnv> implements BillingObje
 
   async recordEvent(input: BillingEventInput): Promise<BillingRecordEventResult> {
     return await this.#object.recordEvent(input);
+  }
+
+  async getStatement(input: BillingStatementInput): Promise<BillingStatement> {
+    return await this.#object.getStatement(input);
   }
 
   async getTrackers(input: BillingTrackerPageInput): Promise<BillingTrackerPage> {

--- a/packages/pi-harness/src/pi/types.ts
+++ b/packages/pi-harness/src/pi/types.ts
@@ -93,7 +93,7 @@ export const projectPiSessionFromWorkflowInstance = (instance: {
   };
 };
 
-export type PiOperationCompletedHookPayload = {
+export type PiOperationDetails = {
   actor: unknown;
   workflowName: string;
   sessionId: string;
@@ -101,6 +101,9 @@ export type PiOperationCompletedHookPayload = {
   stepName: string;
   operationId: string;
   operation: PiHarnessOperation["kind"];
+};
+
+export type PiOperationCompletedHookPayload = PiOperationDetails & {
   /**
    * Model calls exposed by Pi as assistant messages during this operation.
    *

--- a/packages/pi-harness/src/pi/workflows/interactive-chat-workflow.scenario.test.ts
+++ b/packages/pi-harness/src/pi/workflows/interactive-chat-workflow.scenario.test.ts
@@ -6,6 +6,7 @@ import {
   type WorkflowScenarioObservedEmission,
 } from "@fragno-dev/workflows/scenario";
 import { selectCanonicalWorkflowStepEmissions } from "@fragno-dev/workflows/step-emission-control";
+import { NonRetryableError } from "@fragno-dev/workflows/workflow";
 import { Type } from "typebox";
 
 import { instantiate } from "@fragno-dev/core";
@@ -35,7 +36,11 @@ import type { PiHarnessFrontendAgentMessage } from "../harness/agent-harness-eve
 import { createModelsForStreamFn } from "../harness/test-models";
 import { createPiHarnessScenarioEventDecoder } from "../pi-test-utils";
 import { definePiTool } from "../tools";
-import { MAX_PI_COMMAND_IMAGE_DATA_LENGTH, type PiFragmentConfig } from "../types";
+import {
+  MAX_PI_COMMAND_IMAGE_DATA_LENGTH,
+  type PiFragmentConfig,
+  type PiOperationDetails,
+} from "../types";
 import { createInteractiveChatWorkflow } from "./interactive-chat-workflow";
 
 const mockModel: Model<Api> = {
@@ -4190,9 +4195,11 @@ describe("Interactive chat workflow scenarios", () => {
         total: 0.00061,
       },
     };
+    const beforeOperation = vi.fn((_input: PiOperationDetails) => undefined);
     const onOperationCompleted = vi.fn();
     const interactiveChatWorkflow = createInteractiveChatWorkflow({
       name: "interactive-chat-route-integration",
+      beforeOperation,
       options: {
         systemPrompt: "You are helpful.",
         model: mockModel,
@@ -4303,12 +4310,27 @@ describe("Interactive chat workflow scenarios", () => {
                 "user",
                 "assistant",
               ]);
+              expect(beforeOperation).toHaveBeenCalledTimes(1);
+              const successfulOperation = beforeOperation.mock.calls[0]?.[0];
+              assert(successfulOperation, "expected successful operation details");
+              expect(successfulOperation).toMatchObject({
+                actor,
+                workflowName: interactiveChatWorkflow.name,
+                sessionId: detail.id,
+                metadata: { runtime: "default" },
+                stepName: expect.stringMatching(/^command:/),
+                operationId: expect.stringContaining(detail.id),
+                operation: "prompt",
+              });
               expect(onOperationCompleted).toHaveBeenCalledTimes(1);
               expect(onOperationCompleted).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                   actor,
                   workflowName: interactiveChatWorkflow.name,
+                  sessionId: successfulOperation.sessionId,
                   metadata: { runtime: "default" },
+                  stepName: successfulOperation.stepName,
+                  operationId: successfulOperation.operationId,
                   operation: "prompt",
                   modelCalls: [expect.objectContaining({ stopReason: "stop" })],
                 }),
@@ -4350,12 +4372,27 @@ describe("Interactive chat workflow scenarios", () => {
                 stopReason: "error",
                 errorMessage: "provider failed",
               });
+              expect(beforeOperation).toHaveBeenCalledTimes(2);
+              const failedOperation = beforeOperation.mock.calls[1]?.[0];
+              assert(failedOperation, "expected failed operation details");
+              expect(failedOperation).toMatchObject({
+                actor,
+                workflowName: interactiveChatWorkflow.name,
+                sessionId: detail.id,
+                metadata: { runtime: "default" },
+                stepName: expect.stringMatching(/^command:/),
+                operationId: expect.stringContaining(detail.id),
+                operation: "prompt",
+              });
               expect(onOperationCompleted).toHaveBeenCalledTimes(2);
               expect(onOperationCompleted).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                   actor,
                   workflowName: interactiveChatWorkflow.name,
+                  sessionId: failedOperation.sessionId,
                   metadata: { runtime: "default" },
+                  stepName: failedOperation.stepName,
+                  operationId: failedOperation.operationId,
                   operation: "prompt",
                   modelCalls: [
                     expect.objectContaining({ stopReason: "error", usage: failedUsage }),
@@ -4363,6 +4400,120 @@ describe("Interactive chat workflow scenarios", () => {
                   usage: failedUsage,
                 }),
                 expect.any(Object),
+              );
+            },
+          }),
+        ],
+      }),
+    );
+  });
+
+  test("rejects an operation before provider invocation and completion hooks", async () => {
+    const streamFn = vi.fn(createTextStreamFn("unexpected response"));
+    const beforeOperation = vi.fn((_input: PiOperationDetails) => {
+      throw new NonRetryableError("BEFORE_OPERATION_REJECTED");
+    });
+    const onOperationCompleted = vi.fn();
+    const interactiveChatWorkflow = createInteractiveChatWorkflow({
+      name: "interactive-chat-before-operation-rejection",
+      beforeOperation,
+      options: {
+        model: mockModel,
+        models: createModelsForStreamFn(mockModel, streamFn),
+      },
+    });
+    const config: PiFragmentConfig = {
+      workflows: [interactiveChatWorkflow],
+      onOperationCompleted,
+    };
+
+    await runScenario(
+      defineScenario({
+        name: "pi-harness-interactive-chat-before-operation-rejection",
+        workflows: createPiWorkflows({ workflows: config.workflows }),
+        vars: () => ({ sessionId: undefined as string | undefined }),
+        harness: {
+          configureFragments: (harness) => ({
+            pi: instantiate(piHarnessDefinition)
+              .withConfig(config)
+              .withRoutes([piRoutesFactory])
+              .withServices({ workflows: harness.fragment.services }),
+          }),
+        },
+        clients: ({ clientConfig }) => ({
+          user: createPiFragmentClients(clientConfig("pi", { runner: "user" })),
+        }),
+        runners: ["agent", "user"],
+        steps: ({ workflow, runners, clients }) => [
+          workflow.read({
+            read: async () => {
+              const session = await clients.user.useCreateSession.mutateQuery({
+                path: { workflowName: interactiveChatWorkflow.name },
+                body: { name: "Rejected operation", input: {} },
+              });
+              assert(session && !Array.isArray(session), "expected session response");
+              return session.id;
+            },
+            storeAs: "sessionId",
+          }),
+          runners.agent.runUntilIdle({
+            workflow: interactiveChatWorkflow.name,
+            instanceId: (ctx) => ctx.vars.sessionId!,
+            reason: "create",
+          }),
+          workflow.read({
+            read: async (ctx) =>
+              clients.user.useCommandSession.mutateQuery({
+                path: {
+                  workflowName: interactiveChatWorkflow.name,
+                  sessionId: ctx.vars.sessionId!,
+                },
+                body: { kind: "prompt", input: { text: "reject this operation" } },
+              }),
+          }),
+          runners.agent.runUntilIdle({
+            workflow: interactiveChatWorkflow.name,
+            instanceId: (ctx) => ctx.vars.sessionId!,
+            reason: "event",
+          }),
+          runners.agent.drainHooks(),
+          workflow.read({
+            read: async (ctx) => ({
+              sessionId: ctx.vars.sessionId!,
+              status: await ctx.state.getStatus(interactiveChatWorkflow.name, ctx.vars.sessionId!),
+              history: await ctx.state.getHistory(
+                interactiveChatWorkflow.name,
+                ctx.vars.sessionId!,
+              ),
+            }),
+            assert: ({ sessionId, status, history }) => {
+              expect(status).toMatchObject({
+                status: "errored",
+                error: {
+                  name: "NonRetryableError",
+                  message: "BEFORE_OPERATION_REJECTED",
+                },
+              });
+              expect(beforeOperation).toHaveBeenCalledTimes(1);
+              expect(beforeOperation).toHaveBeenLastCalledWith({
+                actor: null,
+                workflowName: interactiveChatWorkflow.name,
+                sessionId,
+                metadata: null,
+                stepName: expect.stringMatching(/^command:/),
+                operationId: expect.stringContaining(sessionId),
+                operation: "prompt",
+              });
+              expect(streamFn).not.toHaveBeenCalled();
+              expect(onOperationCompleted).not.toHaveBeenCalled();
+              assert(
+                !history.emissions.some(
+                  (emission) =>
+                    typeof emission.payload === "object" &&
+                    emission.payload !== null &&
+                    "kind" in emission.payload &&
+                    emission.payload.kind === "pi-session-command-start",
+                ),
               );
             },
           }),

--- a/packages/pi-harness/src/pi/workflows/interactive-chat-workflow.ts
+++ b/packages/pi-harness/src/pi/workflows/interactive-chat-workflow.ts
@@ -19,6 +19,7 @@ import type { PiSessionCommandStartEmission } from "../session-command-protocol"
 import {
   PI_SESSION_COMMAND_STEP_PREFIX,
   type PiCompactCommandOutcome,
+  type PiOperationDetails,
   type PiSessionMetadata,
 } from "../types";
 import {
@@ -76,6 +77,11 @@ const logInteractiveChatAssistantError = (
 export type CreateInteractiveChatWorkflowOptions = {
   name?: string;
   commandTimeout?: WorkflowDuration;
+  /**
+   * Runs inside each durable command attempt before Pi invokes a model. Throw to reject the
+   * operation; retries may call this again until the command step commits.
+   */
+  beforeOperation?: (input: PiOperationDetails) => Promise<void> | void;
   options:
     | WorkflowAgentHarnessOptions
     | ((
@@ -192,6 +198,16 @@ export const createInteractiveChatWorkflow = (config: CreateInteractiveChatWorkf
             },
             checkpointTerminalAssistantError: true,
             runDurableStep: async () => {
+              await config.beforeOperation?.({
+                actor: params.actor ?? null,
+                workflowName,
+                sessionId: event.instanceId,
+                metadata: params.metadata ?? null,
+                stepName: invocation.stepName,
+                operationId: invocation.operationId,
+                operation: command.kind,
+              });
+
               tx.emit({
                 kind: "pi-session-command-start",
                 command: { commandId: command.commandId, kind: command.kind },


### PR DESCRIPTION
- **fix(backoffice): require organization membership for admins**
- **feat(pi-harness): add pre-operation workflow callback**
- **feat(backoffice): expose codemode declarations beyond org scopes**
- **feat(backoffice): aggregate organization billing statements**
- **feat(backoffice): bill personal Pi sessions to organizations**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monthly billing statements aggregating organization, project, and personal usage.
  * Added billing organization selection and authorization for personal Pi sessions.
  * Added a pre-operation callback for interactive chat workflows.
  * Project workspaces now include both static files and workspace files.
* **Bug Fixes**
  * Improved scope-based access checks to prevent unauthorized organization access.
  * Ensured billing is assigned to the correct organization and inherited across related sessions.
* **UI Improvements**
  * Session creation now displays the selected billing organization and prevents creation when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->