### PR TITLE
wilco/bo event source

### DIFF
--- a/.changeset/browser-persistence-diagnostics.md
+++ b/.changeset/browser-persistence-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/tanstack-db-adapter": patch
+---
+
+fix browser persistence startup diagnostics for stalled OPFS initialization

--- a/.changeset/webhook-endpoint-change-hooks.md
+++ b/.changeset/webhook-endpoint-change-hooks.md
@@ -1,0 +1,5 @@
+---
+"@fragno-dev/api-fragment": patch
+---
+
+feat emit durable hooks when webhook endpoints are created or updated

--- a/apps/backoffice/app/backoffice-runtime/object-registry.ts
+++ b/apps/backoffice/app/backoffice-runtime/object-registry.ts
@@ -37,6 +37,10 @@ import type {
 } from "@/fragno/automation";
 import type { AutomationActor } from "@/fragno/automation/actors";
 import type {
+  AutomationEventSource,
+  AutomationEventSourceInput,
+} from "@/fragno/automation/event-sources";
+import type {
   BindExternalIdentityInput,
   BindExternalIdentityResult,
   GetExternalIdentityBindingInput,
@@ -287,6 +291,9 @@ export type AutomationsObject = FetchObject &
       input: GetExternalIdentityBindingInput,
       context: BackofficeActionRpcContext,
     ): Promise<ResolveExternalIdentityResult>;
+    listEventSources(): Promise<AutomationEventSource[]>;
+    getEventSource(input: { source: string }): Promise<AutomationEventSource | null>;
+    ensureEventSource(input: AutomationEventSourceInput): Promise<AutomationEventSource>;
     listEventDefinitions(): Promise<AutomationEventDefinition[]>;
     getEventDefinition(input: {
       source: string;

--- a/apps/backoffice/app/fragno/api.ts
+++ b/apps/backoffice/app/fragno/api.ts
@@ -10,6 +10,7 @@ export type ApiConfig = Pick<
   | "onConnectionChanged"
   | "onConnectionDeleted"
   | "onConnectionAvailable"
+  | "onWebhookEndpointChanged"
   | "onWebhookReceived"
 >;
 
@@ -24,6 +25,7 @@ export function createApiServer(
       onConnectionChanged: config.onConnectionChanged,
       onConnectionDeleted: config.onConnectionDeleted,
       onConnectionAvailable: config.onConnectionAvailable,
+      onWebhookEndpointChanged: config.onWebhookEndpointChanged,
       onWebhookReceived: config.onWebhookReceived,
     },
     {

--- a/apps/backoffice/app/fragno/automation/definition.ts
+++ b/apps/backoffice/app/fragno/automation/definition.ts
@@ -38,6 +38,7 @@ import {
   type AutomationEventDefinition,
 } from "./event-definitions";
 import { createAutomationEventDefinitionServices } from "./event-definitions-storage-runtime";
+import { createAutomationEventSourceServices } from "./event-sources-storage-runtime";
 import { createAutomationEventServices } from "./events-storage-runtime";
 import { createExternalIdentityBindingServices } from "./external-identity-bindings-storage-runtime";
 import type { AutomationEventIngestionPayload, AutomationHookUnitOfWork } from "./internal-hooks";
@@ -386,6 +387,7 @@ export const automationFragmentDefinition = defineFragment<AutomationFragmentCon
     });
     const routeServices = createAutomationRouteServices(defineService);
     const eventServices = createAutomationEventServices(defineService);
+    const eventSourceServices = createAutomationEventSourceServices(defineService);
     const eventDefinitionServices = createAutomationEventDefinitionServices(defineService);
     const marketplaceIngestionServices =
       createAutomationMarketplaceIngestionServices(defineService);
@@ -397,6 +399,7 @@ export const automationFragmentDefinition = defineFragment<AutomationFragmentCon
       ...sandboxServices,
       ...routeServices,
       ...eventServices,
+      ...eventSourceServices,
       ...eventDefinitionServices,
       ...marketplaceIngestionServices,
       ...externalIdentityBindingServices,

--- a/apps/backoffice/app/fragno/automation/event-sources-storage-runtime.ts
+++ b/apps/backoffice/app/fragno/automation/event-sources-storage-runtime.ts
@@ -1,0 +1,78 @@
+import type { DatabaseServiceContext } from "@fragno-dev/db";
+
+import {
+  automationEventSourceInputSchema,
+  buildAutomationEventSourceId,
+  type AutomationEventSourceInput,
+} from "./event-sources";
+import { automationFragmentSchema } from "./schema";
+
+type AutomationEventSourceServiceContext = DatabaseServiceContext<Record<string, never>>;
+
+export function createAutomationEventSourceServices(
+  defineService: <TService>(
+    service: TService & ThisType<AutomationEventSourceServiceContext>,
+  ) => TService,
+) {
+  return defineService({
+    listEventSources() {
+      return this.serviceTx(automationFragmentSchema)
+        .retrieve((uow) =>
+          uow.find("automation_event_source", (b) =>
+            b.whereIndex("primary").orderByIndex("idx_automation_event_source_source", "asc"),
+          ),
+        )
+        .transformRetrieve(([sources]) => sources)
+        .build();
+    },
+
+    getEventSource(input: { source: string }) {
+      const id = buildAutomationEventSourceId(input.source);
+      return this.serviceTx(automationFragmentSchema)
+        .retrieve((uow) =>
+          uow.findFirst("automation_event_source", (b) =>
+            b.whereIndex("primary", (eb) => eb("id", "=", id)),
+          ),
+        )
+        .transformRetrieve(([source]) => source ?? null)
+        .build();
+    },
+
+    ensureEventSource(input: AutomationEventSourceInput) {
+      const source = automationEventSourceInputSchema.parse(input);
+      const id = buildAutomationEventSourceId(source.source);
+
+      return this.serviceTx(automationFragmentSchema)
+        .retrieve((uow) =>
+          uow.findFirst("automation_event_source", (b) =>
+            b.whereIndex("primary", (eb) => eb("id", "=", id)),
+          ),
+        )
+        .mutate(({ uow, retrieveResult: [existing] }) => {
+          if (existing) {
+            uow.update("automation_event_source", existing.id, (b) =>
+              b
+                .set({
+                  label: source.label,
+                  description: source.description,
+                  category: source.category,
+                  updatedAt: b.now(),
+                })
+                .check(),
+            );
+          } else {
+            const now = uow.now();
+            uow.create("automation_event_source", {
+              id,
+              ...source,
+              createdAt: now,
+              updatedAt: now,
+            });
+          }
+
+          return { id, ...source };
+        })
+        .build();
+    },
+  });
+}

--- a/apps/backoffice/app/fragno/automation/event-sources.ts
+++ b/apps/backoffice/app/fragno/automation/event-sources.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const automationEventSourceCategorySchema = z.enum([
+  "app_activity",
+  "backoffice_activity",
+  "lifecycle",
+  "custom",
+]);
+
+export const automationEventSourceSchema = z.object({
+  id: z.string().trim().min(1),
+  source: z.string().trim().min(1),
+  label: z.string().trim().min(1),
+  description: z.string(),
+  category: automationEventSourceCategorySchema,
+  createdAt: z.iso.datetime().optional(),
+  updatedAt: z.iso.datetime().optional(),
+});
+
+export const automationEventSourceInputSchema = z.object({
+  source: z.string().trim().min(1),
+  label: z.string().trim().min(1),
+  description: z.string(),
+  category: automationEventSourceCategorySchema,
+});
+
+export type AutomationEventSource = z.infer<typeof automationEventSourceSchema>;
+export type AutomationEventSourceInput = z.input<typeof automationEventSourceInputSchema>;
+
+/** Encodes user-defined source names so synchronized primary keys remain stable and URL-safe. */
+export function buildAutomationEventSourceId(source: string): string {
+  return encodeURIComponent(source);
+}

--- a/apps/backoffice/app/fragno/automation/scenario-api-webhooks.test.ts
+++ b/apps/backoffice/app/fragno/automation/scenario-api-webhooks.test.ts
@@ -14,11 +14,16 @@ const { DurableObject, RpcTarget, WorkerEntrypoint } = vi.hoisted(() => {
 
 vi.mock("cloudflare:workers", () => ({ DurableObject, RpcTarget, WorkerEntrypoint }));
 
+import { apiSchema } from "@fragno-dev/api-fragment/schema";
 import { RouterContextProvider } from "react-router";
 import { z } from "zod";
 
+import { migrate } from "@fragno-dev/db";
+
 import { BackofficeKernel } from "@/backoffice-runtime/kernel";
+import { encodeBackofficeObjectAddress, org } from "@/backoffice-runtime/object-registry";
 import { backofficeContextScopeSinglePathSegment } from "@/backoffice-runtime/scope-codec";
+import { createApiServer } from "@/fragno/api";
 import { bytesToHex } from "@/lib/crypto";
 import { action as receiveApiWebhook } from "@/routes/api/api";
 import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
@@ -35,6 +40,11 @@ const ENDPOINT_ID = "slack";
 const SLACK_SIGNING_SECRET = "scenario-slack-signing-secret";
 const SLACK_CHALLENGE = "scenario-slack-challenge";
 const SLACK_DELIVERY_ID = "Ev-scenario-123";
+const ACME_ENDPOINT_ID = "acme";
+const ACME_DELIVERY_ID = "evt-acme-123";
+const LEGACY_PUT_ENDPOINT_ID = "legacy-put";
+const LEGACY_PATCH_ENDPOINT_ID = "legacy-patch";
+const FRESH_ENDPOINT_ID = "fresh-webhook";
 
 const slackChallengeBody = {
   type: "url_verification",
@@ -44,6 +54,12 @@ const slackDeliveryBody = {
   type: "event_callback",
   event_id: SLACK_DELIVERY_ID,
   event: { type: "message", text: "Scenario webhook delivery" },
+};
+const acmeDeliveryBody = {
+  id: ACME_DELIVERY_ID,
+  type: "record.created",
+  recordId: "rec-123",
+  data: { status: "new" },
 };
 
 const automationEventPageSchema = z.object({
@@ -59,6 +75,10 @@ type CapturedWebhookResponse = {
 type ApiWebhookScenarioVars = {
   rejectedChallenge: CapturedWebhookResponse | null;
   acceptedChallenge: CapturedWebhookResponse | null;
+  acceptedDelivery: CapturedWebhookResponse | null;
+};
+
+type EventSourceScenarioVars = {
   acceptedDelivery: CapturedWebhookResponse | null;
 };
 
@@ -158,18 +178,397 @@ const postSlackWebhook = ({
   },
 });
 
-const listApiWebhookEvents = async (ctx: BackofficeScenarioContext) => {
+const postAcmeWebhookDelivery = (): BackofficeScenarioStep => ({
+  kind: "when",
+  type: "api.webhook.post",
+  label: "post an Acme record-created webhook delivery",
+  async run(untypedContext) {
+    const ctx = untypedContext as BackofficeScenarioContext<EventSourceScenarioVars>;
+    const scopeSegment = backofficeContextScopeSinglePathSegment({
+      kind: "org",
+      orgId: ORG_ID,
+    });
+    const response = await receiveApiWebhook({
+      request: new Request(
+        `https://example.com/api/http/org%3A${ORG_ID}/webhooks/endpoints/${ACME_ENDPOINT_ID}/events`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(acmeDeliveryBody),
+        },
+      ),
+      context: createScenarioRouterContext(ctx),
+      params: { scopeSegment },
+    } as unknown as Parameters<typeof receiveApiWebhook>[0]);
+
+    ctx.vars.acceptedDelivery = {
+      status: response.status,
+      contentType: response.headers.get("content-type"),
+      body: await response.text(),
+    };
+  },
+});
+
+const listApiEvents = async (ctx: BackofficeScenarioContext, eventType: string) => {
   const response = await ctx.runtime.objects.automations
     .forOrg(ORG_ID)
     .fetch(new Request("https://automations.test/api/automations/events?limit=100"));
   assert(response.ok);
   const page = automationEventPageSchema.parse(await response.json());
-  return page.events.filter(
-    (event) => event.source === "api" && event.eventType === "webhook.received",
-  );
+  return page.events.filter((event) => event.source === "api" && event.eventType === eventType);
 };
 
+const seedLegacyWebhookEndpoints = (): BackofficeScenarioStep => ({
+  kind: "given",
+  type: "api.webhook.seed-legacy-endpoints",
+  label: "seed webhook endpoints created before event-source reconciliation",
+  drain: false,
+  async run(ctx) {
+    const apiObjectName = encodeBackofficeObjectAddress({
+      binding: "API",
+      scope: org(ORG_ID),
+    });
+    const api = createApiServer(
+      { publicBaseUrl: "https://example.com" },
+      {
+        adapters: ctx.runtime.adapters.forScope({
+          type: "named",
+          id: `API:${apiObjectName}`,
+        }),
+      },
+    );
+    await migrate(api);
+
+    const uow = api.$internal.deps.createUnitOfWork().forSchema(apiSchema);
+    for (const endpointId of [LEGACY_PUT_ENDPOINT_ID, LEGACY_PATCH_ENDPOINT_ID]) {
+      uow.create("webhookEndpoint", {
+        id: endpointId,
+        name: "Legacy Webhook",
+        status: "active",
+        authConfig: { type: "none" },
+        verification: { type: "none" },
+        deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+      });
+    }
+    const result = await uow.executeMutations();
+    assert(result.success);
+  },
+});
+
 describe("API webhook scenarios", () => {
+  test("existing webhook endpoint writes reconcile missing and stale event sources", async () => {
+    await runBackofficeScenario(
+      defineBackofficeScenario({
+        name: "API webhook endpoint event-source reconciliation",
+        setup: ({ given }) => [
+          given.organization.exists({ id: ORG_ID, name: "Ada Labs" }),
+          seedLegacyWebhookEndpoints(),
+        ],
+        steps: ({ when, then }) => [
+          then.assert("legacy endpoints start without event sources", async (ctx) => {
+            const automations = ctx.runtime.objects.automations.forOrg(ORG_ID);
+            await expect(
+              Promise.all([
+                automations.getEventSource({ source: LEGACY_PUT_ENDPOINT_ID }),
+                automations.getEventSource({ source: LEGACY_PATCH_ENDPOINT_ID }),
+              ]),
+            ).resolves.toEqual([null, null]);
+          }),
+          when.codemode.run({
+            orgId: ORG_ID,
+            label: "replace a legacy webhook endpoint through PUT",
+            code: `async () => await api.createWebhookEndpoint(${JSON.stringify({
+              endpointId: LEGACY_PUT_ENDPOINT_ID,
+              name: "PUT Reconciled Webhook",
+              status: "active",
+              verification: { type: "none" },
+              deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+              auth: { type: "none" },
+            })})`,
+            assertToolCalls: ["api.webhooks.create"],
+          }),
+          then.assert("PUT provisions the missing event source", async (ctx) => {
+            await expect(
+              ctx.runtime.objects.automations
+                .forOrg(ORG_ID)
+                .getEventSource({ source: LEGACY_PUT_ENDPOINT_ID }),
+            ).resolves.toMatchObject({
+              source: LEGACY_PUT_ENDPOINT_ID,
+              label: "PUT Reconciled Webhook",
+              description: "PUT Reconciled Webhook webhook events received through the API.",
+              category: "custom",
+            });
+          }),
+          when.codemode.run({
+            orgId: ORG_ID,
+            label: "rename a legacy webhook endpoint through PATCH",
+            code: `async () => await api.updateWebhookEndpoint(${JSON.stringify({
+              endpointId: LEGACY_PATCH_ENDPOINT_ID,
+              name: "PATCH Reconciled Webhook",
+            })})`,
+            assertToolCalls: ["api.webhooks.update"],
+          }),
+          then.assert("PATCH provisions the missing source with renamed metadata", async (ctx) => {
+            await expect(
+              ctx.runtime.objects.automations
+                .forOrg(ORG_ID)
+                .getEventSource({ source: LEGACY_PATCH_ENDPOINT_ID }),
+            ).resolves.toMatchObject({
+              source: LEGACY_PATCH_ENDPOINT_ID,
+              label: "PATCH Reconciled Webhook",
+              description: "PATCH Reconciled Webhook webhook events received through the API.",
+              category: "custom",
+            });
+          }),
+          when.codemode.run({
+            orgId: ORG_ID,
+            label: "disable the PATCH-reconciled endpoint without renaming it",
+            code: `async () => await api.updateWebhookEndpoint(${JSON.stringify({
+              endpointId: LEGACY_PATCH_ENDPOINT_ID,
+              status: "disabled",
+            })})`,
+            assertToolCalls: ["api.webhooks.update"],
+          }),
+          then.assert("status-only PATCH preserves event-source metadata", async (ctx) => {
+            await expect(
+              ctx.runtime.objects.automations
+                .forOrg(ORG_ID)
+                .getEventSource({ source: LEGACY_PATCH_ENDPOINT_ID }),
+            ).resolves.toMatchObject({
+              label: "PATCH Reconciled Webhook",
+              description: "PATCH Reconciled Webhook webhook events received through the API.",
+            });
+          }),
+          when.codemode.run({
+            orgId: ORG_ID,
+            label: "create a fresh webhook endpoint",
+            code: `async () => await api.createWebhookEndpoint(${JSON.stringify({
+              endpointId: FRESH_ENDPOINT_ID,
+              name: "Fresh Webhook",
+              status: "active",
+              verification: { type: "none" },
+              deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+              auth: { type: "none" },
+            })})`,
+            assertToolCalls: ["api.webhooks.create"],
+          }),
+          then.automation.event({
+            scope: { kind: "org", orgId: ORG_ID },
+            where: { source: "api", eventType: "webhook_endpoint.created" },
+            expected: {
+              payload: {
+                endpointId: FRESH_ENDPOINT_ID,
+                name: "Fresh Webhook",
+                status: "active",
+                authConfig: { type: "none" },
+                verification: { type: "none" },
+                deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+                secretRefs: [],
+              },
+            },
+          }),
+          then.assert("only the fresh endpoint emitted a creation event", async (ctx) => {
+            await expect(listApiEvents(ctx, "webhook_endpoint.created")).resolves.toHaveLength(1);
+          }),
+          then.hooks.noPending({ orgId: ORG_ID, fragments: ["api", "automations"] }),
+          then.hooks.noFailed({ orgId: ORG_ID, fragments: ["api", "automations"] }),
+        ],
+      }),
+    );
+  });
+
+  test("a webhook endpoint provisions a source for cataloged and reclassified events", async () => {
+    await runBackofficeScenario(
+      defineBackofficeScenario<EventSourceScenarioVars>({
+        name: "API webhook event source, catalog, and routing",
+        vars: () => ({ acceptedDelivery: null }),
+        setup: ({ given }) => [given.organization.exists({ id: ORG_ID, name: "Ada Labs" })],
+        steps: ({ when, then }) => [
+          when.codemode.run({
+            orgId: ORG_ID,
+            label: "create an active Acme webhook endpoint",
+            code: `async () => await api.createWebhookEndpoint(${JSON.stringify({
+              endpointId: ACME_ENDPOINT_ID,
+              name: "Acme",
+              status: "active",
+              verification: { type: "none" },
+              deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+              auth: { type: "none" },
+            })})`,
+            assertToolCalls: ["api.webhooks.create"],
+          }),
+          then.assert("the endpoint provisioned its dynamic event source", async (ctx) => {
+            await expect(
+              ctx.runtime.objects.automations
+                .forOrg(ORG_ID)
+                .getEventSource({ source: ACME_ENDPOINT_ID }),
+            ).resolves.toMatchObject({
+              source: ACME_ENDPOINT_ID,
+              label: "Acme",
+              description: "Acme webhook events received through the API.",
+              category: "custom",
+            });
+          }),
+          then.automation.event({
+            scope: { kind: "org", orgId: ORG_ID },
+            where: { source: "api", eventType: "webhook_endpoint.created" },
+            expected: {
+              payload: {
+                endpointId: ACME_ENDPOINT_ID,
+                name: "Acme",
+                status: "active",
+                authConfig: { type: "none" },
+                verification: { type: "none" },
+                deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+                secretRefs: [],
+              },
+              subject: {
+                scope: { kind: "org", orgId: ORG_ID },
+                orgId: ORG_ID,
+                endpointId: ACME_ENDPOINT_ID,
+              },
+            },
+          }),
+          when.codemode.run({
+            orgId: ORG_ID,
+            label: "register Acme record-created events under the webhook source",
+            code: `async () => await events.catalogCreate(${JSON.stringify({
+              source: ACME_ENDPOINT_ID,
+              eventType: "record.created",
+              label: "Acme record created",
+              description: "A record was created in Acme.",
+              payloadSchema: {
+                type: "object",
+                properties: {
+                  recordId: { type: "string" },
+                  data: { type: "object" },
+                },
+                required: ["recordId", "data"],
+                additionalProperties: false,
+              },
+              example: { recordId: "rec-123", data: { status: "new" } },
+              enabled: true,
+            })})`,
+            assertToolCalls: ["events.catalog.create"],
+          }),
+          then.assert("the webhook source owns the registered event definition", async (ctx) => {
+            await expect(
+              ctx.runtime.objects.automations.forOrg(ORG_ID).getEventDefinition({
+                source: ACME_ENDPOINT_ID,
+                eventType: "record.created",
+              }),
+            ).resolves.toMatchObject({
+              source: ACME_ENDPOINT_ID,
+              eventType: "record.created",
+              label: "Acme record created",
+              enabled: true,
+            });
+          }),
+          when.codemode.run({
+            orgId: ORG_ID,
+            label: "route Acme webhook deliveries into the cataloged event",
+            code: `async () => await router.create(${JSON.stringify({
+              id: "acme-record-created",
+              name: "Classify Acme record-created webhooks",
+              enabled: true,
+              trigger: {
+                kind: "event",
+                source: "api",
+                eventType: "webhook.received",
+                matcher: {
+                  all: [
+                    {
+                      path: "$.payload.endpointId",
+                      op: "eq",
+                      value: ACME_ENDPOINT_ID,
+                    },
+                    {
+                      path: "$.payload.body.type",
+                      op: "eq",
+                      value: "record.created",
+                    },
+                  ],
+                },
+              },
+              action: {
+                kind: "reclassify_event",
+                source: ACME_ENDPOINT_ID,
+                eventType: "record.created",
+                payload: {
+                  kind: "projection",
+                  fields: {
+                    recordId: "$.payload.body.recordId",
+                    data: "$.payload.body.data",
+                  },
+                },
+              },
+              description: "Reclassifies Acme webhook deliveries as Acme record-created events.",
+            })})`,
+            assertToolCalls: ["router.create"],
+          }),
+          then.router.route({
+            orgId: ORG_ID,
+            id: "acme-record-created",
+            trigger: {
+              kind: "event",
+              source: "api",
+              eventType: "webhook.received",
+              matcher: {
+                all: [
+                  { path: "$.payload.endpointId", op: "eq", value: ACME_ENDPOINT_ID },
+                  { path: "$.payload.body.type", op: "eq", value: "record.created" },
+                ],
+              },
+            },
+            action: {
+              kind: "reclassify_event",
+              source: ACME_ENDPOINT_ID,
+              eventType: "record.created",
+              payload: {
+                kind: "projection",
+                fields: {
+                  recordId: "$.payload.body.recordId",
+                  data: "$.payload.body.data",
+                },
+              },
+            },
+          }),
+          postAcmeWebhookDelivery(),
+          then.assert("the Acme delivery is accepted asynchronously", (untypedContext) => {
+            const ctx = untypedContext as BackofficeScenarioContext<EventSourceScenarioVars>;
+            expect(ctx.vars.acceptedDelivery).toMatchObject({
+              status: 202,
+              body: JSON.stringify({ accepted: true }),
+            });
+          }),
+          then.automation.event({
+            scope: { kind: "org", orgId: ORG_ID },
+            where: { source: "api", eventType: "webhook.received" },
+            expected: {
+              payload: {
+                endpointId: ACME_ENDPOINT_ID,
+                deliveryId: ACME_DELIVERY_ID,
+                body: acmeDeliveryBody,
+              },
+            },
+          }),
+          then.automation.event({
+            scope: { kind: "org", orgId: ORG_ID },
+            where: { source: ACME_ENDPOINT_ID, eventType: "record.created" },
+            expected: {
+              payload: {
+                recordId: "rec-123",
+                data: { status: "new" },
+              },
+            },
+          }),
+          then.hooks.noPending({ orgId: ORG_ID, fragments: ["api", "automations"] }),
+          then.hooks.noFailed({ orgId: ORG_ID, fragments: ["api", "automations"] }),
+        ],
+      }),
+    );
+  });
+
   test("Slack verification authenticates and echoes before normal deliveries reach automations", async () => {
     await runBackofficeScenario(
       defineBackofficeScenario<ApiWebhookScenarioVars>({
@@ -253,7 +652,7 @@ describe("API webhook scenarios", () => {
             });
           }),
           then.assert("verification requests do not create automation events", async (ctx) => {
-            await expect(listApiWebhookEvents(ctx)).resolves.toEqual([]);
+            await expect(listApiEvents(ctx, "webhook.received")).resolves.toEqual([]);
           }),
           postSlackWebhook({
             label: "post an authenticated Slack event delivery",

--- a/apps/backoffice/app/fragno/automation/schema.ts
+++ b/apps/backoffice/app/fragno/automation/schema.ts
@@ -2,6 +2,7 @@ import { column, idColumn, schema, type Column } from "@fragno-dev/db/schema";
 
 import type { AutomationEvent } from "./contracts";
 import type { AutomationEventDefinition } from "./event-definitions";
+import type { AutomationEventSource } from "./event-sources";
 import type {
   AutomationRouteAction,
   AutomationRouteMetadata,
@@ -187,5 +188,24 @@ export const automationFragmentSchema = schema("automations", (s) => {
     })
     .alterTable("automation_route", (t) => {
       return t.addColumn("metadata", jsonColumn<AutomationRouteMetadata>().nullable());
+    })
+    .addTable("automation_event_source", (t) => {
+      return t
+        .addColumn("id", idColumn())
+        .addColumn("source", column("string"))
+        .addColumn("label", column("string"))
+        .addColumn("description", column("text"))
+        .addColumn("category", jsonColumn<AutomationEventSource["category"]>())
+        .addColumn(
+          "createdAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .addColumn(
+          "updatedAt",
+          column("timestamp").defaultTo((b) => b.now()),
+        )
+        .createIndex("idx_automation_event_source_source", ["source"], {
+          unique: true,
+        });
     });
 });

--- a/apps/backoffice/app/fragno/automation/tanstack/browser-database.ts
+++ b/apps/backoffice/app/fragno/automation/tanstack/browser-database.ts
@@ -2,6 +2,7 @@ import { workflowsSchema } from "@fragno-dev/workflows/schema";
 
 import {
   createFragnoOutboxCoordinator,
+  type FragnoBrowserPersistenceDiagnostics,
   type FragnoOutboxCatchUpProgress,
   type FragnoOutboxCoordinator,
 } from "@fragno-dev/tanstack-db-adapter";
@@ -54,6 +55,8 @@ export function describeAutomationCollectionSource(
 const resources = new Map<string, Promise<AutomationBrowserDatabase>>();
 const catchUpProgress = new Map<string, FragnoOutboxCatchUpProgress>();
 const catchUpProgressListeners = new Map<string, Set<() => void>>();
+const browserPersistenceDiagnostics = new Map<string, FragnoBrowserPersistenceDiagnostics>();
+const browserPersistenceDiagnosticListeners = new Map<string, Set<() => void>>();
 
 export function getAutomationCatchUpProgress(
   resourceKey: string,
@@ -86,6 +89,39 @@ function publishAutomationCatchUpProgress(
   }
 }
 
+/** Returns the latest browser persistence startup diagnostics for an Automations resource. */
+export function getAutomationBrowserPersistenceDiagnostics(
+  resourceKey: string,
+): FragnoBrowserPersistenceDiagnostics | null {
+  return browserPersistenceDiagnostics.get(resourceKey) ?? null;
+}
+
+/** Subscribes to browser persistence startup diagnostics for an Automations resource. */
+export function subscribeAutomationBrowserPersistenceDiagnostics(
+  resourceKey: string,
+  listener: () => void,
+): () => void {
+  const listeners = browserPersistenceDiagnosticListeners.get(resourceKey) ?? new Set();
+  listeners.add(listener);
+  browserPersistenceDiagnosticListeners.set(resourceKey, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      browserPersistenceDiagnosticListeners.delete(resourceKey);
+    }
+  };
+}
+
+function publishAutomationBrowserPersistenceDiagnostics(
+  resourceKey: string,
+  diagnostics: FragnoBrowserPersistenceDiagnostics,
+): void {
+  browserPersistenceDiagnostics.set(resourceKey, diagnostics);
+  for (const listener of browserPersistenceDiagnosticListeners.get(resourceKey) ?? []) {
+    listener();
+  }
+}
+
 /** One browser database for every scope-specific Automations Durable Object and its shared outbox. */
 export function getAutomationBrowserDatabase(
   source: AutomationCollectionSource,
@@ -114,6 +150,13 @@ async function openAutomationBrowserDatabase(
     onCatchUpProgress(progress) {
       publishAutomationCatchUpProgress(description.resourceKey, progress);
     },
+    ...(import.meta.env.DEV
+      ? {
+          onBrowserPersistenceDiagnostic(diagnostics: FragnoBrowserPersistenceDiagnostics) {
+            publishAutomationBrowserPersistenceDiagnostics(description.resourceKey, diagnostics);
+          },
+        }
+      : {}),
   });
   const collections = createAutomationCollections(coordinator);
 

--- a/apps/backoffice/app/fragno/automation/tanstack/collections.ts
+++ b/apps/backoffice/app/fragno/automation/tanstack/collections.ts
@@ -21,6 +21,9 @@ export type AutomationCollections = {
     (typeof automationFragmentSchema.tables)["automation_route_schedule_state"]
   >;
   events: TableCollection<(typeof automationFragmentSchema.tables)["automation_event"]>;
+  eventSources: TableCollection<
+    (typeof automationFragmentSchema.tables)["automation_event_source"]
+  >;
   marketplaceIngestions: TableCollection<
     (typeof automationFragmentSchema.tables)["marketplace_ingestion"]
   >;
@@ -53,6 +56,7 @@ export function createAutomationCollections(
       "automation_route_schedule_state",
     ),
     events: coordinator.collection(automationFragmentSchema, "automation_event"),
+    eventSources: coordinator.collection(automationFragmentSchema, "automation_event_source"),
     marketplaceIngestions: coordinator.collection(
       automationFragmentSchema,
       "marketplace_ingestion",

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/api.ts
@@ -1,3 +1,6 @@
+import { webhookDeliveryIdentitySchema } from "@fragno-dev/api-fragment/types";
+import { webhookAuthConfigSchema } from "@fragno-dev/api-fragment/webhooks/auth";
+import { webhookVerificationConfigSchema } from "@fragno-dev/api-fragment/webhooks/verification";
 import { z } from "zod";
 
 import type { BackofficeCapability } from "@/fragno/backoffice-capabilities/backoffice-capabilities";
@@ -34,6 +37,20 @@ const apiScopeSubjectSchema = z.object({
 
 const apiConnectionSubjectSchema = apiScopeSubjectSchema.extend({
   connectionId: z.string().min(1),
+});
+
+const apiWebhookEndpointCreatedPayloadSchema = z.object({
+  endpointId: z.string().min(1),
+  name: z.string().min(1),
+  status: z.enum(["draft", "active", "disabled"]),
+  authConfig: webhookAuthConfigSchema,
+  verification: webhookVerificationConfigSchema,
+  deliveryIdentity: webhookDeliveryIdentitySchema,
+  secretRefs: z.array(z.string()),
+});
+
+const apiWebhookEndpointSubjectSchema = apiScopeSubjectSchema.extend({
+  endpointId: z.string().min(1),
 });
 
 const apiWebhookReceivedPayloadSchema = z.object({
@@ -104,6 +121,23 @@ export const apiCapability: BackofficeCapability = {
             authMode: "bearer",
             status: "active",
           },
+        },
+      },
+      {
+        source: AUTOMATION_SOURCE,
+        eventType: "webhook_endpoint.created",
+        label: "API webhook endpoint created",
+        description: "Fires when an API webhook endpoint is created.",
+        payloadSchema: apiWebhookEndpointCreatedPayloadSchema,
+        subjectSchema: apiWebhookEndpointSubjectSchema,
+        example: {
+          endpointId: "stripe",
+          name: "Stripe",
+          status: "active",
+          authConfig: { type: "none" },
+          verification: { type: "none" },
+          deliveryIdentity: { type: "header", name: "stripe-event-id" },
+          secretRefs: [],
         },
       },
       {

--- a/apps/backoffice/app/layouts/backoffice-layout-ui.tsx
+++ b/apps/backoffice/app/layouts/backoffice-layout-ui.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Link, Outlet, isRouteErrorResponse, useRouteError } from "react-router";
+import { Outlet, isRouteErrorResponse, useRouteError } from "react-router";
 
 import { BackofficePageHeader, BackofficeShell } from "@/components/backoffice";
 import { getRouteErrorDebugDetails } from "@/routes/backoffice/route-errors";
@@ -56,14 +56,6 @@ export function ErrorBoundary() {
           eyebrow="Backoffice"
           title={title}
           description={description}
-          actions={
-            <Link
-              to="/backoffice"
-              className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-            >
-              Back to terminal
-            </Link>
-          }
         />
         <div className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-4 text-sm text-[var(--bo-muted)]">
           {status ? <p>Error code: {status}</p> : null}

--- a/apps/backoffice/app/routes/backoffice/automations/browser-persistence-diagnostics.tsx
+++ b/apps/backoffice/app/routes/backoffice/automations/browser-persistence-diagnostics.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useRef, useState } from "react";
+
+import type { FragnoBrowserPersistenceDiagnostics } from "@fragno-dev/tanstack-db-adapter";
+
+import {
+  getAutomationBrowserPersistenceDiagnostics,
+  subscribeAutomationBrowserPersistenceDiagnostics,
+} from "@/fragno/automation/tanstack/browser-database";
+
+/** Shows live browser persistence startup diagnostics inside the development loading state. */
+export function AutomationBrowserPersistenceDiagnosticPanel({
+  resourceKey,
+}: {
+  resourceKey: string;
+}) {
+  const [diagnostics, setDiagnostics] = useState<FragnoBrowserPersistenceDiagnostics | null>(() =>
+    getAutomationBrowserPersistenceDiagnostics(resourceKey),
+  );
+  const unsubscribeRef = useRef<() => void>(() => {});
+  const subscribeRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      unsubscribeRef.current();
+      unsubscribeRef.current = () => {};
+      if (!element) {
+        return;
+      }
+
+      function readLatestDiagnostics() {
+        setDiagnostics(getAutomationBrowserPersistenceDiagnostics(resourceKey));
+      }
+
+      // Worker scheduling stalls can coincide with delayed React subscription effects. A callback
+      // ref registers during commit so startup diagnostics cannot be missed before effects run.
+      unsubscribeRef.current = subscribeAutomationBrowserPersistenceDiagnostics(
+        resourceKey,
+        readLatestDiagnostics,
+      );
+      readLatestDiagnostics();
+    },
+    [resourceKey],
+  );
+
+  return (
+    <div ref={subscribeRef}>
+      {diagnostics ? (
+        <details
+          open
+          className="mt-3 max-w-4xl border border-amber-500/30 bg-amber-500/6 text-left"
+        >
+          <summary className="cursor-pointer px-3 py-2 font-mono text-[10px] font-semibold tracking-[0.16em] text-amber-700 uppercase dark:text-amber-200">
+            Browser persistence diagnostics · {Math.round(diagnostics.elapsedMs / 1_000)}s
+          </summary>
+          <div className="border-t border-amber-500/20 p-3">
+            <p className="max-w-3xl text-xs text-amber-800 dark:text-amber-100">
+              {diagnostics.likelyCause}
+            </p>
+            <pre className="mt-3 max-h-80 overflow-auto bg-[var(--bo-panel-2)] p-3 font-mono text-[10px] leading-relaxed text-[var(--bo-muted)] shadow-[inset_0_0_0_1px_var(--bo-border)]">
+              {JSON.stringify(diagnostics, null, 2)}
+            </pre>
+          </div>
+        </details>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/backoffice/app/routes/backoffice/automations/dashboard.tsx
+++ b/apps/backoffice/app/routes/backoffice/automations/dashboard.tsx
@@ -131,10 +131,12 @@ const fallbackSourceLabel = (source: string) =>
 
 function dashboardSources({
   routes,
+  eventSources,
   eventDefinitions,
   includeUnroutedSources,
 }: {
   routes: readonly DashboardRoute[];
+  eventSources: readonly DashboardSource[];
   eventDefinitions: readonly DashboardEventDefinitionWithSource[];
   includeUnroutedSources: boolean;
 }): DashboardSource[] {
@@ -147,6 +149,11 @@ function dashboardSources({
       label: eventSource.label,
       description: eventSource.description,
     });
+  }
+
+  for (const eventSource of eventSources) {
+    const id = normalizedSourceId(eventSource.id);
+    sourceCatalog.set(id, { ...eventSource, id });
   }
 
   for (const eventDefinition of eventDefinitions) {
@@ -984,6 +991,18 @@ export function AutomationSwimlaneDashboard({
   const [searchParams, setSearchParams] = useSearchParams();
 
   const routesState = useAutomationRoutes(collections);
+  const eventSourcesQuery = useLiveQuery(
+    (query) =>
+      query
+        .from({ source: collections.eventSources })
+        .orderBy(({ source }) => source.label, "asc")
+        .select(({ source }) => ({
+          id: source.source,
+          label: source.label,
+          description: source.description,
+        })),
+    [collections.eventSources],
+  );
   const eventDefinitionsQuery = useLiveQuery(
     (query) =>
       query
@@ -1061,6 +1080,7 @@ export function AutomationSwimlaneDashboard({
   const eventRoutes = routes.filter((route) => route.action.kind !== "start_workflow");
   const sources = dashboardSources({
     routes: view === "workflows" ? workflowRoutes : eventRoutes,
+    eventSources: eventSourcesQuery.data ?? [],
     eventDefinitions,
     includeUnroutedSources: view === "events",
   });
@@ -1095,6 +1115,7 @@ export function AutomationSwimlaneDashboard({
   const showInspector = view === "events" || inspectorSelection !== null;
   const errors = [
     routesState.status === "error" ? routesState.message : null,
+    eventSourcesQuery.isError ? "Event source synchronization failed." : null,
     eventDefinitionsQuery.isError ? "Event catalog synchronization failed." : null,
     workflowsQuery.isError ? "Workflow synchronization failed." : null,
   ].filter((message): message is string => Boolean(message));

--- a/apps/backoffice/app/routes/backoffice/automations/scope-layout.tsx
+++ b/apps/backoffice/app/routes/backoffice/automations/scope-layout.tsx
@@ -24,6 +24,7 @@ import { fetchUploadAdapterIdentity } from "@/fragno/upload/tanstack/server";
 
 import { buildBackofficeLoginPath } from "../auth-navigation";
 import type { Route } from "./+types/scope-layout";
+import { AutomationBrowserPersistenceDiagnosticPanel } from "./browser-persistence-diagnostics";
 import {
   createAutomationProject,
   loadAutomationWorkspaceData,
@@ -357,6 +358,9 @@ function AutomationClientLoading() {
           JavaScript is required to open scoped automations.
         </span>
       </noscript>
+      {import.meta.env.DEV && resourceKey ? (
+        <AutomationBrowserPersistenceDiagnosticPanel resourceKey={resourceKey} />
+      ) : null}
     </BackofficeSystemState>
   );
 }

--- a/apps/backoffice/app/routes/backoffice/not-found.tsx
+++ b/apps/backoffice/app/routes/backoffice/not-found.tsx
@@ -1,5 +1,3 @@
-import { Link } from "react-router";
-
 import { BackofficePageHeader } from "@/components/backoffice";
 
 export default function BackofficeNotFound() {
@@ -10,14 +8,6 @@ export default function BackofficeNotFound() {
         eyebrow="Backoffice"
         title="Page not found"
         description="This backoffice route does not exist."
-        actions={
-          <Link
-            to="/backoffice"
-            className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-          >
-            Back to terminal
-          </Link>
-        }
       />
 
       <div className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-4 text-sm text-[var(--bo-muted)]">

--- a/apps/backoffice/content/static/skills/api-webhooks/SKILL.md
+++ b/apps/backoffice/content/static/skills/api-webhooks/SKILL.md
@@ -1,28 +1,23 @@
 ---
 name: api-webhooks
 description:
-  Configure inbound webhooks received by Backoffice API endpoints. Use when the user wants to
-  receive provider webhooks, asks for a webhook/callback endpoint URL, gives a webhook secret or
-  sample payload, configures webhook authentication/signatures, or wires webhook.received events
-  into automations.
+  Configure inbound API webhooks end to end. Use when the user needs a webhook/callback URL,
+  provides webhook auth or sample payloads, defines provider events, or routes webhook.received
+  deliveries into cataloged automation events.
 ---
 
 # API Webhooks
 
-Use this skill for scope-aware inbound HTTP webhook endpoints, provider delivery IDs,
-authentication, endpoint verification challenges, public webhook URLs, and webhook-triggered
-automations.
+Configure one coherent webhook contract: endpoint, event source, cataloged provider events, routes,
+and verification. Use codemode and return a final inventory so the user can see exactly what was
+registered.
 
-# API webhook configuration
+## Setup sequence
 
-The API capability is available automatically for the current scope. Webhook endpoints share its
-storage and public base URL.
+### 1. Reserve the endpoint URL
 
-Typical setup flow:
-
-1. Create a draft endpoint. Assume the user needs a webhook URL before auth, payload, or header
-   details are known. Deduce a good stable lowercase `endpointId` from the user's request; this is
-   usually the name of the service you are configuring webhooks for:
+Immediately create a draft endpoint with a stable lowercase `endpointId` derived from the provider
+name, then give the user the exact `publicUrl` returned by the tool.
 
 ```js
 const draft = await api.createWebhookEndpoint({
@@ -37,23 +32,150 @@ const draft = await api.createWebhookEndpoint({
 return { webhookUrl: draft.publicUrl };
 ```
 
-Draft endpoints reserve a stable URL and reject deliveries with "not configured yet" until you
-update them to `status: "active"`.
+Creating the endpoint also provisions an event source named after its `endpointId`. For example,
+endpoint `example-provider` owns source `example-provider`. Source provisioning is asynchronous. If
+an immediate `events.catalogCreate` reports that this source does not exist, retry that operation a
+bounded number of times for this specific error. Keep the endpoint and source identifiers unchanged.
 
-2. Collect the remaining inputs before activating the draft endpoint:
-   - webhook auth type: `none`, `bearer`, `apiKey`, `basic`, or `hmac`. Typical case is HMAC.
-   - if auth is `hmac`: algorithm, signature header/query name, signature encoding, optional
-     signature prefix, and whether the provider signs the raw body or a prefixed timestamped body;
-   - whether the provider verifies the endpoint with a synchronous challenge, including the HTTP
-     method, match field, and echoed field;
-   - example JSON payload;
-   - relevant delivery/signature headers.
-3. If any auth, signature, payload, header, or delivery identity detail is unknown, keep the
-   endpoint in `draft` and ask the user for the missing details. Do not activate the endpoint yet.
-4. Choose `deliveryIdentity` from the example payload or headers. Prefer provider delivery ids such
-   as `webhookId`, `event.id`, `id`, or a provider delivery-id header.
-5. Update the draft endpoint with the correct auth configuration, delivery identity, and
-   `status: "active"`. Return the exact `webhook.publicUrl` from the tool result:
+Draft endpoints reserve a stable URL and reject deliveries with `WEBHOOK_ENDPOINT_DRAFT` and
+"Webhook endpoint is not configured yet" until activated.
+
+### 2. Establish the webhook contract
+
+Collect the information required to make deliveries deterministic:
+
+- example JSON payloads for every event type the user wants to receive;
+- relevant delivery, signature, and discriminator headers;
+- a provider delivery ID from a header or payload path;
+- authentication details;
+- endpoint verification challenge details, when applicable;
+- the payload field that discriminates event types, such as `type`.
+
+Keep the endpoint in `draft` while required details are missing. The `endpointId` is the only value
+to deduce without evidence.
+
+Choose `deliveryIdentity` from a stable provider identifier such as `webhookId`, `event.id`, `id`,
+or a provider delivery-ID header.
+
+Authentication choices are `none`, `bearer`, `apiKey`, `basic`, and `hmac`. Treat “webhook secret,”
+“signing secret,” “key,” or a secret-shaped webhook value as an HMAC clue and collect the algorithm,
+signature location and name, encoding, optional prefix, and signed-payload format. Use bearer
+authentication only when the provider explicitly sends `Authorization: Bearer ...`.
+
+### Setup guardrails
+
+- The API capability is available automatically for the current scope. Webhook endpoints share its
+  storage and public URL configuration.
+- Use the shared `api` capability directly; `connections.setup` is for outbound API connections.
+- Give the user the complete, fully qualified receiving URL returned as `webhook.publicUrl`. Refer
+  to it as the webhook URL, not the public base URL.
+- Assemble the final URL only from the tool result. The documented URL shape is explanatory, not a
+  substitute for `webhook.publicUrl`.
+- Ask for example payloads and relevant headers before choosing delivery identities, schemas, or
+  routes.
+- Derive only the `endpointId` without evidence. Keep the endpoint in draft while authentication,
+  signature, verification, payload, header, discriminator, or delivery-identity details are unknown.
+- Store authentication secrets through endpoint tools and omit secret values from summaries,
+  schemas, event examples, and completion responses.
+
+### 3. Register provider events
+
+For each distinct provider event, call `events.catalogCreate` with:
+
+- `source`: the webhook `endpointId`;
+- a stable `eventType` derived from the provider event discriminator;
+- a useful label and description;
+- a payload schema based on the projected event payload;
+- a representative example;
+- `enabled: true`.
+
+```js
+const registered = await events.catalogCreate({
+  source: "example-provider",
+  eventType: "record.created",
+  label: "Example Provider record created",
+  description: "A record was created in Example Provider.",
+  payloadSchema: {
+    type: "object",
+    properties: {
+      recordId: { type: "string" },
+      data: { type: "object" },
+    },
+    required: ["recordId"],
+    additionalProperties: true,
+  },
+  example: { recordId: "rec_123", data: { status: "new" } },
+  enabled: true,
+});
+```
+
+The registered schema is the destination contract. Every route projection must produce all its
+required fields.
+
+### 4. Route accepted deliveries
+
+Accepted deliveries first produce `api.webhook.received`. Create one reclassification route for each
+cataloged provider event.
+
+Every route must be endpoint-scoped. When the provider carries multiple event types, also match its
+event discriminator. Without the endpoint matcher, a route consumes deliveries from every API
+webhook endpoint.
+
+The route matcher and projection inspect the complete automation event envelope. Webhook fields are
+under `$.payload`; provider body fields are under `$.payload.body`.
+
+```js
+const route = await router.create({
+  id: "example-provider-record-created",
+  name: "Classify Example Provider record-created webhooks",
+  enabled: true,
+  trigger: {
+    kind: "event",
+    source: "api",
+    eventType: "webhook.received",
+    matcher: {
+      all: [
+        { path: "$.payload.endpointId", op: "eq", value: "example-provider" },
+        { path: "$.payload.body.type", op: "eq", value: "record.created" },
+      ],
+    },
+  },
+  action: {
+    kind: "reclassify_event",
+    source: "example-provider",
+    eventType: "record.created",
+    payload: {
+      kind: "projection",
+      fields: {
+        recordId: "$.payload.body.recordId",
+        data: "$.payload.body.data",
+      },
+    },
+  },
+  description:
+    "Reclassifies Example Provider record.created deliveries as example-provider record.created events.",
+});
+```
+
+Projection paths always start with `$.`. Compare the projection against the destination event schema
+before creating the route; every required destination field must resolve for a matching delivery.
+
+### 5. Activate the endpoint
+
+Update the draft only after the webhook contract is known. When the user supplies the complete
+contract before setup begins, creating the endpoint directly as `active` is also valid.
+
+```js
+const webhook = await api.updateWebhookEndpoint({
+  endpointId: "example-provider",
+  status: "active",
+  verification: { type: "none" },
+  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
+  auth: { type: "none" },
+});
+```
+
+For HMAC, configure the exact provider contract:
 
 ```js
 const webhook = await api.updateWebhookEndpoint({
@@ -69,107 +191,41 @@ const webhook = await api.updateWebhookEndpoint({
       location: "header",
       name: "x-provider-signature",
       encoding: "hex",
+      prefix: "sha256=",
     },
     signedPayload: { type: "rawBody" },
   },
 });
-
-return webhook.publicUrl;
 ```
 
-6. Tell the user you are standing by to check for deliveries. Once the provider sends a test
-   delivery, verify recent API durable hooks:
+### HMAC decision guide
 
-```js
-await hooks.list({ fragment: "api", pageSize: 10 });
-```
-
-Notes:
-
-- Public receive URLs look like `/api/http/:scope/webhooks/endpoints/:endpointId/events`.
-- Return the exact `webhook.publicUrl` after creating or updating an endpoint; do not manually
-  assemble the final URL unless you are only explaining the URL shape before creation.
-
-Rules:
-
-- ALWAYS start by immediately setting up a draft endpoint with a good endpointId AND informing the
-  user of the FULL receiving webhook URL. ALWAYS DO THIS.
-- Do not talk about setting up the API capability; it is available automatically.
-- Do NOT mention the public base URL. This could confuse the user. Only mention the fully qualified
-  url including the filled in endpointId and orgId.
-- Do not call `connections.setup` for API webhooks; webhook endpoints use the shared `api`
-  capability automatically.
-- Do not guess webhook auth from the word "secret" or "key". If the user says "webhook secret",
-  "signing secret", or gives a secret-shaped webhook key, treat it as likely `hmac` and ask for the
-  signature header/encoding/payload details if missing. Use `bearer` only when the provider
-  explicitly sends an `Authorization: Bearer ...` header.
-- Do not guess the delivery identity when the provider payload/header shape is unknown.
-- ALWAYS ask the user for an example webhook payload and relevant headers, then choose a stable id
-  that is unique per provider delivery.
-- If auth scheme, signature header, signature encoding, signed payload, or delivery identity is
-  unknown, ask for the missing information before activating the endpoint. Create a draft endpoint
-  first if the user needs the URL.
-- DO NOT GUESS ANYTHING but the endpointId. Ask for all other details before activating the
-  endpoint.
-
-HMAC decision guide:
-
-- `algorithm`: ask whether the provider uses `sha1`, `sha256`, or `sha512`.
-- `signature.location`: ask whether the signature is in a `header` or `query` parameter.
-- `signature.name`: ask for the exact header or query parameter name.
-- `signature.encoding`: ask whether the signature value is `hex`, `base64`, or `base64url`.
-- `signature.prefix`: include this only when the provider prefixes the signature value, for example
+- `algorithm`: use the provider's documented `sha1`, `sha256`, or `sha512` algorithm.
+- `signature.location`: use `header` or `query` according to where the provider sends the signature.
+- `signature.name`: preserve the exact header or query-parameter name.
+- `signature.encoding`: use the documented `hex`, `base64`, or `base64url` encoding.
+- `signature.prefix`: include it only when the provider prefixes the encoded signature, such as
   `sha256=` or `v1=`.
-- `signedPayload`: use `rawBody` only when the provider signs the raw request body. Use
-  `timestampedBody` when the provider signs a prefix, timestamp, delimiter, and raw body. Ask for
-  the exact `prefix`, `timestampHeader`, and `delimiter`; use an empty prefix only when the provider
-  signs the timestamp first.
-- `verification`: use `{ type: "none" }` for ordinary delivery-only endpoints. Use a `challenge`
-  verification when the provider sends a synchronous value that the endpoint must echo before normal
-  deliveries begin. Configure its HTTP method, a `present` or `equals` predicate, and the header,
-  query value, or JSON body path to echo.
+- `signedPayload`: use `rawBody` when the provider signs the unmodified request body. Use
+  `timestampedBody` when it signs a prefix, timestamp, delimiter, and raw body.
+- For `timestampedBody`, preserve the exact `prefix`, `timestampHeader`, and `delimiter`, and use
+  the provider's replay-tolerance window. An empty prefix is valid only when the provider signs the
+  timestamp first without a prefix.
 
-Basic setup example:
+### Verification challenge guide
 
-```js
-const webhook = await api.createWebhookEndpoint({
-  endpointId: "example-provider",
-  name: "Example Provider",
-  status: "active",
-  verification: { type: "none" },
-  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
-  auth: { type: "none" },
-});
+Use `{ type: "none" }` for ordinary delivery-only endpoints. Use `challenge` when the provider sends
+a synchronous value that must be echoed before deliveries begin.
 
-return webhook.publicUrl;
-```
+A challenge configuration specifies:
 
-HMAC setup example:
+- the exact HTTP `method`;
+- a `present` predicate when the source only needs to exist, or an `equals` predicate when it must
+  match a fixed value;
+- a match source from a header, query parameter, or JSON body path;
+- the header, query parameter, or JSON body path whose value the response echoes.
 
-```js
-const webhook = await api.createWebhookEndpoint({
-  endpointId: "example-provider",
-  name: "Example Provider",
-  status: "active",
-  verification: { type: "none" },
-  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
-  auth: {
-    type: "hmac",
-    secret: "whs_secret_123",
-    algorithm: "sha256",
-    signature: {
-      location: "header",
-      name: "x-provider-signature",
-      encoding: "hex",
-    },
-    signedPayload: { type: "rawBody" },
-  },
-});
-
-return webhook.publicUrl;
-```
-
-Slack-style signed challenge example:
+### Slack-style signed challenge example
 
 ```js
 const webhook = await api.createWebhookEndpoint({
@@ -213,14 +269,48 @@ const webhook = await api.createWebhookEndpoint({
 return webhook.publicUrl;
 ```
 
-# API webhook events
+### 6. Verify end-to-end
 
-Cataloged automation events:
+Tell the user when the endpoint is ready for a provider test delivery. Send a representative
+delivery when possible, then inspect both queues:
 
-- `source`: `api`, `eventType`: `webhook.received` — fires after a configured webhook endpoint
-  accepts and authenticates a delivery.
+```js
+const [apiHooks, automationHooks] = await Promise.all([
+  hooks.list({ fragment: "api", pageSize: 20 }),
+  hooks.list({ fragment: "automations", pageSize: 50 }),
+]);
+```
 
-Webhook payloads include:
+Verification is complete only when:
+
+1. the endpoint returns an accepted response;
+2. the matching `onWebhookReceived` API hook completes;
+3. the original `api.webhook.received` automation event completes;
+4. each expected reclassified `<endpointId>.<eventType>` event completes without projection or
+   schema errors.
+
+A `202 Accepted` response or a pending automation hook is intermediate evidence, not completion.
+When a hook fails, inspect its exact projection or schema error, repair the route, send a new unique
+delivery, and verify again.
+
+## Completion response
+
+Finish every webhook setup with one inventory containing:
+
+- endpoint name, status, and exact fully qualified `publicUrl`;
+- event source (`endpointId`);
+- every registered `source.eventType`;
+- every route as `trigger → destination`, including endpoint and discriminator matchers;
+- authentication and verification mode, without secret values;
+- end-to-end verification status.
+
+If the endpoint remains a draft, list the missing inputs required for activation. If no provider
+events were registered, state that explicitly.
+
+## Event envelope reference
+
+`api.webhook.received` fires after an active endpoint accepts and authenticates a delivery. Its
+payload contains:
 
 - `endpointId`
 - `deliveryId`
@@ -231,38 +321,27 @@ Webhook payloads include:
 - parsed JSON `body`
 - `contentType`
 
-Use `hookId` or the automation event id for idempotency. Duplicate provider deliveries with the same
-endpoint and delivery id produce the same hook id.
+Use `hookId` or the automation event ID for idempotency. Duplicate provider deliveries with the same
+endpoint and delivery ID produce the same hook ID.
 
-# API webhook tools
+## Tool reference
 
-API webhook tools can:
+Use codemode first.
 
-- list configured webhook endpoints;
-- inspect a webhook endpoint;
-- create or replace a webhook endpoint;
-- update a webhook endpoint;
-- delete a webhook endpoint.
+Webhook endpoint methods:
 
-Use codemode first. The `api` provider methods are `listWebhookEndpoints`, `getWebhookEndpoint`,
-`createWebhookEndpoint`, `updateWebhookEndpoint`, and `deleteWebhookEndpoint`.
+- `api.listWebhookEndpoints` lists configured endpoints.
+- `api.getWebhookEndpoint` inspects one endpoint.
+- `api.createWebhookEndpoint` creates or replaces an endpoint.
+- `api.updateWebhookEndpoint` updates an endpoint.
+- `api.deleteWebhookEndpoint` deletes an endpoint.
 
-Examples:
+A direct active endpoint is appropriate when the complete contract is already known:
 
 ```js
-await api.listWebhookEndpoints();
-
-const draft = await api.createWebhookEndpoint({
+const webhook = await api.createWebhookEndpoint({
   endpointId: "example-provider",
   name: "Example Provider",
-  status: "draft",
-  verification: { type: "none" },
-  deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
-  auth: { type: "none" },
-});
-
-const webhook = await api.updateWebhookEndpoint({
-  endpointId: draft.id,
   status: "active",
   verification: { type: "none" },
   deliveryIdentity: { type: "jsonBodyPath", path: ["webhookId"] },
@@ -271,3 +350,24 @@ const webhook = await api.updateWebhookEndpoint({
 
 return webhook.publicUrl;
 ```
+
+Inspect existing configuration before replacing it:
+
+```js
+const endpoints = await api.listWebhookEndpoints();
+const endpoint = await api.getWebhookEndpoint({ endpointId: "example-provider" });
+```
+
+Event and routing methods:
+
+- `events.catalogList`
+- `events.catalogGet`
+- `events.catalogCreate`
+- `router.list`
+- `router.get`
+- `router.create`
+- `router.update`
+- `router.delete`
+
+Webhook endpoints use the shared `api` capability automatically. Return the exact tool-provided
+`publicUrl`; the receive URL shape is `/api/http/:scope/webhooks/endpoints/:endpointId/events`.

--- a/apps/backoffice/workers/api.do.test.ts
+++ b/apps/backoffice/workers/api.do.test.ts
@@ -41,6 +41,63 @@ describe("API system capability", () => {
     await expect(response.json()).resolves.toEqual({ connections: [] });
   });
 
+  test("creates an automation event source for a new webhook endpoint", async () => {
+    const runtime = await createRuntime();
+    const scope = { kind: "org" as const, orgId: "org-1" };
+    const api = runtime.objects.api.for(scope);
+
+    const response = await api.fetch(
+      new Request("https://api.do/api/api/webhooks/endpoints/slack", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Slack",
+          status: "active",
+          verification: { type: "none" },
+          deliveryIdentity: { type: "header", name: "x-slack-event-id" },
+          auth: { type: "none" },
+        }),
+      }),
+    );
+    assert.equal(response.status, 201);
+
+    await api.alarm?.();
+    await runtime.drainWaitUntil();
+
+    const automations = runtime.objects.automations.for(scope);
+    await expect(automations.listEventSources()).resolves.toEqual([
+      expect.objectContaining({
+        source: "slack",
+        label: "Slack",
+        description: "Slack webhook events received through the API.",
+        category: "custom",
+      }),
+    ]);
+
+    const eventsResponse = await automations.fetch(
+      new Request("https://automations.test/api/automations/events?limit=10"),
+    );
+    assert.equal(eventsResponse.status, 200);
+    await expect(eventsResponse.json()).resolves.toMatchObject({
+      events: [
+        {
+          source: "api",
+          eventType: "webhook_endpoint.created",
+          payload: {
+            endpointId: "slack",
+            name: "Slack",
+            status: "active",
+            authConfig: { type: "none" },
+            verification: { type: "none" },
+            deliveryIdentity: { type: "header", name: "x-slack-event-id" },
+            secretRefs: [],
+          },
+          subject: expect.objectContaining({ endpointId: "slack", orgId: "org-1" }),
+        },
+      ],
+    });
+  });
+
   test("does not advertise API or MCP in system scope", async () => {
     const runtime = await createRuntime();
     const capabilities = createBackofficeCapabilitiesRuntime({

--- a/apps/backoffice/workers/api.do.ts
+++ b/apps/backoffice/workers/api.do.ts
@@ -178,6 +178,35 @@ export class InMemoryApiObject extends RpcTarget implements ApiObject {
           { propagationContext: context.capturePropagationContext() },
         );
       },
+      onWebhookEndpointChanged: async (payload, context) => {
+        const automations = this.#runtimeServices.objects.automations.for(ownerScope);
+        await automations.ensureEventSource({
+          source: payload.endpointId,
+          label: payload.endpoint.name,
+          description: `${payload.endpoint.name} webhook events received through the API.`,
+          category: "custom",
+        });
+        if (payload.change !== "created") {
+          return;
+        }
+        await automations.ingestEvent(
+          {
+            id: context.hookId.toString(),
+            scope: ownerScope,
+            source: "api",
+            eventType: "webhook_endpoint.created",
+            occurredAt: new Date().toISOString(),
+            payload: { endpointId: payload.endpointId, ...payload.endpoint },
+            actors: {
+              initiator: AUTOMATION_SYSTEM_INITIATOR,
+              principal: null,
+              delegation: [],
+            },
+            subject: scopeSubject(ownerScope, { endpointId: payload.endpointId }),
+          },
+          { propagationContext: context.capturePropagationContext() },
+        );
+      },
       onWebhookReceived: async (payload, context) => {
         const scope = ownerScope;
         await this.#runtimeServices.objects.automations.for(scope).ingestEvent(

--- a/apps/backoffice/workers/automations.do.ts
+++ b/apps/backoffice/workers/automations.do.ts
@@ -56,6 +56,10 @@ import type {
 } from "@/fragno/automation";
 import { BACKOFFICE_WORKFLOW_ACTORS_METADATA_KEY } from "@/fragno/automation/actors";
 import { createAutomationsRuntime, type AutomationsRuntime } from "@/fragno/automation/automations";
+import type {
+  AutomationEventSource,
+  AutomationEventSourceInput,
+} from "@/fragno/automation/event-sources";
 import {
   bindExternalIdentityInputSchema,
   getExternalIdentityBindingInputSchema,
@@ -1019,6 +1023,53 @@ export class InMemoryAutomationsObject extends RpcTarget implements AutomationsO
     context?: BackofficeRpcContext,
   ): Promise<AutomationIngestResult> {
     return await this.triggerIngestEvent(event, context);
+  }
+
+  async listEventSources(): Promise<AutomationEventSource[]> {
+    await this.#ensureConfigured({ scope: this.#requireScope() });
+    const { runtime } = this.#host.requireConfigured("Automations runtime is not ready.");
+    const sources = await runtime.automationFragment.callServices(() =>
+      runtime.automationFragment.services.listEventSources(),
+    );
+
+    return sources.map((source) => ({
+      id: source.id.valueOf(),
+      source: source.source,
+      label: source.label,
+      description: source.description,
+      category: source.category,
+      createdAt: source.createdAt.toISOString(),
+      updatedAt: source.updatedAt.toISOString(),
+    }));
+  }
+
+  async getEventSource(input: { source: string }): Promise<AutomationEventSource | null> {
+    await this.#ensureConfigured({ scope: this.#requireScope() });
+    const { runtime } = this.#host.requireConfigured("Automations runtime is not ready.");
+    const source = await runtime.automationFragment.callServices(() =>
+      runtime.automationFragment.services.getEventSource(input),
+    );
+
+    return source
+      ? {
+          id: source.id.valueOf(),
+          source: source.source,
+          label: source.label,
+          description: source.description,
+          category: source.category,
+          createdAt: source.createdAt.toISOString(),
+          updatedAt: source.updatedAt.toISOString(),
+        }
+      : null;
+  }
+
+  async ensureEventSource(input: AutomationEventSourceInput): Promise<AutomationEventSource> {
+    await this.#ensureConfigured({ scope: this.#requireScope() });
+    const { runtime } = this.#host.requireConfigured("Automations runtime is not ready.");
+
+    return await runtime.automationFragment.callServices(() =>
+      runtime.automationFragment.services.ensureEventSource(input),
+    );
   }
 
   async listEventDefinitions(): Promise<AutomationEventDefinition[]> {

--- a/packages/api-fragment/src/definition.ts
+++ b/packages/api-fragment/src/definition.ts
@@ -1,8 +1,11 @@
 import { defineFragment } from "@fragno-dev/core";
 import { withDatabase, type HookContext, type HookFn } from "@fragno-dev/db";
 
-import type { ApiFragmentConfig as BaseApiFragmentConfig } from "./api-types";
-import type { ApiRequestInput } from "./api-types";
+import type {
+  ApiFragmentConfig as BaseApiFragmentConfig,
+  ApiRequestInput,
+  WebhookEndpoint,
+} from "./api-types";
 import { apiSchema } from "./schema";
 import {
   createOAuthCallbackSnapshot,
@@ -49,6 +52,21 @@ interface InternalWebhookReceivedPayload {
   contentType: string | null;
 }
 
+export interface WebhookEndpointHookSnapshot {
+  name: WebhookEndpoint["name"];
+  status: WebhookEndpoint["status"];
+  authConfig: WebhookEndpoint["authConfig"];
+  verification: WebhookEndpoint["verification"];
+  deliveryIdentity: WebhookEndpoint["deliveryIdentity"];
+  secretRefs: WebhookEndpoint["secretRefs"];
+}
+
+export interface WebhookEndpointChangedPayload {
+  change: "created" | "updated";
+  endpointId: string;
+  endpoint: WebhookEndpointHookSnapshot;
+}
+
 export interface WebhookReceivedPayload {
   endpointId: string;
   deliveryId: string;
@@ -73,6 +91,10 @@ export interface ApiFragmentHooksConfig {
     payload: ApiConnectionAvailablePayload,
     context: HookContext,
   ) => Promise<void> | void;
+  onWebhookEndpointChanged?: (
+    payload: WebhookEndpointChangedPayload,
+    context: HookContext,
+  ) => Promise<void> | void;
   onWebhookReceived?: (
     payload: WebhookReceivedPayload,
     context: HookContext,
@@ -85,6 +107,7 @@ export type ApiHooksMap = {
   onConnectionChanged: HookFn<ApiConnectionChangedPayload>;
   onConnectionDeleted: HookFn<ApiConnectionDeletedPayload>;
   onConnectionAvailable: HookFn<ApiConnectionAvailablePayload>;
+  onWebhookEndpointChanged: HookFn<WebhookEndpointChangedPayload>;
   onWebhookReceived: HookFn<InternalWebhookReceivedPayload>;
 };
 
@@ -115,6 +138,9 @@ export const apiFragmentDefinition = defineFragment<ApiFragmentConfig>("api-frag
     }),
     onConnectionAvailable: defineHook(async function (payload) {
       await config.onConnectionAvailable?.(payload, this);
+    }),
+    onWebhookEndpointChanged: defineHook(async function (payload) {
+      await config.onWebhookEndpointChanged?.(payload, this);
     }),
     onWebhookReceived: defineHook(async function (payload) {
       await config.onWebhookReceived?.(

--- a/packages/api-fragment/src/routes.ts
+++ b/packages/api-fragment/src/routes.ts
@@ -18,7 +18,7 @@ import {
   type WebhookEndpointAuthInput,
 } from "./api-types";
 import { sha256Base64Url, utf8Bytes } from "./crypto";
-import { apiFragmentDefinition } from "./definition";
+import { apiFragmentDefinition, type WebhookEndpointHookSnapshot } from "./definition";
 import { apiSchema } from "./schema";
 import { assertAllowedBaseUrl, storedAuthPayloadSchema } from "./services";
 import {
@@ -142,6 +142,23 @@ function parseWebhookEndpointStatus(status: string): "draft" | "active" | "disab
     return status;
   }
   throw new Error(`Unexpected webhook endpoint status: ${status}`);
+}
+
+function webhookEndpointHookSnapshot(endpoint: {
+  name: string;
+  status: string;
+  authConfig: WebhookAuthConfig;
+  verification: WebhookVerificationConfig;
+  deliveryIdentity: WebhookDeliveryIdentity;
+}): WebhookEndpointHookSnapshot {
+  return {
+    name: endpoint.name,
+    status: parseWebhookEndpointStatus(endpoint.status),
+    authConfig: endpoint.authConfig,
+    verification: endpoint.verification,
+    deliveryIdentity: endpoint.deliveryIdentity,
+    secretRefs: [...getWebhookAuthSecretRefs(endpoint.authConfig)],
+  };
 }
 
 function recordFromSearchParams(
@@ -278,27 +295,36 @@ export const apiRoutesFactory = defineRoutes(apiFragmentDefinition).create(
           )
           .mutate(({ forSchema, retrieveResult: [existing, existingSecrets] }) => {
             const uow = forSchema(apiSchema);
+            const endpoint = {
+              id: pathParams.endpointId,
+              name: body.name,
+              status: body.status,
+              authConfig: authStorage.authConfig,
+              verification: body.verification,
+              deliveryIdentity: body.deliveryIdentity,
+              createdAt: existing?.createdAt,
+            };
             if (existing) {
               uow.update("webhookEndpoint", existing.id, (b) =>
                 b
                   .set({
-                    name: body.name,
-                    status: body.status,
-                    authConfig: authStorage.authConfig,
-                    verification: body.verification,
-                    deliveryIdentity: body.deliveryIdentity,
+                    name: endpoint.name,
+                    status: endpoint.status,
+                    authConfig: endpoint.authConfig,
+                    verification: endpoint.verification,
+                    deliveryIdentity: endpoint.deliveryIdentity,
                     updatedAt: b.now(),
                   })
                   .check(),
               );
             } else {
               uow.create("webhookEndpoint", {
-                id: pathParams.endpointId,
-                name: body.name,
-                status: body.status,
-                authConfig: authStorage.authConfig,
-                verification: body.verification,
-                deliveryIdentity: body.deliveryIdentity,
+                id: endpoint.id,
+                name: endpoint.name,
+                status: endpoint.status,
+                authConfig: endpoint.authConfig,
+                verification: endpoint.verification,
+                deliveryIdentity: endpoint.deliveryIdentity,
               });
             }
 
@@ -327,18 +353,13 @@ export const apiRoutesFactory = defineRoutes(apiFragmentDefinition).create(
               }
             }
 
-            return {
-              created: !existing,
-              endpoint: {
-                id: pathParams.endpointId,
-                name: body.name,
-                status: body.status,
-                authConfig: authStorage.authConfig,
-                verification: body.verification,
-                deliveryIdentity: body.deliveryIdentity,
-                createdAt: existing?.createdAt,
-              },
-            };
+            uow.triggerHook("onWebhookEndpointChanged", {
+              change: existing ? "updated" : "created",
+              endpointId: pathParams.endpointId,
+              endpoint: webhookEndpointHookSnapshot(endpoint),
+            });
+
+            return { created: !existing, endpoint };
           })
           .execute();
 
@@ -721,6 +742,11 @@ export const apiRoutesFactory = defineRoutes(apiFragmentDefinition).create(
                 });
               }
             }
+            uow.triggerHook("onWebhookEndpointChanged", {
+              change: "updated",
+              endpointId: pathParams.endpointId,
+              endpoint: webhookEndpointHookSnapshot(next),
+            });
             return { found: true as const, endpoint: next };
           })
           .execute();

--- a/packages/api-fragment/src/webhooks/management.test.ts
+++ b/packages/api-fragment/src/webhooks/management.test.ts
@@ -1,12 +1,14 @@
-import { assert, describe, expect, test } from "vitest";
+import { assert, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { instantiate } from "@fragno-dev/core";
-import { buildDatabaseFragmentsTest } from "@fragno-dev/test";
+import { buildDatabaseFragmentsTest, drainDurableHooks } from "@fragno-dev/test";
 
 import { createApiFragmentClients } from "../client/client";
 import { apiFragmentDefinition } from "../definition";
 import { apiRoutesFactory } from "../routes";
 import { apiSchema } from "../schema";
+
+const onWebhookEndpointChanged = vi.fn();
 
 const buildApiTest = async () => {
   const setup = await buildDatabaseFragmentsTest()
@@ -17,6 +19,7 @@ const buildApiTest = async () => {
       instantiate(apiFragmentDefinition)
         .withConfig({
           publicBaseUrl: "https://app.test",
+          onWebhookEndpointChanged,
         })
         .withRoutes([apiRoutesFactory]),
     )
@@ -38,6 +41,10 @@ async function readWebhookSecrets(test: ApiTest, endpointId: string) {
 }
 
 describe("webhook endpoint management", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   test("exports webhook endpoint client builders", () => {
     const clients = createApiFragmentClients();
 
@@ -91,6 +98,24 @@ describe("webhook endpoint management", () => {
       deliveryIdentity: { type: "header", name: "stripe-event-id" },
     });
     expect(JSON.stringify(created.data)).not.toContain("whsec_secret");
+
+    await drainDurableHooks(fragment);
+    expect(onWebhookEndpointChanged).toHaveBeenCalledOnce();
+    expect(onWebhookEndpointChanged).toHaveBeenCalledWith(
+      {
+        change: "created",
+        endpointId: "stripe",
+        endpoint: {
+          name: "Stripe",
+          status: "active",
+          authConfig: expect.objectContaining({ type: "hmac", secretRef: "secret" }),
+          verification: { type: "none" },
+          deliveryIdentity: { type: "header", name: "stripe-event-id" },
+          secretRefs: ["secret"],
+        },
+      },
+      expect.objectContaining({ idempotencyKey: expect.any(String), hookId: expect.any(Object) }),
+    );
 
     const secrets = await readWebhookSecrets(setup, "stripe");
     expect(secrets).toHaveLength(1);
@@ -146,6 +171,89 @@ describe("webhook endpoint management", () => {
     });
     assert(missing.type === "error");
     assert(missing.error.code === "WEBHOOK_ENDPOINT_NOT_FOUND");
+
+    await setup.test.cleanup();
+  });
+
+  test("reconciles webhook endpoint changes after PUT replacements and PATCH updates", async () => {
+    const setup = await buildApiTest();
+    const fragment = setup.fragments.api.fragment;
+
+    await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "reconciled-webhook" },
+      body: {
+        name: "Initial",
+        status: "active",
+        verification: { type: "none" },
+        deliveryIdentity: { type: "header", name: "x-event-id" },
+        auth: { type: "bearer", token: "initial-token" },
+      },
+    });
+    await drainDurableHooks(fragment);
+    vi.clearAllMocks();
+
+    await fragment.callRoute("PUT", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "reconciled-webhook" },
+      body: {
+        name: "Replaced",
+        status: "active",
+        verification: { type: "none" },
+        deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+        auth: { type: "basic", username: "ada", password: "lovelace" },
+      },
+    });
+    await drainDurableHooks(fragment);
+    expect(onWebhookEndpointChanged).toHaveBeenCalledOnce();
+    expect(onWebhookEndpointChanged).toHaveBeenCalledWith(
+      {
+        change: "updated",
+        endpointId: "reconciled-webhook",
+        endpoint: {
+          name: "Replaced",
+          status: "active",
+          authConfig: { type: "basic", usernameRef: "username", passwordRef: "password" },
+          verification: { type: "none" },
+          deliveryIdentity: { type: "jsonBodyPath", path: ["id"] },
+          secretRefs: ["username", "password"],
+        },
+      },
+      expect.any(Object),
+    );
+    vi.clearAllMocks();
+
+    await fragment.callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "reconciled-webhook" },
+      body: { name: "Renamed" },
+    });
+    await drainDurableHooks(fragment);
+    expect(onWebhookEndpointChanged).toHaveBeenCalledOnce();
+    expect(onWebhookEndpointChanged).toHaveBeenCalledWith(
+      {
+        change: "updated",
+        endpointId: "reconciled-webhook",
+        endpoint: expect.objectContaining({
+          name: "Renamed",
+          status: "active",
+          secretRefs: ["username", "password"],
+        }),
+      },
+      expect.any(Object),
+    );
+    vi.clearAllMocks();
+
+    await fragment.callRoute("PATCH", "/webhooks/endpoints/:endpointId", {
+      pathParams: { endpointId: "reconciled-webhook" },
+      body: { status: "disabled" },
+    });
+    await drainDurableHooks(fragment);
+    expect(onWebhookEndpointChanged).toHaveBeenCalledWith(
+      {
+        change: "updated",
+        endpointId: "reconciled-webhook",
+        endpoint: expect.objectContaining({ name: "Renamed", status: "disabled" }),
+      },
+      expect.any(Object),
+    );
 
     await setup.test.cleanup();
   });

--- a/packages/tanstack-db-adapter/src/coordinator.e2e.test.ts
+++ b/packages/tanstack-db-adapter/src/coordinator.e2e.test.ts
@@ -22,6 +22,7 @@ import { createNodeSQLitePersistence } from "@tanstack/node-db-sqlite-persistenc
 
 import {
   createFragnoOutboxCoordinator,
+  type FragnoBrowserPersistenceDiagnostics,
   type FragnoCollectionRow,
   type FragnoOutboxCoordinatorDependencies,
   type FragnoOutboxCoordinatorState,
@@ -337,23 +338,75 @@ describe("Fragno TanStack adapter from scratch end-to-end", () => {
     }
   });
 
-  it("rejects startup when browser persistence opening stalls", async () => {
-    const server = await createTestServer("persistence-opening-timeout");
-    const coordinatorPromise = createFragnoOutboxCoordinator(
-      { baseUrl: server.baseUrl, fetch: server.fetch, schemas: [appSchema] },
+  it("reports delayed startup before synchronizing route-backed state into SQLite", async () => {
+    const server = await createTestServer("delayed-persistence-startup");
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "fragno-delayed-startup-"));
+    const databasePath = join(temporaryDirectory, "persistence.sqlite");
+    const persistenceOpeningStarted = Promise.withResolvers<void>();
+    const allowPersistenceOpening = Promise.withResolvers<void>();
+    const diagnosticPublished = Promise.withResolvers<FragnoBrowserPersistenceDiagnostics>();
+    let persistenceCleanupCalls = 0;
+    let coordinatorCleaned = false;
+
+    const coordinatorOpening = createFragnoOutboxCoordinator(
       {
-        openPersistence() {
-          return new Promise<never>(() => {});
+        baseUrl: server.baseUrl,
+        fetch: server.fetch,
+        schemas: [appSchema],
+        onBrowserPersistenceDiagnostic(diagnostics) {
+          diagnosticPublished.resolve(diagnostics);
+        },
+      },
+      {
+        async openPersistence() {
+          persistenceOpeningStarted.resolve();
+          await allowPersistenceOpening.promise;
+          const database = new Database(databasePath);
+          return {
+            persistence: createNodeSQLitePersistence({ database }),
+            async cleanup() {
+              persistenceCleanupCalls += 1;
+              database.close();
+            },
+          };
         },
       },
     );
 
     try {
-      await expect(coordinatorPromise).rejects.toThrow(
-        "Fragno outbox startup timed out after 5000ms while opening browser persistence.",
-      );
+      await persistenceOpeningStarted.promise;
+      const diagnostic = await diagnosticPublished.promise;
+      assert.ok(diagnostic.elapsedMs >= 3_000);
+      assert.match(diagnostic.databaseName, /^fragno-v3-[0-9a-f]{32}\.sqlite$/);
+
+      allowPersistenceOpening.resolve();
+      const coordinator = await coordinatorOpening;
+      try {
+        const users = coordinator.collection(appSchema, "users");
+        await server.createDiscussion();
+        await coordinator.preload();
+        await waitForCollection(users, () => users.get("user-2")?.name === "Grace");
+        await coordinator.flushPersistence();
+
+        expect(sortedRows<User>(users.values())).toEqual([
+          { id: "user-1", name: "Ada" },
+          { id: "user-2", name: "Grace" },
+        ]);
+        assert.ok(readDurableCheckpoint(databasePath));
+      } finally {
+        await coordinator.cleanup();
+        coordinatorCleaned = true;
+      }
+
+      assert.equal(persistenceCleanupCalls, 1);
     } finally {
+      allowPersistenceOpening.resolve();
+      if (!coordinatorCleaned) {
+        const coordinator = await coordinatorOpening.catch(() => null);
+        await coordinator?.cleanup().catch(() => {});
+      }
       await server.cleanup();
+      await rm(temporaryDirectory, { recursive: true, force: true });
     }
   }, 10_000);
 

--- a/packages/tanstack-db-adapter/src/coordinator.ts
+++ b/packages/tanstack-db-adapter/src/coordinator.ts
@@ -5,6 +5,10 @@ import type { AnySchema, AnyTable, FragnoId, FragnoReference } from "@fragno-dev
 import type { Collection } from "@tanstack/db";
 import type { PersistedCollectionPersistence } from "@tanstack/db-sqlite-persistence-core";
 
+import {
+  openFragnoBrowserPersistenceWithDiagnostics,
+  type FragnoBrowserPersistenceDiagnostics,
+} from "./coordinator/fragno-browser-persistence-startup";
 import { FragnoCollectionRegistry } from "./coordinator/fragno-collection-registry";
 import {
   FRAGNO_INTERNAL_COLLECTION_ID,
@@ -80,6 +84,7 @@ export type FragnoCollectionRow<TTable extends AnyTable> = {
 };
 
 export type { FragnoOutboxCheckpoint } from "./checkpoint";
+export type { FragnoBrowserPersistenceDiagnostics } from "./coordinator/fragno-browser-persistence-startup";
 
 export {
   FragnoInternalCollection,
@@ -108,11 +113,13 @@ export type FragnoOutboxCatchUpProgress = {
   percent: number;
 };
 
+type FragnoOutboxPersistenceResource = {
+  persistence: PersistedCollectionPersistence;
+  cleanup(): Promise<void>;
+};
+
 export type FragnoOutboxCoordinatorDependencies = {
-  openPersistence(options: { databaseName: string }): Promise<{
-    persistence: PersistedCollectionPersistence;
-    cleanup(): Promise<void>;
-  }>;
+  openPersistence(options: { databaseName: string }): Promise<FragnoOutboxPersistenceResource>;
 };
 
 export type FragnoCollectionOptions = {
@@ -150,6 +157,8 @@ export async function createFragnoOutboxCoordinator<const TSchemas extends reado
     fetch: typeof globalThis.fetch;
     schemas: TSchemas;
     onCatchUpProgress?(progress: FragnoOutboxCatchUpProgress): void;
+    /** Receives recurring browser persistence diagnostics while startup remains stalled. */
+    onBrowserPersistenceDiagnostic?(diagnostics: FragnoBrowserPersistenceDiagnostics): void;
   },
   dependencies: FragnoOutboxCoordinatorDependencies = {
     openPersistence: openBrowserFragnoOutboxPersistence,
@@ -178,10 +187,11 @@ export async function createFragnoOutboxCoordinator<const TSchemas extends reado
   // The v3 prefix leaves behind databases created with the temporary single-process wiring.
   const databaseName = `fragno-v3-${databaseHash.slice(0, 32)}.sqlite`;
 
-  const persistenceResource = await waitForFragnoOutboxStartupStage(
-    dependencies.openPersistence({ databaseName }),
-    "opening browser persistence",
-  );
+  const persistenceResource = await openFragnoBrowserPersistenceWithDiagnostics({
+    databaseName,
+    onDiagnostic: (diagnostics) => options.onBrowserPersistenceDiagnostic?.(diagnostics),
+    openPersistence: () => dependencies.openPersistence({ databaseName }),
+  });
   const persistence = orderFragnoPersistenceWrites(persistenceResource.persistence);
 
   let internalCollection: FragnoInternalCollection | undefined;

--- a/packages/tanstack-db-adapter/src/coordinator/fragno-browser-persistence-startup.test.ts
+++ b/packages/tanstack-db-adapter/src/coordinator/fragno-browser-persistence-startup.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
+
+import { openFragnoBrowserPersistenceWithDiagnostics } from "./fragno-browser-persistence-startup";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("Fragno browser persistence startup", () => {
+  it("reports diagnostics after three seconds and keeps waiting for persistence", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("Worker", undefined);
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const persistenceOpening = Promise.withResolvers<{ opened: true }>();
+    const persistenceOpeningStarted = Promise.withResolvers<void>();
+    let startupSettled = false;
+    const diagnosticsReported: unknown[] = [];
+    const startupPromise = openFragnoBrowserPersistenceWithDiagnostics({
+      databaseName: "fragno-test.sqlite",
+      onDiagnostic(diagnostics) {
+        diagnosticsReported.push(diagnostics);
+      },
+      openPersistence() {
+        persistenceOpeningStarted.resolve();
+        return persistenceOpening.promise;
+      },
+    });
+    void startupPromise.then(
+      () => {
+        startupSettled = true;
+      },
+      () => {
+        startupSettled = true;
+      },
+    );
+
+    await persistenceOpeningStarted.promise;
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    assert.equal(startupSettled, false);
+    expect(warning).toHaveBeenCalledTimes(1);
+    assert.match(
+      String(warning.mock.calls[0]?.[0]),
+      /^Fragno outbox browser persistence is still opening after 3000ms\..*Initialization will keep waiting\.$/,
+    );
+    const expectedDiagnostics = {
+      databaseName: "fragno-test.sqlite",
+      elapsedMs: 3_000,
+      timerDriftMs: 0,
+      workerProbe: {
+        status: "unsupported",
+      },
+      runtime: {
+        opfsAvailable: false,
+      },
+    };
+    expect(warning.mock.calls[0]?.[1]).toMatchObject(expectedDiagnostics);
+    expect(diagnosticsReported).toHaveLength(1);
+    expect(diagnosticsReported[0]).toMatchObject(expectedDiagnostics);
+
+    persistenceOpening.resolve({ opened: true });
+    await expect(startupPromise).resolves.toEqual({ opened: true });
+  });
+
+  it("keeps reporting diagnostics when a browser inspection stalls", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("Worker", undefined);
+    const queryLocks = vi.fn(() => new Promise<never>(() => {}));
+    vi.stubGlobal("navigator", { locks: { query: queryLocks } });
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const persistenceOpening = Promise.withResolvers<{ opened: true }>();
+    const diagnosticsReported: unknown[] = [];
+    const startupPromise = openFragnoBrowserPersistenceWithDiagnostics({
+      databaseName: "fragno-test.sqlite",
+      onDiagnostic(diagnostics) {
+        diagnosticsReported.push(diagnostics);
+      },
+      openPersistence() {
+        return persistenceOpening.promise;
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expect(diagnosticsReported).toHaveLength(1);
+    expect(diagnosticsReported[0]).toMatchObject({
+      webLocks: {
+        status: "failed",
+        error: "Web Locks inspection timed out after 1000ms.",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expect(warning).toHaveBeenCalledTimes(2);
+    expect(diagnosticsReported).toHaveLength(2);
+    expect(queryLocks).toHaveBeenCalledTimes(1);
+
+    persistenceOpening.resolve({ opened: true });
+    await expect(startupPromise).resolves.toEqual({ opened: true });
+  });
+
+  it("opens persistence while the dedicated worker probe is still starting", async () => {
+    class DelayedWorkerProbe extends EventTarget {
+      static readonly instances: DelayedWorkerProbe[] = [];
+      terminated = false;
+
+      constructor(_scriptUrl: string | URL) {
+        super();
+        DelayedWorkerProbe.instances.push(this);
+      }
+
+      terminate() {
+        this.terminated = true;
+      }
+    }
+
+    vi.stubGlobal("Worker", DelayedWorkerProbe);
+    const persistenceOpening = Promise.withResolvers<{ opened: true }>();
+    const persistenceOpeningStarted = Promise.withResolvers<void>();
+    let persistenceOpenCalls = 0;
+    const startupPromise = openFragnoBrowserPersistenceWithDiagnostics({
+      databaseName: "fragno-test.sqlite",
+      onDiagnostic: null,
+      openPersistence() {
+        persistenceOpenCalls += 1;
+        persistenceOpeningStarted.resolve();
+        return persistenceOpening.promise;
+      },
+    });
+
+    await persistenceOpeningStarted.promise;
+    assert.equal(DelayedWorkerProbe.instances.length, 1);
+    assert.equal(persistenceOpenCalls, 1);
+    assert.equal(DelayedWorkerProbe.instances[0]!.terminated, false);
+
+    persistenceOpening.resolve({ opened: true });
+    await expect(startupPromise).resolves.toEqual({ opened: true });
+    assert.equal(DelayedWorkerProbe.instances[0]!.terminated, true);
+  });
+});

--- a/packages/tanstack-db-adapter/src/coordinator/fragno-browser-persistence-startup.ts
+++ b/packages/tanstack-db-adapter/src/coordinator/fragno-browser-persistence-startup.ts
@@ -1,0 +1,568 @@
+const FRAGNO_BROWSER_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS = 3_000;
+const FRAGNO_BROWSER_PERSISTENCE_INSPECTION_TIMEOUT_MS = 1_000;
+
+type FragnoBrowserDiagnostic<TValue> =
+  | { status: "available"; value: TValue }
+  | { status: "unavailable"; reason: string }
+  | { status: "failed"; error: string };
+
+type FragnoBrowserLock = {
+  name: string;
+  mode: string;
+  clientId: string | null;
+};
+
+type FragnoBrowserLockSnapshot = {
+  held: FragnoBrowserLock[];
+  pending: FragnoBrowserLock[];
+  relevantHeld: FragnoBrowserLock[];
+  relevantPending: FragnoBrowserLock[];
+  interpretation: string;
+};
+
+type FragnoBrowserStorageEstimate = {
+  quota: number | null;
+  usage: number | null;
+  usageDetails: Record<string, number> | null;
+};
+
+type FragnoBrowserWorkerProbeSnapshot =
+  | { status: "unsupported"; reason: string }
+  | { status: "starting"; elapsedMs: number }
+  | {
+      status: "responsive";
+      responseMs: number;
+      runtime: {
+        timerAvailable: boolean;
+        opfsAvailable: boolean;
+        fileSystemFileHandleGlobalAvailable: boolean;
+        syncAccessHandlePrototypeAvailable: boolean;
+      };
+    }
+  | { status: "failed"; error: string };
+
+type FragnoBrowserWorkerProbe = {
+  snapshot(): FragnoBrowserWorkerProbeSnapshot;
+  cleanup(): void;
+};
+
+type FragnoOPFSEntry =
+  | { kind: "file"; name: string }
+  | {
+      kind: "directory";
+      name: string;
+      entries: Array<{ name: string; kind: string }>;
+      inspectionError: string | null;
+    };
+
+type FragnoBrowserDiagnosticsGlobal = typeof globalThis & {
+  FileSystemFileHandle?: {
+    prototype?: { createSyncAccessHandle?: unknown };
+  };
+  navigator?: Navigator & {
+    storage?: StorageManager & {
+      getDirectory?: () => Promise<FileSystemDirectoryHandle>;
+    };
+  };
+};
+
+/** Captures worker, runtime, storage, Web Locks, and OPFS state during a stalled browser startup. */
+export type FragnoBrowserPersistenceDiagnostics = {
+  databaseName: string;
+  elapsedMs: number;
+  timerDriftMs: number;
+  collectedAt: string;
+  likelyCause: string;
+  workerProbe: FragnoBrowserWorkerProbeSnapshot;
+  runtime: {
+    href: string | null;
+    origin: string | null;
+    userAgent: string | null;
+    visibilityState: DocumentVisibilityState | null;
+    readyState: DocumentReadyState | null;
+    documentHasFocus: boolean | null;
+    isSecureContext: boolean;
+    crossOriginIsolated: boolean;
+    online: boolean | null;
+    hardwareConcurrency: number | null;
+    workerAvailable: boolean;
+    broadcastChannelAvailable: boolean;
+    webLocksAvailable: boolean;
+    opfsAvailable: boolean;
+    fileSystemFileHandleGlobalAvailable: boolean;
+  };
+  webLocks: FragnoBrowserDiagnostic<FragnoBrowserLockSnapshot>;
+  storageEstimate: FragnoBrowserDiagnostic<FragnoBrowserStorageEstimate>;
+  persistedStorage: FragnoBrowserDiagnostic<boolean>;
+  opfsEntries: FragnoBrowserDiagnostic<FragnoOPFSEntry[]>;
+};
+
+type FragnoBrowserPersistenceStartupOptions<TResource> = {
+  databaseName: string;
+  onDiagnostic: ((diagnostics: FragnoBrowserPersistenceDiagnostics) => void) | null;
+  openPersistence(): Promise<TResource>;
+};
+
+type FragnoBrowserPersistenceDiagnosticInspectors = {
+  webLocks(): Promise<FragnoBrowserDiagnostic<FragnoBrowserLockSnapshot>>;
+  storageEstimate(): Promise<FragnoBrowserDiagnostic<FragnoBrowserStorageEstimate>>;
+  persistedStorage(): Promise<FragnoBrowserDiagnostic<boolean>>;
+  opfsEntries(): Promise<FragnoBrowserDiagnostic<FragnoOPFSEntry[]>>;
+};
+
+/** Opens browser persistence immediately while an observational worker probe reports startup diagnostics. */
+export async function openFragnoBrowserPersistenceWithDiagnostics<TResource>(
+  options: FragnoBrowserPersistenceStartupOptions<TResource>,
+): Promise<TResource> {
+  const startedAt = Date.now();
+  const workerProbe = startFragnoBrowserWorkerProbe();
+  const diagnosticsInspectors = createFragnoBrowserPersistenceDiagnosticInspectors(
+    options.databaseName,
+  );
+  let settled = false;
+  let expectedDiagnosticsElapsedMs = FRAGNO_BROWSER_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS;
+  let diagnosticsTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function scheduleDiagnostics() {
+    diagnosticsTimer = setTimeout(() => {
+      const elapsedMs = Date.now() - startedAt;
+      void collectFragnoBrowserPersistenceDiagnostics({
+        databaseName: options.databaseName,
+        elapsedMs,
+        timerDriftMs: Math.max(0, elapsedMs - expectedDiagnosticsElapsedMs),
+        workerProbe: workerProbe.snapshot(),
+        inspectors: diagnosticsInspectors,
+      }).then((diagnostics) => {
+        if (settled) {
+          return;
+        }
+
+        console.warn(
+          `Fragno outbox browser persistence is still opening after ${diagnostics.elapsedMs}ms. ${diagnostics.likelyCause} Initialization will keep waiting.`,
+          diagnostics,
+        );
+        try {
+          options.onDiagnostic?.(diagnostics);
+        } catch (error) {
+          console.error("Fragno browser persistence diagnostic listener failed.", error);
+        }
+        expectedDiagnosticsElapsedMs += FRAGNO_BROWSER_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS;
+        scheduleDiagnostics();
+      });
+    }, FRAGNO_BROWSER_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS);
+  }
+
+  scheduleDiagnostics();
+  try {
+    return await options.openPersistence();
+  } finally {
+    settled = true;
+    clearTimeout(diagnosticsTimer);
+    workerProbe.cleanup();
+  }
+}
+
+function startFragnoBrowserWorkerProbe(): FragnoBrowserWorkerProbe {
+  const browserGlobal = globalThis as FragnoBrowserDiagnosticsGlobal;
+  if (
+    typeof browserGlobal.Worker !== "function" ||
+    typeof browserGlobal.Blob !== "function" ||
+    typeof browserGlobal.URL?.createObjectURL !== "function"
+  ) {
+    return {
+      snapshot: () => ({
+        status: "unsupported",
+        reason: "Dedicated worker probing is unavailable in this runtime.",
+      }),
+      cleanup() {},
+    };
+  }
+
+  const startedAt = Date.now();
+  let snapshot: FragnoBrowserWorkerProbeSnapshot = { status: "starting", elapsedMs: 0 };
+  let worker: Worker | null = null;
+  let workerUrl: string | null = null;
+
+  function cleanup() {
+    worker?.terminate();
+    worker = null;
+    if (workerUrl) {
+      browserGlobal.URL.revokeObjectURL(workerUrl);
+      workerUrl = null;
+    }
+  }
+
+  try {
+    const source = `globalThis.postMessage({
+      type: "fragno-browser-worker-ready",
+      timerAvailable: typeof globalThis.setTimeout === "function",
+      opfsAvailable: typeof globalThis.navigator?.storage?.getDirectory === "function",
+      fileSystemFileHandleGlobalAvailable: typeof globalThis.FileSystemFileHandle === "function",
+      syncAccessHandlePrototypeAvailable:
+        typeof globalThis.FileSystemFileHandle?.prototype?.createSyncAccessHandle === "function",
+    });`;
+    workerUrl = browserGlobal.URL.createObjectURL(
+      new browserGlobal.Blob([source], { type: "text/javascript" }),
+    );
+    worker = new browserGlobal.Worker(workerUrl);
+    worker.addEventListener("message", (event: MessageEvent<unknown>) => {
+      const runtime = event.data as {
+        type: "fragno-browser-worker-ready";
+        timerAvailable: boolean;
+        opfsAvailable: boolean;
+        fileSystemFileHandleGlobalAvailable: boolean;
+        syncAccessHandlePrototypeAvailable: boolean;
+      };
+      snapshot = {
+        status: "responsive",
+        responseMs: Date.now() - startedAt,
+        runtime: {
+          timerAvailable: runtime.timerAvailable,
+          opfsAvailable: runtime.opfsAvailable,
+          fileSystemFileHandleGlobalAvailable: runtime.fileSystemFileHandleGlobalAvailable,
+          syncAccessHandlePrototypeAvailable: runtime.syncAccessHandlePrototypeAvailable,
+        },
+      };
+      cleanup();
+    });
+    worker.addEventListener("error", (event: ErrorEvent) => {
+      snapshot = {
+        status: "failed",
+        error: event.message || "Dedicated worker probe failed without an error message.",
+      };
+      cleanup();
+    });
+    worker.addEventListener("messageerror", () => {
+      snapshot = {
+        status: "failed",
+        error: "Dedicated worker probe response could not be deserialized.",
+      };
+      cleanup();
+    });
+  } catch (error) {
+    snapshot = { status: "failed", error: describeFragnoBrowserDiagnosticError(error) };
+    cleanup();
+  }
+
+  return {
+    snapshot() {
+      if (snapshot.status !== "starting") {
+        return snapshot;
+      }
+      return { status: "starting", elapsedMs: Date.now() - startedAt };
+    },
+    cleanup,
+  };
+}
+
+function createFragnoBrowserPersistenceDiagnosticInspectors(
+  databaseName: string,
+): FragnoBrowserPersistenceDiagnosticInspectors {
+  return {
+    webLocks: createRecurringFragnoBrowserDiagnosticInspector("Web Locks inspection", () =>
+      inspectFragnoBrowserLocks(databaseName),
+    ),
+    storageEstimate: createRecurringFragnoBrowserDiagnosticInspector(
+      "Storage estimate inspection",
+      inspectFragnoBrowserStorageEstimate,
+    ),
+    persistedStorage: createRecurringFragnoBrowserDiagnosticInspector(
+      "Persisted storage inspection",
+      inspectFragnoBrowserPersistedStorage,
+    ),
+    opfsEntries: createRecurringFragnoBrowserDiagnosticInspector("OPFS inspection", () =>
+      inspectFragnoBrowserOPFSEntries(databaseName),
+    ),
+  };
+}
+
+function createRecurringFragnoBrowserDiagnosticInspector<TValue>(
+  inspectionName: string,
+  inspect: () => Promise<FragnoBrowserDiagnostic<TValue>>,
+): () => Promise<FragnoBrowserDiagnostic<TValue>> {
+  let activeInspection: Promise<FragnoBrowserDiagnostic<TValue>> | null = null;
+
+  return function inspectFragnoBrowserDiagnostic() {
+    if (activeInspection === null) {
+      activeInspection = inspect().finally(() => {
+        activeInspection = null;
+      });
+    }
+
+    return waitForFragnoBrowserDiagnosticInspection(inspectionName, activeInspection);
+  };
+}
+
+function waitForFragnoBrowserDiagnosticInspection<TValue>(
+  inspectionName: string,
+  inspection: Promise<FragnoBrowserDiagnostic<TValue>>,
+): Promise<FragnoBrowserDiagnostic<TValue>> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      settled = true;
+      resolve({
+        status: "failed",
+        error: `${inspectionName} timed out after ${FRAGNO_BROWSER_PERSISTENCE_INSPECTION_TIMEOUT_MS}ms.`,
+      });
+    }, FRAGNO_BROWSER_PERSISTENCE_INSPECTION_TIMEOUT_MS);
+
+    void inspection.then(
+      (diagnostic) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        resolve(diagnostic);
+      },
+      (error: unknown) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        resolve({ status: "failed", error: describeFragnoBrowserDiagnosticError(error) });
+      },
+    );
+  });
+}
+
+async function collectFragnoBrowserPersistenceDiagnostics(options: {
+  databaseName: string;
+  elapsedMs: number;
+  timerDriftMs: number;
+  workerProbe: FragnoBrowserWorkerProbeSnapshot;
+  inspectors: FragnoBrowserPersistenceDiagnosticInspectors;
+}): Promise<FragnoBrowserPersistenceDiagnostics> {
+  const browserGlobal = globalThis as FragnoBrowserDiagnosticsGlobal;
+  const browserNavigator = browserGlobal.navigator;
+  const browserDocument = browserGlobal.document;
+  const browserLocation = browserGlobal.location;
+
+  const [webLocks, storageEstimate, persistedStorage, opfsEntries] = await Promise.all([
+    options.inspectors.webLocks(),
+    options.inspectors.storageEstimate(),
+    options.inspectors.persistedStorage(),
+    options.inspectors.opfsEntries(),
+  ]);
+
+  const visibilityState = browserDocument?.visibilityState ?? null;
+  const likelyCause = diagnoseFragnoBrowserPersistenceStall({
+    visibilityState,
+    workerProbe: options.workerProbe,
+    webLocks,
+  });
+
+  return {
+    databaseName: options.databaseName,
+    elapsedMs: options.elapsedMs,
+    timerDriftMs: options.timerDriftMs,
+    collectedAt: new Date().toISOString(),
+    likelyCause,
+    workerProbe: options.workerProbe,
+    runtime: {
+      href: browserLocation?.href ?? null,
+      origin: browserLocation?.origin ?? null,
+      userAgent: browserNavigator?.userAgent ?? null,
+      visibilityState,
+      readyState: browserDocument?.readyState ?? null,
+      documentHasFocus: browserDocument?.hasFocus() ?? null,
+      isSecureContext: browserGlobal.isSecureContext ?? false,
+      crossOriginIsolated: browserGlobal.crossOriginIsolated ?? false,
+      online: browserNavigator?.onLine ?? null,
+      hardwareConcurrency: browserNavigator?.hardwareConcurrency ?? null,
+      workerAvailable: typeof browserGlobal.Worker === "function",
+      broadcastChannelAvailable: typeof browserGlobal.BroadcastChannel === "function",
+      webLocksAvailable: typeof browserNavigator?.locks?.query === "function",
+      opfsAvailable: typeof browserNavigator?.storage?.getDirectory === "function",
+      fileSystemFileHandleGlobalAvailable: typeof browserGlobal.FileSystemFileHandle === "function",
+    },
+    webLocks,
+    storageEstimate,
+    persistedStorage,
+    opfsEntries,
+  };
+}
+
+function diagnoseFragnoBrowserPersistenceStall(options: {
+  visibilityState: DocumentVisibilityState | null;
+  workerProbe: FragnoBrowserWorkerProbeSnapshot;
+  webLocks: Awaited<ReturnType<typeof inspectFragnoBrowserLocks>>;
+}): string {
+  const hasRelevantLocks =
+    options.webLocks.status === "available" &&
+    (options.webLocks.value.relevantHeld.length > 0 ||
+      options.webLocks.value.relevantPending.length > 0);
+
+  if (options.workerProbe.status === "starting" && !hasRelevantLocks) {
+    if (options.visibilityState === "hidden") {
+      return "The diagnostic worker has not responded and OPFS has created no locks. The document is hidden, which may be contributing to worker scheduling delays in this Electron runtime; the SQLite persistence worker may also be waiting to execute.";
+    }
+    return "The diagnostic worker has not responded and OPFS has created no locks. The SQLite persistence worker may also be waiting to execute.";
+  }
+
+  if (options.workerProbe.status === "failed") {
+    return `Diagnostic worker startup failed: ${options.workerProbe.error}`;
+  }
+
+  if (options.webLocks.status === "available") {
+    return options.webLocks.value.interpretation;
+  }
+
+  return "The upstream persistence API has not completed and exposes no finer-grained initialization progress.";
+}
+
+async function inspectFragnoBrowserLocks(
+  databaseName: string,
+): Promise<FragnoBrowserDiagnostic<FragnoBrowserLockSnapshot>> {
+  try {
+    const lockManager = globalThis.navigator?.locks;
+    if (!lockManager?.query) {
+      return { status: "unavailable", reason: "Web Locks query is unavailable." };
+    }
+
+    const snapshot = (await lockManager.query()) as {
+      held: Array<{ name: string; mode: string; clientId?: string }>;
+      pending: Array<{ name: string; mode: string; clientId?: string }>;
+    };
+    const held = snapshot.held.map(materializeFragnoBrowserLock);
+    const pending = snapshot.pending.map(materializeFragnoBrowserLock);
+    const databaseLockName = `ahp:/${databaseName}`;
+    const isRelevantLock = (lock: FragnoBrowserLock) =>
+      lock.name === databaseLockName || lock.name.startsWith(".ahp-");
+    const relevantHeld = held.filter(isRelevantLock);
+    const relevantPending = pending.filter(isRelevantLock);
+
+    let interpretation = "OPFS did not expose an active initialization lock.";
+    if (relevantPending.some((lock) => lock.name === databaseLockName)) {
+      interpretation = "OPFS is waiting to acquire the database access-handle lock.";
+    } else if (relevantHeld.some((lock) => lock.name === databaseLockName)) {
+      interpretation =
+        "OPFS acquired the database access-handle lock but did not finish opening SQLite.";
+    } else if (relevantHeld.some((lock) => lock.name.startsWith(".ahp-"))) {
+      interpretation =
+        "OPFS created its temporary VFS lock but has not requested the database access-handle lock.";
+    }
+
+    return {
+      status: "available",
+      value: { held, pending, relevantHeld, relevantPending, interpretation },
+    };
+  } catch (error) {
+    return { status: "failed", error: describeFragnoBrowserDiagnosticError(error) };
+  }
+}
+
+async function inspectFragnoBrowserStorageEstimate(): Promise<
+  FragnoBrowserDiagnostic<FragnoBrowserStorageEstimate>
+> {
+  try {
+    const storage = globalThis.navigator?.storage;
+    if (!storage?.estimate) {
+      return { status: "unavailable", reason: "Storage estimate is unavailable." };
+    }
+
+    const estimate = (await storage.estimate()) as StorageEstimate & {
+      usageDetails?: Record<string, number>;
+    };
+    return {
+      status: "available",
+      value: {
+        quota: estimate.quota ?? null,
+        usage: estimate.usage ?? null,
+        usageDetails: estimate.usageDetails ? { ...estimate.usageDetails } : null,
+      },
+    };
+  } catch (error) {
+    return { status: "failed", error: describeFragnoBrowserDiagnosticError(error) };
+  }
+}
+
+async function inspectFragnoBrowserPersistedStorage(): Promise<FragnoBrowserDiagnostic<boolean>> {
+  try {
+    const storage = globalThis.navigator?.storage;
+    if (!storage?.persisted) {
+      return { status: "unavailable", reason: "Persisted storage status is unavailable." };
+    }
+
+    return { status: "available", value: await storage.persisted() };
+  } catch (error) {
+    return { status: "failed", error: describeFragnoBrowserDiagnosticError(error) };
+  }
+}
+
+async function inspectFragnoBrowserOPFSEntries(
+  databaseName: string,
+): Promise<FragnoBrowserDiagnostic<FragnoOPFSEntry[]>> {
+  try {
+    const browserNavigator = (globalThis as FragnoBrowserDiagnosticsGlobal).navigator;
+    const getDirectory = browserNavigator?.storage?.getDirectory;
+    if (!getDirectory) {
+      return { status: "unavailable", reason: "OPFS directory inspection is unavailable." };
+    }
+
+    const root = await getDirectory.call(browserNavigator.storage);
+    const entries: FragnoOPFSEntry[] = [];
+    for await (const entry of iterateFragnoFileSystemDirectory(root)) {
+      if (!entry.name.startsWith(".ahp-") && !entry.name.startsWith(databaseName)) {
+        continue;
+      }
+
+      if (entry.kind === "file") {
+        // Reading file metadata can contend with the sync access handles whose startup we are
+        // diagnosing. Directory names reveal the relevant OPFS state without perturbing it.
+        entries.push({ kind: "file", name: entry.name });
+        continue;
+      }
+
+      try {
+        const children = [];
+        for await (const child of iterateFragnoFileSystemDirectory(
+          entry as FileSystemDirectoryHandle,
+        )) {
+          children.push({ name: child.name, kind: child.kind });
+        }
+        entries.push({
+          kind: "directory",
+          name: entry.name,
+          entries: children,
+          inspectionError: null,
+        });
+      } catch (error) {
+        entries.push({
+          kind: "directory",
+          name: entry.name,
+          entries: [],
+          inspectionError: describeFragnoBrowserDiagnosticError(error),
+        });
+      }
+    }
+
+    return { status: "available", value: entries };
+  } catch (error) {
+    return { status: "failed", error: describeFragnoBrowserDiagnosticError(error) };
+  }
+}
+
+function iterateFragnoFileSystemDirectory(
+  directory: FileSystemDirectoryHandle,
+): AsyncIterable<FileSystemHandle> {
+  return (
+    directory as FileSystemDirectoryHandle & {
+      values(): AsyncIterable<FileSystemHandle>;
+    }
+  ).values();
+}
+
+function materializeFragnoBrowserLock(lock: {
+  name: string;
+  mode: string;
+  clientId?: string;
+}): FragnoBrowserLock {
+  return { name: lock.name, mode: lock.mode, clientId: lock.clientId ?? null };
+}
+
+function describeFragnoBrowserDiagnosticError(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}


### PR DESCRIPTION
- **fix(tanstack-db-adapter,backoffice): diagnose persistence stalls**
- **feat(api-fragment): emit webhook endpoint change hooks**
- **feat(backoffice): catalog webhook event sources**
- **refactor(backoffice): remove obsolete terminal links**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook endpoint creation and updates now emit durable automation events.
  * Automation event sources can be synchronized, listed, and displayed on the dashboard.
  * Added development diagnostics for stalled browser persistence startup, including likely causes and runtime details.

* **Bug Fixes**
  * Improved detection and reporting of browser persistence initialization delays.

* **Documentation**
  * Expanded webhook guidance with setup, verification, authentication, delivery, and troubleshooting workflows.

* **Style**
  * Removed “Back to terminal” links from error and not-found pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->