### PR TITLE
fix(db,workflows): retry wrapped Durable Object conflicts

### DIFF
--- a/.changeset/durable-object-workflow-conflicts.md
+++ b/.changeset/durable-object-workflow-conflicts.md
@@ -1,0 +1,6 @@
+---
+"@fragno-dev/db": patch
+"@fragno-dev/workflows": patch
+---
+
+fix: retry workflow step inserts when Durable Object query errors wrap SQLite unique conflicts.

--- a/apps/backoffice/workers/vitest-env.ts
+++ b/apps/backoffice/workers/vitest-env.ts
@@ -9,3 +9,7 @@ export default {
 export class OutboxHarnessDurableObject extends DurableObject {
   async alarm() {}
 }
+
+export class WorkflowsHarnessDurableObject extends DurableObject {
+  async alarm() {}
+}

--- a/apps/backoffice/workers/workflows-runner.cloudflare.test.ts
+++ b/apps/backoffice/workers/workflows-runner.cloudflare.test.ts
@@ -1,0 +1,203 @@
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+
+import { SqlAdapter } from "@fragno-dev/db/adapters/sql";
+import { DurableObjectDialect } from "@fragno-dev/db/dialects/durable-object";
+import { CloudflareDurableObjectsDriverConfig } from "@fragno-dev/db/drivers";
+import {
+  createWorkflowsTestRuntime,
+  runWorkflowsTestTick,
+  type WorkflowsTestRunPayload,
+} from "@fragno-dev/workflows/test";
+import {
+  defineWorkflow,
+  type WorkflowsFragmentConfig,
+  type WorkflowsRegistry,
+} from "@fragno-dev/workflows/workflow";
+import { env } from "cloudflare:workers";
+
+import { migrate } from "@fragno-dev/db";
+import { createWorkflowsFragment } from "@fragno-dev/workflows";
+
+type WorkflowsCloudflareTestEnv = typeof env & {
+  WORKFLOWS_HARNESS: DurableObjectNamespace;
+};
+
+type WorkflowsRuntime = ReturnType<typeof createWorkflowsFragment>;
+
+function wrapDurableObjectSqlErrors(state: DurableObjectState): DurableObjectState {
+  const sourceSql = state.storage.sql;
+  const sql: SqlStorage = {
+    exec<T extends Record<string, SqlStorageValue>>(
+      query: string,
+      ...bindings: SqlStorageValue[]
+    ): SqlStorageCursor<T> {
+      try {
+        return sourceSql.exec<T>(query, ...bindings);
+      } catch (cause) {
+        // Some Durable Object hosts preserve the SQLite error only as the cause of a query error.
+        throw new Error(`Durable Object SQLite rejected query: ${query}`, { cause });
+      }
+    },
+    get databaseSize() {
+      return sourceSql.databaseSize;
+    },
+    Cursor: sourceSql.Cursor,
+    Statement: sourceSql.Statement,
+  };
+
+  return {
+    id: state.id,
+    storage: {
+      transaction: state.storage.transaction.bind(state.storage),
+      sql,
+    },
+  } as DurableObjectState;
+}
+
+function createDurableObjectWorkflowsRuntime<TRegistry extends WorkflowsRegistry>(
+  state: DurableObjectState,
+  config: WorkflowsFragmentConfig<TRegistry>,
+) {
+  const adapter = new SqlAdapter({
+    dialect: new DurableObjectDialect({ ctx: wrapDurableObjectSqlErrors(state) }),
+    driverConfig: new CloudflareDurableObjectsDriverConfig(),
+  });
+  const fragment = createWorkflowsFragment(config, { databaseAdapter: adapter });
+  return { fragment };
+}
+
+async function runWorkflowService<TResult>(
+  fragment: WorkflowsRuntime,
+  createServiceCall: () => unknown,
+): Promise<TResult> {
+  return (await fragment.inContext(async function () {
+    return await this.handlerTx()
+      .withServiceCalls(() => [createServiceCall() as never])
+      .transform(({ serviceResult: [result] }) => result as TResult)
+      .execute();
+  })) as TResult;
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function buildWorkflowTickPayload(
+  workflowName: string,
+  instanceId: string,
+  reason: WorkflowsTestRunPayload["reason"],
+): WorkflowsTestRunPayload {
+  return { workflowName, instanceId, reason };
+}
+
+describe("Workflows Runner with Durable Object SQLite", () => {
+  test("concurrent create and event ticks retry a Durable Object-wrapped wait-step conflict", async () => {
+    const namespace = (env as WorkflowsCloudflareTestEnv).WORKFLOWS_HARNESS;
+    const stub = namespace.get(namespace.idFromName("concurrent-create-event-step-insert"));
+
+    await runInDurableObject(stub, async (_instance, state) => {
+      const firstPassageStarted = createDeferred();
+      const releaseFirstPassage = createDeferred();
+      const eventPassageStarted = createDeferred();
+      const releaseEventPassage = createDeferred();
+      let passageCount = 0;
+
+      const ConcurrentCreateEventWorkflow = defineWorkflow(
+        { name: "durable-object-concurrent-create-event-workflow" },
+        async (_event, step) => {
+          passageCount += 1;
+          if (passageCount === 1) {
+            firstPassageStarted.resolve();
+            await releaseFirstPassage.promise;
+          }
+
+          const command = await step.waitForEvent<{ text: string }>("wait-command", {
+            type: "command",
+            onConsume: async () => {
+              eventPassageStarted.resolve();
+              await releaseEventPassage.promise;
+            },
+          });
+          return command.payload;
+        },
+      );
+      const workflows = { CONCURRENT_CREATE_EVENT: ConcurrentCreateEventWorkflow };
+      const config = {
+        workflows,
+        runtime: createWorkflowsTestRuntime(),
+        autoTickHooks: false,
+      } satisfies WorkflowsFragmentConfig<typeof workflows>;
+      const mainRuntime = createDurableObjectWorkflowsRuntime(state, config);
+      const createRunner = createDurableObjectWorkflowsRuntime(state, config);
+      const eventRunner = createDurableObjectWorkflowsRuntime(state, config);
+      await migrate(mainRuntime.fragment);
+
+      const { id: instanceId } = await runWorkflowService<{ id: string }>(
+        mainRuntime.fragment,
+        () =>
+          mainRuntime.fragment.services.createInstance(ConcurrentCreateEventWorkflow.name, {
+            id: "durable-object-concurrent-create-event-1",
+          }),
+      );
+      const createTick = runWorkflowsTestTick({
+        fragment: createRunner.fragment,
+        config,
+        payload: buildWorkflowTickPayload(ConcurrentCreateEventWorkflow.name, instanceId, "create"),
+      });
+      await firstPassageStarted.promise;
+
+      await runWorkflowService(mainRuntime.fragment, () =>
+        mainRuntime.fragment.services.sendEvent(ConcurrentCreateEventWorkflow.name, instanceId, {
+          type: "command",
+          payload: { text: "hello" },
+        }),
+      );
+      const eventTick = runWorkflowsTestTick({
+        fragment: eventRunner.fragment,
+        config,
+        payload: buildWorkflowTickPayload(ConcurrentCreateEventWorkflow.name, instanceId, "event"),
+      });
+      await eventPassageStarted.promise;
+
+      releaseFirstPassage.resolve();
+      await createTick;
+      releaseEventPassage.resolve();
+
+      await expect(eventTick).resolves.toBeGreaterThanOrEqual(0);
+      await expect(
+        runWorkflowService(mainRuntime.fragment, () =>
+          mainRuntime.fragment.services.getInstanceStatus(
+            ConcurrentCreateEventWorkflow.name,
+            instanceId,
+          ),
+        ),
+      ).resolves.toMatchObject({ status: "complete", output: { text: "hello" } });
+      await expect(
+        runWorkflowService(mainRuntime.fragment, () =>
+          mainRuntime.fragment.services.listHistory({
+            workflowName: ConcurrentCreateEventWorkflow.name,
+            instanceId,
+          }),
+        ),
+      ).resolves.toMatchObject({
+        steps: [
+          expect.objectContaining({
+            stepKey: "waitForEvent:wait-command",
+            status: "completed",
+          }),
+        ],
+        events: [
+          expect.objectContaining({
+            type: "command",
+            consumedByStepKey: "waitForEvent:wait-command",
+          }),
+        ],
+      });
+    });
+  });
+});

--- a/apps/backoffice/wrangler.vitest.jsonc
+++ b/apps/backoffice/wrangler.vitest.jsonc
@@ -15,12 +15,16 @@
         "name": "OUTBOX_HARNESS",
         "class_name": "OutboxHarnessDurableObject",
       },
+      {
+        "name": "WORKFLOWS_HARNESS",
+        "class_name": "WorkflowsHarnessDurableObject",
+      },
     ],
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["OutboxHarnessDurableObject"],
+      "new_sqlite_classes": ["OutboxHarnessDurableObject", "WorkflowsHarnessDurableObject"],
     },
   ],
 }

--- a/packages/fragment-workflows/src/runner.test.ts
+++ b/packages/fragment-workflows/src/runner.test.ts
@@ -2682,6 +2682,87 @@ describe("Workflows Runner", () => {
     assert(status.status === "complete");
   });
 
+  test("concurrent create and event ticks converge on the first committed wait step", async () => {
+    const firstPassageStarted = Promise.withResolvers<void>();
+    const releaseFirstPassage = Promise.withResolvers<void>();
+    const eventPassageStarted = Promise.withResolvers<void>();
+    const releaseEventPassage = Promise.withResolvers<void>();
+    let passageCount = 0;
+
+    const ConcurrentCreateEventWorkflow = defineWorkflow(
+      { name: "concurrent-create-event-workflow" },
+      async (_event, step) => {
+        passageCount += 1;
+        if (passageCount === 1) {
+          firstPassageStarted.resolve();
+          await releaseFirstPassage.promise;
+        }
+
+        const command = await step.waitForEvent<{ text: string }>("wait-command", {
+          type: "command",
+          onConsume: async () => {
+            eventPassageStarted.resolve();
+            await releaseEventPassage.promise;
+          },
+        });
+        return command.payload;
+      },
+    );
+
+    const harness = await createWorkflowsTestHarness({
+      workflows: { CONCURRENT_CREATE_EVENT: ConcurrentCreateEventWorkflow },
+      adapter: { type: "kysely-sqlite" },
+      testBuilder: buildDatabaseFragmentsTest(),
+      autoTickHooks: false,
+    });
+
+    const instanceId = await harness.createInstance("CONCURRENT_CREATE_EVENT", {
+      id: "concurrent-create-event-1",
+    });
+    const [instance] = (
+      await harness.db
+        .createUnitOfWork("read-concurrent-create-event-instance")
+        .forSchema(workflowsSchema)
+        .find("workflow_instance", (b) => b.whereIndex("primary"))
+        .executeRetrieve()
+    )[0];
+    assert(instance);
+
+    const createTick = harness.tick(buildPayload(instance, "create"));
+    await firstPassageStarted.promise;
+
+    await harness.sendEvent("CONCURRENT_CREATE_EVENT", instanceId, {
+      type: "command",
+      payload: { text: "hello" },
+    });
+    const eventTick = harness.tick(buildPayload(instance, "event"));
+    await eventPassageStarted.promise;
+
+    releaseFirstPassage.resolve();
+    await createTick;
+    releaseEventPassage.resolve();
+
+    await expect(eventTick).resolves.toBeGreaterThanOrEqual(0);
+    await expect(harness.getStatus("CONCURRENT_CREATE_EVENT", instanceId)).resolves.toMatchObject({
+      status: "complete",
+      output: { text: "hello" },
+    });
+    await expect(harness.getHistory("CONCURRENT_CREATE_EVENT", instanceId)).resolves.toMatchObject({
+      steps: [
+        expect.objectContaining({
+          stepKey: "waitForEvent:wait-command",
+          status: "completed",
+        }),
+      ],
+      events: [
+        expect.objectContaining({
+          type: "command",
+          consumedByStepKey: "waitForEvent:wait-command",
+        }),
+      ],
+    });
+  });
+
   test("terminate during in-flight tick does not get overwritten", async () => {
     // report: terminating while a tick is running should persist termination over completion.
     const started = Promise.withResolvers<void>();

--- a/packages/fragment-workflows/src/test.ts
+++ b/packages/fragment-workflows/src/test.ts
@@ -146,6 +146,36 @@ export type WorkflowsTestRunPayload = Omit<WorkflowEnqueuedHookPayload, "instanc
   instanceRef?: string;
 };
 
+/** Run one workflow tick against a concrete fragment runtime and database adapter. */
+export async function runWorkflowsTestTick<TRegistry extends WorkflowsRegistry>(options: {
+  fragment: WorkflowsFragment<TRegistry>;
+  config: WorkflowsFragmentConfig<TRegistry> & { workflows: TRegistry };
+  payload: WorkflowsTestRunPayload;
+}): Promise<number> {
+  const { fragment, config, payload } = options;
+  const handlerTx = ((...args: Parameters<DatabaseHandlerTx>) =>
+    fragment.inContext(function (this: { handlerTx: DatabaseHandlerTx }) {
+      return this.handlerTx(...args);
+    })) as DatabaseHandlerTx;
+
+  return await fragment.inContext(function () {
+    return runWorkflowsTick({
+      handlerTx,
+      busHandlerTx: handlerTx,
+      workflows: config.workflows,
+      createExecutionId: () => config.runtime.random.uuid(),
+      createEpoch: () => config.runtime.random.uuid(),
+      stepEmissions: fragment.$internal.deps.stepEmissions,
+      payload: {
+        ...payload,
+        instanceRef:
+          payload.instanceRef ?? buildScopedInstanceRowId(payload.workflowName, payload.instanceId),
+        timestamp: config.runtime.time.now(),
+      },
+    });
+  });
+}
+
 export type WorkflowsTestRunner<
   TRegistry extends WorkflowsRegistry = WorkflowsRegistry,
   TFragments extends Record<string, AnyFragmentResult> = Record<string, AnyFragmentResult>,
@@ -691,12 +721,12 @@ export async function createWorkflowsTestHarness<
       },
     };
   }
-  const config: WorkflowsFragmentConfig<TRegistry> = {
+  const config = {
     workflows,
     runtime,
     autoTickHooks: options.autoTickHooks,
     ...options.fragmentConfig,
-  };
+  } satisfies WorkflowsFragmentConfig<TRegistry>;
   const baseBuilder = options.testBuilder.withTestAdapter(adapterConfig);
   const configuredBuilder = options.configureBuilder
     ? options.configureBuilder(baseBuilder)
@@ -723,10 +753,6 @@ export async function createWorkflowsTestHarness<
   const getWorkflowFragment = () => fragmentsWithWorkflows.workflows;
   const getFragment = () => getWorkflowFragment().fragment;
   const getDb = () => getWorkflowFragment().db;
-  const workflowsByName = new Map<string, WorkflowRegistryEntry>();
-  for (const entry of Object.values(workflows)) {
-    workflowsByName.set(entry.name, entry);
-  }
 
   const runWorkflowService = async <T>(createServiceCall: () => unknown) =>
     await getFragment().inContext(async function () {
@@ -741,39 +767,15 @@ export async function createWorkflowsTestHarness<
     "fragments" | "recreateFragments" | "inContext"
   >;
 
-  const getWorkflowFragmentFromRuntime = (runnerRuntime: RunnerRuntime) =>
-    runnerRuntime.fragments.workflows.fragment;
-
-  const completePayload = (payload: WorkflowsTestRunPayload): WorkflowEnqueuedHookPayload => ({
-    ...payload,
-    instanceRef:
-      payload.instanceRef ?? buildScopedInstanceRowId(payload.workflowName, payload.instanceId),
-  });
-
-  const runTick = async (
+  const runTestTickForRuntime = async (
     runnerRuntime: RunnerRuntime,
     payload: WorkflowsTestRunPayload,
-    stepEmissions: WorkflowsFragmentConfig<TRegistry>["stepEmissions"],
-  ) => {
-    const workflowFragment = getWorkflowFragmentFromRuntime(runnerRuntime);
-    return await workflowFragment.inContext(function () {
-      const handlerTx = ((...args: Parameters<DatabaseHandlerTx>) =>
-        workflowFragment.inContext(function (this: { handlerTx: DatabaseHandlerTx }) {
-          return this.handlerTx(...args);
-        })) as DatabaseHandlerTx;
-
-      return runWorkflowsTick({
-        handlerTx,
-        busHandlerTx: handlerTx,
-        workflows,
-        workflowsByName,
-        createExecutionId: () => runtime.random.uuid(),
-        createEpoch: () => runtime.random.uuid(),
-        stepEmissions,
-        payload: { ...completePayload(payload), timestamp: clock.now() },
-      });
+  ) =>
+    await runWorkflowsTestTick({
+      fragment: runnerRuntime.fragments.workflows.fragment,
+      config,
+      payload,
     });
-  };
 
   const mainRunnerRuntime: RunnerRuntime = {
     fragments: fragmentsWithWorkflows,
@@ -797,11 +799,7 @@ export async function createWorkflowsTestHarness<
 
     const tick = async (payload: WorkflowsTestRunPayload) => {
       const runnerRuntime = await getRunnerRuntime();
-      return await runTick(
-        runnerRuntime,
-        payload,
-        runnerRuntime.fragments.workflows.fragment.$internal.deps.stepEmissions,
-      );
+      return await runTestTickForRuntime(runnerRuntime, payload);
     };
 
     const runUntilIdle = async (
@@ -851,7 +849,7 @@ export async function createWorkflowsTestHarness<
 
   const defaultRunner = createRunner(mainRunnerRuntime);
   const tick = async (payload: WorkflowsTestRunPayload) =>
-    await runTick(mainRunnerRuntime, payload, config.stepEmissions);
+    await runTestTickForRuntime(mainRunnerRuntime, payload);
   const runUntilIdle = async (payload: WorkflowsTestRunPayload, options?: RunUntilIdleOptions) => {
     const maxTicks = options?.maxTicks ?? 25;
     let ticks = 0;

--- a/packages/fragno-db/src/adapters/generic-sql/driver-config.test.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/driver-config.test.ts
@@ -28,6 +28,28 @@ describe("DriverConfig.normalizeError", () => {
     expect(normalized).toMatchObject({ kind: "unique", table: "users", columns: ["email"] });
   });
 
+  it("normalizes Durable Object query errors with a SQLite unique-constraint cause", () => {
+    const config = new CloudflareDurableObjectsDriverConfig();
+    const sqliteError = withProps(
+      "UNIQUE constraint failed: workflow_step_workflows.instanceRef, workflow_step_workflows.stepKey",
+      { code: "SQLITE_CONSTRAINT_UNIQUE" },
+    );
+    const queryError = new Error(
+      'Durable Object SQLite rejected query: insert into "workflow_step_workflows" (...) values (...)',
+      { cause: sqliteError },
+    );
+
+    const normalized = config.normalizeError(queryError);
+
+    expect(normalized).toBeInstanceOf(DatabaseConstraintError);
+    expect(normalized).toMatchObject({
+      kind: "unique",
+      table: "workflow_step_workflows",
+      columns: ["instanceRef", "stepKey"],
+      cause: queryError,
+    });
+  });
+
   it("extracts columns from prefixed sqlite-wasm unique errors", () => {
     const config = new SQLocalDriverConfig();
     const normalized = config.normalizeError(

--- a/packages/fragno-db/src/adapters/generic-sql/driver-config.ts
+++ b/packages/fragno-db/src/adapters/generic-sql/driver-config.ts
@@ -255,7 +255,23 @@ export class CloudflareDurableObjectsDriverConfig extends DriverConfig {
   override readonly outboxVersionstampStrategy = "insert-on-conflict-returning";
 
   override normalizeError(error: unknown): Error {
-    return normalizeSqliteError(error);
+    const normalizedError = normalizeSqliteError(error);
+    if (normalizedError !== error || !(error instanceof Error) || error.cause === undefined) {
+      return normalizedError;
+    }
+
+    const normalizedCause = normalizeSqliteError(error.cause);
+    if (normalizedCause instanceof DatabaseConstraintError) {
+      return new DatabaseConstraintError({
+        kind: normalizedCause.kind,
+        table: normalizedCause.table,
+        constraint: normalizedCause.constraint,
+        columns: normalizedCause.columns,
+        cause: error,
+      });
+    }
+
+    return normalizedError;
   }
 }
 


### PR DESCRIPTION
Normalize SQLite constraint errors found in Durable Object error causes
so optimistic workflow step inserts are retried instead of marking
instances errored. Add generic and Cloudflare integration coverage, plus
a reusable workflow test-tick primitive shared by the test harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of database conflicts in Cloudflare Durable Objects.
  - Workflow steps now retry safely when concurrent operations encounter unique-constraint conflicts.
  - Prevented duplicate event consumption during concurrent workflow processing.

- **Testing**
  - Added coverage for concurrent workflow execution, retry completion, event handling, and final workflow results.
  - Added validation for clearer database constraint error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->