### PR TITLE
wilco/bo current scope

### DIFF
--- a/apps/backoffice/app/files/content/generating-backoffice-uis-skill.test.ts
+++ b/apps/backoffice/app/files/content/generating-backoffice-uis-skill.test.ts
@@ -267,6 +267,7 @@ describe("generating Backoffice UIs skill", () => {
     expect(systemGuidance).toContain("Classify execution errors from their messages");
     expect(systemGuidance).toMatch(/Report\s+success only from an executed result/u);
     expect(systemGuidance).toContain("A scope is the ownership and authorization boundary");
+    expect(systemGuidance).toContain("context.getCurrentScope()");
     expect(systemGuidance).toContain("context.current.store.get(...)");
     expect(systemGuidance).toContain("context.org(orgId)");
     expect(systemGuidance).toContain("context.user(userId)");

--- a/apps/backoffice/app/fragno/codemode/codemode-executor.ts
+++ b/apps/backoffice/app/fragno/codemode/codemode-executor.ts
@@ -148,6 +148,12 @@ const createScopedContextProxySource = () => String.raw`
       }
     });
     const context = {
+      getCurrentScope: async () => {
+        const resJson = await __dispatchers.__context.call("getCurrentScope", __stringifyForCodemode([]));
+        const data = __parseForCodemode(resJson);
+        if (data.error) throw new Error(data.error);
+        return data.result;
+      },
       get current() { return __createScopedContextHandle({ kind: "current" }); },
       org: (orgId) => __createScopedContextHandle({ kind: "org", orgId: String(orgId) }),
       user: (userId) => __createScopedContextHandle({ kind: "user", userId: String(userId) }),

--- a/apps/backoffice/app/fragno/codemode/execute.ts
+++ b/apps/backoffice/app/fragno/codemode/execute.ts
@@ -135,6 +135,7 @@ const createBackofficeScopedCodemodeProvider = ({
 }) => ({
   name: "__context",
   fns: {
+    getCurrentScope: async () => context.execution.scope,
     callScoped: async (rawInput: unknown) => {
       const input = rawInput as ScopedCodemodeCallInput;
       const currentScope = context.execution.scope;

--- a/apps/backoffice/app/fragno/codemode/run-backoffice-codemode.cloudflare.test.ts
+++ b/apps/backoffice/app/fragno/codemode/run-backoffice-codemode.cloudflare.test.ts
@@ -73,6 +73,20 @@ describe("runBackofficeCodemode", () => {
     assert(result.result === "hello expression");
   });
 
+  test("returns the exact current execution scope", async () => {
+    const toolContext = createTrustedSystemBackofficeToolContext({ runtimes: {} });
+    const result = await runBackofficeCodemode({
+      env,
+      families: runtimeToolFamilies,
+      toolContext: toolContext.createScopedContext({ kind: "org", orgId: "org-1" }),
+      code: `async () => await context.getCurrentScope()`,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({ kind: "org", orgId: "org-1" });
+    expect(result.toolCalls).toEqual([]);
+  });
+
   test("does not expose unsupported state tools", async () => {
     const result = await runBackofficeCodemode({
       env,

--- a/apps/backoffice/app/fragno/runtime-tools/bash-host.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/bash-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, assert } from "vitest";
+import { assert, describe, expect, test } from "vitest";
 
 import { InMemoryFs } from "just-bash";
 
@@ -6,6 +6,35 @@ import { createBashHost } from "./bash-host";
 import { EMPTY_BASH_HOST_CONTEXT } from "./bash-host.test-utils";
 
 describe("createBashHost", () => {
+  test("exposes the exact current execution scope", async () => {
+    const { bash } = createBashHost({
+      fs: new InMemoryFs(),
+      context: {
+        ...EMPTY_BASH_HOST_CONTEXT,
+        execution: {
+          ...EMPTY_BASH_HOST_CONTEXT.execution,
+          scope: { kind: "org", orgId: "org-1" },
+        },
+      },
+    });
+
+    await expect(bash.exec("context.current")).resolves.toMatchObject({
+      stdout: "kind   org\norgId  org-1\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    await expect(bash.exec("context.current --format json")).resolves.toMatchObject({
+      stdout: '{"kind":"org","orgId":"org-1"}\n',
+      stderr: "",
+      exitCode: 0,
+    });
+    await expect(bash.exec("context.current --print org-id")).resolves.toMatchObject({
+      stdout: "org-1\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   test.skip("regression: defense-in-depth handles assignment command substitutions", async () => {
     const { bash } = createBashHost({
       fs: new InMemoryFs(),

--- a/apps/backoffice/app/fragno/runtime-tools/bash-host.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/bash-host.ts
@@ -1,4 +1,4 @@
-import { Bash as BashRuntime, type Bash } from "just-bash";
+import { Bash as BashRuntime, defineCommand, type Bash } from "just-bash";
 
 import type {
   BackofficeContextScope,
@@ -14,6 +14,7 @@ import { createBackofficeToolContext } from "@/fragno/runtime-tools/tool-context
 import { runtimeToolFamilies } from "@/fragno/runtime-tools/tool-families";
 
 import type { AutomationCommandContext, BashAutomationCommandResult } from "./automation-types";
+import { createCurrentScopeBashCommand } from "./current-scope-command";
 import type { RegisteredApiCommandContext } from "./families/api-runtime";
 import type { AutomationStoreRuntime } from "./families/automations-bindings";
 import type { DurableHooksRuntime } from "./families/automations-durable-hooks";
@@ -122,6 +123,7 @@ const createRegisteredBashCommands = (input: BashCommandFactoryInput) => {
       context,
       commandCallsResult: input.commandCallsResult,
     }),
+    createCurrentScopeBashCommand(input.context.execution.scope, defineCommand),
     isomorphicGitCommand,
   ];
 };

--- a/apps/backoffice/app/fragno/runtime-tools/current-scope-command.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/current-scope-command.ts
@@ -1,0 +1,94 @@
+import type { defineCommand } from "just-bash";
+
+import type { BackofficeContextScope } from "@/backoffice-runtime/context";
+
+import type { AutomationCommandHelp } from "./automation-types";
+import {
+  buildCommandHelp,
+  defineCliArgsParser,
+  ensureTrailingNewline,
+  formatCommandStdout,
+  hasHelpOption,
+  parseCliTokens,
+  readOutputOptions,
+  STANDARD_COMMAND_OPTIONS,
+} from "./bash-cli";
+
+type DefineBashCommand = typeof defineCommand;
+
+/** Bash command that prints the exact scope governing the current execution. */
+export const CURRENT_SCOPE_BASH_COMMAND = "context.current";
+
+/** Shared help metadata for the current scope Bash command and terminal autocomplete. */
+export const CURRENT_SCOPE_BASH_COMMAND_HELP = {
+  summary: "Print the exact scope governing the current execution.",
+  options: [],
+  examples: ["context.current", "context.current --format json", "context.current --print org-id"],
+} as const satisfies AutomationCommandHelp;
+
+/** Client-safe command metadata used by terminal help and autocomplete. */
+export const CURRENT_SCOPE_BASH_COMMAND_SPEC = {
+  command: CURRENT_SCOPE_BASH_COMMAND,
+  ...CURRENT_SCOPE_BASH_COMMAND_HELP,
+  options: STANDARD_COMMAND_OPTIONS,
+};
+
+function parseCurrentScopeCommandArgs(args: string[]): Record<string, never> {
+  return defineCliArgsParser<Record<string, never>>(CURRENT_SCOPE_BASH_COMMAND, {})(args);
+}
+
+function formatCurrentScopeText(scope: BackofficeContextScope): string {
+  switch (scope.kind) {
+    case "system":
+      return "kind  system\n";
+    case "org":
+      return `kind   org\norgId  ${scope.orgId}\n`;
+    case "user":
+      return `kind    user\nuserId  ${scope.userId}\n`;
+    case "project":
+      return `kind       project\norgId      ${scope.orgId}\nprojectId  ${scope.projectId}\n`;
+  }
+
+  throw new Error("context.current received an unsupported Backoffice scope kind.");
+}
+
+/** Creates the Bash command that exposes trusted current execution scope metadata. */
+export function createCurrentScopeBashCommand(
+  scope: BackofficeContextScope,
+  defineBashCommand: DefineBashCommand,
+) {
+  return defineBashCommand(
+    CURRENT_SCOPE_BASH_COMMAND,
+    async function executeCurrentScopeBashCommand(args) {
+      const parsed = parseCliTokens(args);
+      if (hasHelpOption(parsed)) {
+        return {
+          stdout: buildCommandHelp({
+            name: CURRENT_SCOPE_BASH_COMMAND,
+            help: CURRENT_SCOPE_BASH_COMMAND_HELP,
+            parse: parseCurrentScopeCommandArgs,
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+
+      try {
+        parseCurrentScopeCommandArgs(args);
+        const outputOptions = readOutputOptions(parsed);
+        const stdout =
+          outputOptions.format === "json" || outputOptions.print
+            ? formatCommandStdout(outputOptions, { data: scope })
+            : formatCurrentScopeText(scope);
+        return { stdout, stderr: "", exitCode: 0 };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          stdout: "",
+          stderr: ensureTrailingNewline(`${CURRENT_SCOPE_BASH_COMMAND}: ${message}`),
+          exitCode: 1,
+        };
+      }
+    },
+  );
+}

--- a/apps/backoffice/app/fragno/runtime-tools/reference.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/reference.test.ts
@@ -465,10 +465,17 @@ describe("runtime tool reference generation", () => {
         };
 
         // Scoped context handles target a selected Backoffice context.
+        type BackofficeCodemodeScope =
+          | { kind: "system" }
+          | { kind: "org"; orgId: string }
+          | { kind: "user"; userId: string }
+          | { kind: "project"; orgId: string; projectId: string };
         type BackofficeCodemodeScopedProviders = {
           reson8: Reson8CodemodeProvider;
         };
         declare const context: {
+          /** Return the exact scope governing this codemode execution. */
+          getCurrentScope(): Promise<BackofficeCodemodeScope>;
           /** Providers bound to the selected current context. */
           readonly current: BackofficeCodemodeScopedProviders;
           /** Providers bound to an organisation context. */
@@ -548,10 +555,17 @@ describe("runtime tool reference generation", () => {
         };
 
         // Scoped context handles target a selected Backoffice context.
+        type BackofficeCodemodeScope =
+          | { kind: "system" }
+          | { kind: "org"; orgId: string }
+          | { kind: "user"; userId: string }
+          | { kind: "project"; orgId: string; projectId: string };
         type BackofficeCodemodeScopedProviders = {
           telegram: TelegramCodemodeProvider;
         };
         declare const context: {
+          /** Return the exact scope governing this codemode execution. */
+          getCurrentScope(): Promise<BackofficeCodemodeScope>;
           /** Providers bound to the selected current context. */
           readonly current: BackofficeCodemodeScopedProviders;
           /** Providers bound to an organisation context. */
@@ -3587,6 +3601,11 @@ describe("runtime tool reference generation", () => {
       } | null;
 
       // Scoped context handles target a selected Backoffice context.
+      type BackofficeCodemodeScope =
+        | { kind: "system" }
+        | { kind: "org"; orgId: string }
+        | { kind: "user"; userId: string }
+        | { kind: "project"; orgId: string; projectId: string };
       type BackofficeCodemodeScopedProviders = {
         state: StateCodemodeProvider;
         capabilities: CapabilitiesCodemodeProvider;
@@ -3611,6 +3630,8 @@ describe("runtime tool reference generation", () => {
         internal: InternalCodemodeProvider;
       };
       declare const context: {
+        /** Return the exact scope governing this codemode execution. */
+        getCurrentScope(): Promise<BackofficeCodemodeScope>;
         /** Providers bound to the selected current context. */
         readonly current: BackofficeCodemodeScopedProviders;
         /** Providers bound to an organisation context. */
@@ -3667,6 +3688,11 @@ describe("runtime tool reference generation", () => {
       /// <reference path="/static/codemode/providers/upload.d.ts" />
 
       // Scoped context handles target a selected Backoffice context.
+      type BackofficeCodemodeScope =
+        | { kind: "system" }
+        | { kind: "org"; orgId: string }
+        | { kind: "user"; userId: string }
+        | { kind: "project"; orgId: string; projectId: string };
       type BackofficeCodemodeScopedProviders = {
         state: StateCodemodeProvider;
         capabilities: CapabilitiesCodemodeProvider;
@@ -3690,6 +3716,8 @@ describe("runtime tool reference generation", () => {
         upload: UploadCodemodeProvider;
       };
       declare const context: {
+        /** Return the exact scope governing this codemode execution. */
+        getCurrentScope(): Promise<BackofficeCodemodeScope>;
         /** Providers bound to the selected current context. */
         readonly current: BackofficeCodemodeScopedProviders;
         /** Providers bound to an organisation context. */
@@ -4318,10 +4346,17 @@ describe("runtime tool reference generation", () => {
       } | null;
 
       // Scoped context handles target a selected Backoffice context.
+      type BackofficeCodemodeScope =
+        | { kind: "system" }
+        | { kind: "org"; orgId: string }
+        | { kind: "user"; userId: string }
+        | { kind: "project"; orgId: string; projectId: string };
       type BackofficeCodemodeScopedProviders = {
         router: RouterCodemodeProvider;
       };
       declare const context: {
+        /** Return the exact scope governing this codemode execution. */
+        getCurrentScope(): Promise<BackofficeCodemodeScope>;
         /** Providers bound to the selected current context. */
         readonly current: BackofficeCodemodeScopedProviders;
         /** Providers bound to an organisation context. */
@@ -5058,10 +5093,17 @@ describe("runtime tool reference generation", () => {
       } | null;
 
       // Scoped context handles target a selected Backoffice context.
+      type BackofficeCodemodeScope =
+        | { kind: "system" }
+        | { kind: "org"; orgId: string }
+        | { kind: "user"; userId: string }
+        | { kind: "project"; orgId: string; projectId: string };
       type BackofficeCodemodeScopedProviders = {
         router: RouterCodemodeProvider;
       };
       declare const context: {
+        /** Return the exact scope governing this codemode execution. */
+        getCurrentScope(): Promise<BackofficeCodemodeScope>;
         /** Providers bound to the selected current context. */
         readonly current: BackofficeCodemodeScopedProviders;
         /** Providers bound to an organisation context. */
@@ -5431,10 +5473,17 @@ describe("runtime tool reference generation", () => {
       } | null;
 
       // Scoped context handles target a selected Backoffice context.
+      type BackofficeCodemodeScope =
+        | { kind: "system" }
+        | { kind: "org"; orgId: string }
+        | { kind: "user"; userId: string }
+        | { kind: "project"; orgId: string; projectId: string };
       type BackofficeCodemodeScopedProviders = {
         router: RouterCodemodeProvider;
       };
       declare const context: {
+        /** Return the exact scope governing this codemode execution. */
+        getCurrentScope(): Promise<BackofficeCodemodeScope>;
         /** Providers bound to the selected current context. */
         readonly current: BackofficeCodemodeScopedProviders;
         /** Providers bound to an organisation context. */
@@ -6222,6 +6271,11 @@ describe("runtime tool reference generation", () => {
       /// <reference path="/static/codemode/providers/upload.d.ts" />
 
       // Scoped context handles target a selected Backoffice context.
+      type BackofficeCodemodeScope =
+        | { kind: "system" }
+        | { kind: "org"; orgId: string }
+        | { kind: "user"; userId: string }
+        | { kind: "project"; orgId: string; projectId: string };
       type BackofficeCodemodeScopedProviders = {
         state: StateCodemodeProvider;
         capabilities: CapabilitiesCodemodeProvider;
@@ -6245,6 +6299,8 @@ describe("runtime tool reference generation", () => {
         upload: UploadCodemodeProvider;
       };
       declare const context: {
+        /** Return the exact scope governing this codemode execution. */
+        getCurrentScope(): Promise<BackofficeCodemodeScope>;
         /** Providers bound to the selected current context. */
         readonly current: BackofficeCodemodeScopedProviders;
         /** Providers bound to an organisation context. */

--- a/apps/backoffice/app/fragno/runtime-tools/reference.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/reference.ts
@@ -310,10 +310,17 @@ export const renderCodemodeScopedContextTypes = (namespaces: readonly string[]) 
 
   return [
     "// Scoped context handles target a selected Backoffice context.",
+    "type BackofficeCodemodeScope =",
+    '  | { kind: "system" }',
+    '  | { kind: "org"; orgId: string }',
+    '  | { kind: "user"; userId: string }',
+    '  | { kind: "project"; orgId: string; projectId: string };',
     "type BackofficeCodemodeScopedProviders = {",
     ...scopedProviderEntries,
     "};",
     "declare const context: {",
+    "  /** Return the exact scope governing this codemode execution. */",
+    "  getCurrentScope(): Promise<BackofficeCodemodeScope>;",
     "  /** Providers bound to the selected current context. */",
     "  readonly current: BackofficeCodemodeScopedProviders;",
     "  /** Providers bound to an organisation context. */",

--- a/apps/backoffice/app/fragno/runtime-tools/runtime-tools.authorization.test.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/runtime-tools.authorization.test.ts
@@ -78,7 +78,15 @@ describe("runtime tool authorization", () => {
         {},
         createToolContext({ grants: [{ namespace: "internal", permission: "read" }] }),
       ),
-    ).rejects.toMatchObject({ reason: "principal-permission-denied" });
+    ).rejects.toMatchObject({
+      message: [
+        "Permission denied for internal.testManage.",
+        "Action: Test internal permissions.",
+        "Required permission: internal.manage.",
+        "Reason: The current principal does not have the required permission.",
+      ].join("\n"),
+      reason: "principal-permission-denied",
+    });
     expect(execute).not.toHaveBeenCalled();
   });
 
@@ -154,7 +162,13 @@ describe("runtime tool authorization", () => {
 
     await expect(bash.exec("internal.test.bash")).resolves.toMatchObject({
       exitCode: 1,
-      stderr: expect.stringContaining("required permission"),
+      stderr: expect.stringContaining(
+        [
+          "Permission denied for internal.testBash.",
+          "Action: Test custom Bash adapter authorization.",
+          "Required permission: internal.manage.",
+        ].join("\n"),
+      ),
     });
     expect(executeBashAdapter).not.toHaveBeenCalled();
   });

--- a/apps/backoffice/app/fragno/runtime-tools/runtime-tools.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/runtime-tools.ts
@@ -6,11 +6,16 @@ import type {
   BackofficeContextScope,
   BackofficeExecutionContext,
 } from "@/backoffice-runtime/context";
-import { BackofficeKernel, noopBackofficeKernelObserver } from "@/backoffice-runtime/kernel";
+import {
+  BackofficeForbiddenError,
+  BackofficeKernel,
+  noopBackofficeKernelObserver,
+} from "@/backoffice-runtime/kernel";
 import {
   isBackofficePermissionRequirement,
   type BackofficePermission,
   type BackofficePermissionNamespace,
+  type BackofficePermissionRequirement,
 } from "@/backoffice-runtime/permissions";
 import { AUTOMATION_SYSTEM_INITIATOR } from "@/fragno/automation/actors";
 import type { BackofficeCapabilityId } from "@/fragno/backoffice-capabilities/backoffice-capabilities";
@@ -254,6 +259,22 @@ const summarizeToolValue = (value: unknown) => {
   return summary.length > 500 ? `${summary.slice(0, 497)}...` : summary;
 };
 
+function runtimeToolAuthorizationError(
+  tool: AnyBackofficeRuntimeTool,
+  operation: BackofficePermissionRequirement,
+  cause: BackofficeForbiddenError,
+): BackofficeForbiddenError {
+  return new BackofficeForbiddenError(
+    [
+      `Permission denied for ${tool.namespace}.${tool.name}.`,
+      `Action: ${tool.description}`,
+      `Required permission: ${operation.namespace}.${operation.permission}.`,
+      `Reason: ${cause.message}`,
+    ].join("\n"),
+    cause.reason,
+  );
+}
+
 const authorizeBackofficeRuntimeTool = async (
   tool: AnyBackofficeRuntimeTool,
   parsedInput: unknown,
@@ -271,11 +292,18 @@ const authorizeBackofficeRuntimeTool = async (
       );
     }
 
-    await context.kernel.assertAuthorized({
-      execution: context.execution,
-      operation,
-      resource,
-    });
+    try {
+      await context.kernel.assertAuthorized({
+        execution: context.execution,
+        operation,
+        resource,
+      });
+    } catch (error) {
+      if (error instanceof BackofficeForbiddenError) {
+        throw runtimeToolAuthorizationError(tool, operation, error);
+      }
+      throw error;
+    }
   }
 };
 

--- a/apps/backoffice/app/routes/backoffice/pi-terminal-specs.test.ts
+++ b/apps/backoffice/app/routes/backoffice/pi-terminal-specs.test.ts
@@ -71,7 +71,7 @@ describe("getAvailablePiTerminalCommandSpecs", () => {
   test("always includes the shell helper commands", () => {
     const commands = commandsFor({});
 
-    expect(commands).toEqual(expect.arrayContaining(["ls", "help", "find"]));
+    expect(commands).toEqual(expect.arrayContaining(["ls", "help", "find", "context.current"]));
   });
 
   test("excludes hidden families even when their runtime is wired", () => {

--- a/apps/backoffice/app/routes/backoffice/pi-terminal-specs.ts
+++ b/apps/backoffice/app/routes/backoffice/pi-terminal-specs.ts
@@ -7,6 +7,7 @@
 
 import type { AutomationCommandOptionSpec } from "@/fragno/runtime-tools/automation-types";
 import { STANDARD_COMMAND_OPTIONS } from "@/fragno/runtime-tools/bash-cli";
+import { CURRENT_SCOPE_BASH_COMMAND_SPEC } from "@/fragno/runtime-tools/current-scope-command";
 import {
   createRuntimeToolReferenceContext,
   createRuntimeToolReferences,
@@ -38,6 +39,7 @@ const SHELL_COMMAND_SPECS = [
   { command: "help", summary: "List the commands available in this terminal.", options: [] },
   { command: "ls", summary: "List files and directories.", options: [] },
   { command: "pwd", summary: "Print the terminal working directory.", options: [] },
+  CURRENT_SCOPE_BASH_COMMAND_SPEC,
 ] as const;
 
 const appendStandardCommandOptions = (options: readonly AutomationCommandOptionSpec[]) => {

--- a/apps/backoffice/app/routes/backoffice/terminal-commands.ts
+++ b/apps/backoffice/app/routes/backoffice/terminal-commands.ts
@@ -1,5 +1,6 @@
 import type { AutomationCommandOptionSpec } from "@/fragno/runtime-tools/automation-types";
 import { STANDARD_COMMAND_OPTIONS } from "@/fragno/runtime-tools/bash-cli";
+import { CURRENT_SCOPE_BASH_COMMAND_SPEC } from "@/fragno/runtime-tools/current-scope-command";
 import {
   createRuntimeToolReferenceContext,
   createRuntimeToolReferences,
@@ -24,6 +25,7 @@ const BACKOFFICE_TERMINAL_SHELL_COMMAND_SPECS = [
   { command: "find", summary: "Search for files under a directory.", options: [] },
   { command: "ls", summary: "List files and directories.", options: [] },
   { command: "pwd", summary: "Print the terminal working directory.", options: [] },
+  CURRENT_SCOPE_BASH_COMMAND_SPEC,
 ] as const;
 const appendStandardCommandOptions = (options: readonly AutomationCommandOptionSpec[]) => {
   const optionNames = new Set(options.map((option) => option.name));

--- a/apps/backoffice/content/static/SYSTEM.md
+++ b/apps/backoffice/content/static/SYSTEM.md
@@ -77,7 +77,9 @@ A scope is the ownership and authorization boundary for files, data, connections
 configuration. The current scope is the selected system/admin, organisation, project, or user
 context.
 
-- Top-level providers and `context.current` target the current scope: for example, `store.get(...)`
+- `context.getCurrentScope()` returns the exact system, organisation, project, or user scope
+  governing the execution.
+- Top-level providers and `context.current` target that current scope: for example, `store.get(...)`
   and `context.current.store.get(...)`.
 - Explicit handles target an authorized scope: `context.org(orgId)`, `context.user(userId)`, or
   `context.project(projectId)`. A project handle requires a current organisation or project context


### PR DESCRIPTION
- **feat(backoffice): expose the current execution scope**
- **fix(backoffice): contextualize runtime tool permission errors**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `context.current` to show the exact active system, organization, user, or project scope.
  - Added `context.getCurrentScope()` for retrieving the current execution scope in codemode.
  - Added text and structured output options for current-scope information.

- **Bug Fixes**
  - Improved permission-denied errors with clearer details about the tool, action, required permission, and reason.

- **Documentation**
  - Updated scope guidance to explain current-scope access and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->