### PR TITLE
feat(backoffice): redesign Marketplace experience

### DIFF
--- a/apps/backoffice/app/routes/backoffice/marketplace/artifact-files.client.test.tsx
+++ b/apps/backoffice/app/routes/backoffice/marketplace/artifact-files.client.test.tsx
@@ -45,10 +45,46 @@ const secondVersionData: MarketplaceArtifactExplorerData = {
   ]),
   selectedVersion: "2.0.0",
 };
+const overviewData: MarketplaceArtifactExplorerData = {
+  state: "ready",
+  fileTree: createFileTree([
+    {
+      kind: "file",
+      path: "README.md",
+      sizeBytes: 25,
+      contentType: "text/markdown",
+      updatedAt: null,
+      metadata: null,
+    },
+  ]),
+  selectedVersion: "1.0.0",
+};
 
 afterEach(cleanup);
 
 describe("Marketplace artifact lazy content", () => {
+  test("loads the overview by default", async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/backoffice/marketplace/example",
+          element: <MarketplaceArtifactFiles data={overviewData} />,
+        },
+        {
+          path: "/backoffice/marketplace/example/artifact-file",
+          loader: () => "# Package overview\n\nReady to install.",
+        },
+      ],
+      { initialEntries: ["/backoffice/marketplace/example"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await screen.findByRole("heading", { name: "Package overview" });
+    screen.getByText("Ready to install.");
+    assert(router.state.location.search === "");
+  });
+
   test("stores the selected workflow in the URL", async () => {
     const router = createMemoryRouter(
       [

--- a/apps/backoffice/app/routes/backoffice/marketplace/artifact-files.test.tsx
+++ b/apps/backoffice/app/routes/backoffice/marketplace/artifact-files.test.tsx
@@ -31,13 +31,14 @@ const artifactData: MarketplaceArtifactExplorerData = {
 };
 
 describe("MarketplaceArtifactFiles", () => {
-  test("defaults to the metadata-only files tab and omits the old badges", () => {
+  test("defaults to the overview tab and omits the old badges", () => {
     const markup = renderMarketplaceArtifacts("/backoffice/marketplace/example");
 
-    assert(markup.includes("Package contents"));
+    assert(markup.includes("No package overview"));
     assert(markup.includes("Overview"));
     assert(markup.includes("Workflows"));
     assert(markup.includes("Files"));
+    assert(!markup.includes("Package contents"));
     assert(!markup.includes("Read only"));
     assert(!markup.includes("2 releases"));
     assert(!markup.includes("could not be found"));

--- a/apps/backoffice/app/routes/backoffice/marketplace/artifact-files.tsx
+++ b/apps/backoffice/app/routes/backoffice/marketplace/artifact-files.tsx
@@ -1,5 +1,5 @@
 import { PackageOpen } from "lucide-react";
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Link, useFetcher, useLocation } from "react-router";
 import { Streamdown } from "streamdown";
 
@@ -69,12 +69,12 @@ function ReadyMarketplaceArtifactFiles({
 }) {
   const location = useLocation();
   const overview = useFetcher<string>();
-  const [overviewRequested, setOverviewRequested] = useState(false);
+  const [requestedOverviewPath, setRequestedOverviewPath] = useState<string | null>(null);
   const requestedTab = new URLSearchParams(location.search).get("artifactTab");
   const activeTab: MarketplaceArtifactTab =
     requestedTab === "overview" || requestedTab === "workflows" || requestedTab === "files"
       ? requestedTab
-      : "files";
+      : "overview";
   const overviewPath =
     findMarketplaceArtifactEntry(data, "README.md")?.kind === "file"
       ? `${MARKETPLACE_ARTIFACT_ROOT_PATH}/README.md`
@@ -83,11 +83,21 @@ function ReadyMarketplaceArtifactFiles({
     ? buildArtifactFileResourcePath(location.pathname, overviewPath)
     : null;
   const loadOverview = () => {
-    if (overviewResourcePath) {
-      setOverviewRequested(true);
+    if (overviewResourcePath && requestedOverviewPath !== overviewResourcePath) {
+      setRequestedOverviewPath(overviewResourcePath);
       void overview.load(overviewResourcePath);
     }
   };
+  useEffect(() => {
+    if (
+      activeTab === "overview" &&
+      overviewResourcePath &&
+      requestedOverviewPath !== overviewResourcePath
+    ) {
+      setRequestedOverviewPath(overviewResourcePath);
+      void overview.load(overviewResourcePath);
+    }
+  }, [activeTab, overview, overviewResourcePath, requestedOverviewPath]);
   const tabs = (["overview", "workflows", "files"] as const).map((tab) => ({
     id: tab,
     label: tab === "overview" ? "Overview" : tab === "workflows" ? "Workflows" : "Files",
@@ -106,9 +116,13 @@ function ReadyMarketplaceArtifactFiles({
       {activeTab === "overview" ? (
         <MarketplaceArtifactOverview
           path={overviewPath}
-          requested={overviewRequested}
+          requested={requestedOverviewPath === overviewResourcePath}
           loading={overview.state !== "idle"}
-          markdown={typeof overview.data === "string" ? overview.data : null}
+          markdown={
+            requestedOverviewPath === overviewResourcePath && typeof overview.data === "string"
+              ? overview.data
+              : null
+          }
           onLoad={loadOverview}
         />
       ) : activeTab === "workflows" ? (

--- a/apps/backoffice/app/routes/backoffice/marketplace/browse.test.ts
+++ b/apps/backoffice/app/routes/backoffice/marketplace/browse.test.ts
@@ -1,0 +1,101 @@
+import { assert, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
+
+const { findBackofficeMeMock, listPublishedListingsMock } = vi.hoisted(() => ({
+  findBackofficeMeMock: vi.fn(),
+  listPublishedListingsMock: vi.fn(),
+}));
+
+vi.mock("@/fragno/auth/auth-server", () => ({ findBackofficeMe: findBackofficeMeMock }));
+
+import BackofficeMarketplaceBrowse, { loader } from "./browse";
+
+const authenticatedUser = {
+  user: { id: "user-1", email: "ada@example.com" },
+  organizations: [{ organization: { id: "org-1", name: "Ada Labs" } }],
+  activeOrganization: { organization: { id: "org-1", name: "Ada Labs" } },
+};
+const marketplace = { listPublishedListings: listPublishedListingsMock };
+const context = {
+  get: () => ({
+    runtime: {
+      objects: { marketplace: { singleton: () => marketplace } },
+    },
+  }),
+};
+const listings = [
+  {
+    listingId: "system#telegram-channel",
+    slug: "telegram-channel",
+    name: "Telegram channel",
+    summary: "Publish operational updates to a Telegram channel from a durable workflow.",
+    description: "A published Marketplace package for Telegram channel updates.",
+    tags: ["telegram", "notifications"],
+    category: "communication",
+    publisherName: "Fragno",
+    status: "published",
+    latestVersion: "1.0.0",
+    publishedAt: "2026-08-20T00:00:00.000Z",
+    updatedAt: "2026-08-20T00:00:00.000Z",
+  },
+];
+
+beforeEach(() => {
+  findBackofficeMeMock.mockReset();
+  listPublishedListingsMock.mockReset();
+  findBackofficeMeMock.mockResolvedValue(authenticatedUser);
+  listPublishedListingsMock.mockResolvedValue({
+    listings,
+    hasNextPage: false,
+  });
+});
+
+describe("Marketplace featured browse", () => {
+  test("ignores legacy category filters and always requests the unfiltered Marketplace", async () => {
+    const url = new URL(
+      "https://example.test/backoffice/marketplace/org/org-1/marketplace?category=communication",
+    );
+
+    const result = await loader({ request: new Request(url), context, url } as never);
+
+    assert(!(result instanceof Response));
+    expect(listPublishedListingsMock).toHaveBeenCalledWith({});
+    assert(!("category" in result));
+  });
+
+  test("presents published packages as featured items without filter controls", () => {
+    const router = createMemoryRouter(
+      [
+        {
+          element: createElement(Outlet, {
+            context: { selectedScope: { kind: "org", orgId: "org-1", label: "Ada Labs" } },
+          }),
+          children: [
+            {
+              path: "*",
+              element: createElement(BackofficeMarketplaceBrowse, {
+                loaderData: {
+                  basePath: "/backoffice/marketplace/org/org-1/marketplace",
+                  listings,
+                  hasNextPage: false,
+                },
+              } as never),
+            },
+          ],
+        },
+      ],
+      { initialEntries: ["/backoffice/marketplace/org/org-1/marketplace"] },
+    );
+
+    const markup = renderToStaticMarkup(createElement(RouterProvider, { router }));
+
+    assert(markup.includes("Featured packages"));
+    assert(markup.includes("Featured"));
+    assert(!markup.includes("Ready to add to Ada Labs."));
+    assert(!markup.includes("Apply filter"));
+    assert(!markup.includes("<select"));
+  });
+});

--- a/apps/backoffice/app/routes/backoffice/marketplace/browse.tsx
+++ b/apps/backoffice/app/routes/backoffice/marketplace/browse.tsx
@@ -1,7 +1,6 @@
-import { Form, Link, useOutletContext } from "react-router";
+import { Link, useOutletContext } from "react-router";
 
 import { findBackofficeMe } from "@/fragno/auth/auth-server";
-import { MARKETPLACE_CATEGORIES, marketplaceCategorySchema } from "@/fragno/marketplace/contracts";
 import {
   decodeMarketplaceListingCursor,
   MarketplaceListingCursorError,
@@ -13,18 +12,6 @@ import type { Route } from "./+types/browse";
 import type { MarketplaceLayoutContext } from "./layout-context";
 import { marketplaceListingPath } from "./navigation";
 
-const marketplacePagePath = (input: { basePath: string; category?: string; cursor?: string }) => {
-  const search = new URLSearchParams();
-  if (input.category) {
-    search.set("category", input.category);
-  }
-  if (input.cursor) {
-    search.set("cursor", input.cursor);
-  }
-  const query = search.toString();
-  return query ? `${input.basePath}?${query}` : input.basePath;
-};
-
 const publishedAtFormatter = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
@@ -32,7 +19,13 @@ const publishedAtFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
-const formatPublishedAt = (value: string) => publishedAtFormatter.format(new Date(value));
+function marketplacePagePath(basePath: string, cursor: string): string {
+  return `${basePath}?${new URLSearchParams({ cursor })}`;
+}
+
+function formatPublishedAt(value: string): string {
+  return publishedAtFormatter.format(new Date(value));
+}
 
 export async function loader({ request, context, url }: Route.LoaderArgs) {
   const me = await findBackofficeMe(request, context);
@@ -43,15 +36,9 @@ export async function loader({ request, context, url }: Route.LoaderArgs) {
     );
   }
 
-  const categoryValue = url.searchParams.get("category")?.trim() || undefined;
-  const categoryResult = marketplaceCategorySchema.optional().safeParse(categoryValue);
-  if (!categoryResult.success) {
-    throw new Response("Invalid marketplace category.", { status: 400 });
-  }
-  const category = categoryResult.data;
   const cursor = url.searchParams.get("cursor")?.trim() || undefined;
   try {
-    decodeMarketplaceListingCursor({ encodedCursor: cursor, category });
+    decodeMarketplaceListingCursor({ encodedCursor: cursor });
   } catch (error) {
     if (error instanceof MarketplaceListingCursorError) {
       throw new Response(error.message, { status: 400 });
@@ -60,8 +47,8 @@ export async function loader({ request, context, url }: Route.LoaderArgs) {
   }
 
   const marketplace = context.get(BackofficeWorkerContext).runtime.objects.marketplace.singleton();
-  const page = await marketplace.listPublishedListings({ category, cursor });
-  return { basePath: url.pathname, category: category ?? null, ...page };
+  const page = await marketplace.listPublishedListings(cursor ? { cursor } : {});
+  return { basePath: url.pathname, ...page };
 }
 
 export function meta() {
@@ -69,114 +56,137 @@ export function meta() {
     { title: "Automation Marketplace" },
     {
       name: "description",
-      content: "Browse and publish versioned automation packages.",
+      content: "Discover versioned automation packages ready to install.",
     },
   ];
 }
 
 export default function BackofficeMarketplaceBrowse({ loaderData }: Route.ComponentProps) {
   const { selectedScope } = useOutletContext<MarketplaceLayoutContext>();
-  const { basePath, category, listings, nextCursor, hasNextPage } = loaderData;
+  const { basePath, listings, nextCursor, hasNextPage } = loaderData;
 
   return (
-    <div className="space-y-4">
-      <section className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-3">
-        <Form method="get" className="flex flex-col gap-3 md:flex-row md:items-end">
-          <label className="flex min-w-0 flex-1 flex-col gap-1">
-            <span className="text-[10px] tracking-[0.22em] text-[var(--bo-muted-2)] uppercase">
-              Category
-            </span>
-            <select
-              name="category"
-              defaultValue={category ?? ""}
-              className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-sm text-[var(--bo-fg)] outline-none focus:border-[color:var(--bo-accent)]"
-            >
-              <option value="">All categories</option>
-              {MARKETPLACE_CATEGORIES.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
-          </label>
-          <button
-            type="submit"
-            className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-4 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
-          >
-            Apply filter
-          </button>
-        </Form>
-      </section>
-
+    <div className="space-y-5">
       {listings.length === 0 ? (
-        <section className="border border-dashed border-[color:var(--bo-border-strong)] bg-[var(--bo-panel)] px-6 py-16 text-center">
-          <p className="text-[10px] tracking-[0.24em] text-[var(--bo-muted-2)] uppercase">
-            Empty shelf
+        <section className="bo-panel-surface bg-[var(--bo-panel)] px-6 py-16 text-center">
+          <p className="font-mono text-[10px] tracking-[0.2em] text-[var(--bo-muted-2)] uppercase">
+            Featured automations
           </p>
-          <h2 className="mt-3 text-2xl font-semibold text-[var(--bo-fg)]">
-            No published automations{category ? ` in ${category}` : " yet"}.
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-balance text-[var(--bo-fg)]">
+            No published automations yet.
           </h2>
-          <p className="mx-auto mt-2 max-w-xl text-sm text-[var(--bo-muted)]">
-            Publish a JSON automation package to establish the first immutable version.
+          <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-pretty text-[var(--bo-muted)]">
+            Published packages will appear here when they are ready to install.
           </p>
         </section>
       ) : (
-        <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {listings.map((listing) => (
-            <Link
-              key={listing.listingId}
-              to={marketplaceListingPath(listing.listingId, selectedScope)}
-              className="group flex min-h-56 flex-col border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-5 transition-[border-color,transform,background-color] hover:-translate-y-0.5 hover:border-[color:var(--bo-accent)] hover:bg-[var(--bo-panel-2)]"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <span className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-2 py-1 font-mono text-[9px] tracking-[0.16em] text-[var(--bo-muted-2)] uppercase">
-                  {listing.category}
-                </span>
-                <span className="font-mono text-[10px] text-[var(--bo-muted-2)]">
-                  v{listing.latestVersion}
-                </span>
-              </div>
+        <section aria-labelledby="featured-marketplace-heading">
+          <div className="mb-3 flex flex-wrap items-end justify-between gap-3 px-1">
+            <div>
+              <h2
+                id="featured-marketplace-heading"
+                className="text-lg font-semibold tracking-tight text-[var(--bo-fg)]"
+              >
+                Featured packages
+              </h2>
+              <p className="mt-1 text-xs text-[var(--bo-muted)]">
+                Published automations ready to install.
+              </p>
+            </div>
+            <p className="font-mono text-[9px] tracking-[0.14em] text-[var(--bo-muted-2)] uppercase">
+              {listings.length}
+              {hasNextPage ? "+" : ""} available
+            </p>
+          </div>
 
-              <div className="mt-6 flex-1">
-                <h2 className="text-xl font-semibold tracking-tight text-[var(--bo-fg)] group-hover:text-[var(--bo-accent-fg)]">
-                  {listing.name}
-                </h2>
-                <p className="mt-2 line-clamp-4 text-sm leading-6 text-[var(--bo-muted)]">
-                  {listing.summary}
-                </p>
-                <p className="mt-3 text-[10px] tracking-[0.18em] text-[var(--bo-muted-2)] uppercase">
-                  By {listing.publisherName}
-                </p>
-                {listing.tags.length ? (
-                  <div className="mt-4 flex flex-wrap gap-1.5">
-                    {listing.tags.map((tag) => (
-                      <span key={tag} className="font-mono text-[10px] text-[var(--bo-muted-2)]">
-                        #{tag}
+          <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+            {listings.map((listing, index) => {
+              const isLeadFeature = index === 0;
+              return (
+                <Link
+                  key={listing.listingId}
+                  to={marketplaceListingPath(listing.listingId, selectedScope)}
+                  className={
+                    isLeadFeature
+                      ? "group relative flex min-h-72 flex-col overflow-hidden bg-[var(--bo-panel)] p-6 shadow-[inset_0_0_0_1px_var(--bo-border)] transition-[scale,background-color,box-shadow] duration-150 ease-out hover:bg-[var(--bo-panel-2)] hover:shadow-[inset_0_0_0_1px_var(--bo-accent),0_16px_36px_rgba(var(--bo-accent-rgb),0.1)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96] md:p-7 lg:col-span-2"
+                      : "group flex min-h-72 flex-col bg-[var(--bo-panel)] p-6 shadow-[inset_0_0_0_1px_var(--bo-border)] transition-[scale,background-color,box-shadow] duration-150 ease-out hover:bg-[var(--bo-panel-2)] hover:shadow-[inset_0_0_0_1px_var(--bo-accent)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96]"
+                  }
+                >
+                  {isLeadFeature ? (
+                    <span
+                      className="absolute top-0 left-0 h-1 w-full bg-[var(--bo-accent)]"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {isLeadFeature ? (
+                        <span className="bg-[var(--bo-accent-bg)] px-2 py-1 font-mono text-[9px] font-semibold tracking-[0.14em] text-[var(--bo-accent-fg)] uppercase shadow-[inset_0_0_0_1px_var(--bo-accent)]">
+                          Featured
+                        </span>
+                      ) : null}
+                      <span className="bg-[var(--bo-panel-2)] px-2 py-1 font-mono text-[9px] tracking-[0.14em] text-[var(--bo-muted-2)] uppercase shadow-[inset_0_0_0_1px_var(--bo-border)]">
+                        {listing.category}
                       </span>
-                    ))}
+                    </div>
+                    <span className="shrink-0 font-mono text-[10px] font-semibold text-[var(--bo-muted-2)]">
+                      v{listing.latestVersion}
+                    </span>
                   </div>
-                ) : null}
-              </div>
 
-              <div className="mt-6 border-t border-[color:var(--bo-border)] pt-3 text-right text-[10px] text-[var(--bo-muted-2)]">
-                {formatPublishedAt(listing.publishedAt)}
-              </div>
-            </Link>
-          ))}
+                  <div className="mt-8 flex-1">
+                    <h3
+                      className={`font-semibold tracking-[-0.025em] text-balance text-[var(--bo-fg)] transition-colors duration-150 ease-out group-hover:text-[var(--bo-accent-fg)] ${isLeadFeature ? "max-w-2xl text-3xl" : "text-2xl"}`}
+                    >
+                      {listing.name}
+                    </h3>
+                    <p
+                      className={`mt-3 line-clamp-4 leading-6 text-pretty text-[var(--bo-muted)] ${isLeadFeature ? "max-w-2xl text-[15px]" : "text-sm"}`}
+                    >
+                      {listing.summary}
+                    </p>
+                    {listing.tags.length ? (
+                      <div className="mt-5 flex flex-wrap gap-1.5">
+                        {listing.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="font-mono text-[10px] text-[var(--bo-muted-2)]"
+                          >
+                            #{tag}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className="mt-7 flex items-end justify-between gap-4 border-t border-[color:var(--bo-border)] pt-4">
+                    <div className="min-w-0">
+                      <p className="truncate text-xs font-medium text-[var(--bo-fg)]">
+                        {listing.publisherName}
+                      </p>
+                      <p className="mt-1 font-mono text-[9px] text-[var(--bo-muted-2)]">
+                        Published {formatPublishedAt(listing.publishedAt)}
+                      </p>
+                    </div>
+                    <span className="shrink-0 text-[10px] font-semibold tracking-[0.14em] text-[var(--bo-accent-fg)] uppercase">
+                      View package →
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
         </section>
       )}
 
       {hasNextPage && nextCursor ? (
-        <div className="flex justify-end">
+        <div className="flex justify-center pt-1">
           <Link
-            to={marketplacePagePath({
-              basePath,
-              category: category ?? undefined,
-              cursor: nextCursor,
-            })}
-            className="border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-4 py-2 text-[10px] font-semibold tracking-[0.22em] text-[var(--bo-muted)] uppercase transition-colors hover:border-[color:var(--bo-border-strong)] hover:text-[var(--bo-fg)]"
+            to={marketplacePagePath(basePath, nextCursor)}
+            className="bo-control-surface inline-flex min-h-11 items-center justify-center bg-[var(--bo-panel-2)] px-5 text-[10px] font-semibold tracking-[0.18em] text-[var(--bo-muted)] uppercase transition-[scale,background-color,color,box-shadow] duration-150 ease-out hover:bg-[var(--bo-panel)] hover:text-[var(--bo-fg)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96]"
           >
-            Next shelf →
+            Show more automations →
           </Link>
         </div>
       ) : null}

--- a/apps/backoffice/app/routes/backoffice/marketplace/detail.test.ts
+++ b/apps/backoffice/app/routes/backoffice/marketplace/detail.test.ts
@@ -322,10 +322,38 @@ describe("marketplace detail loader", () => {
 });
 
 describe("marketplace artifact version navigation", () => {
+  test("moves version and installation controls into the package header", () => {
+    const markup = renderMarketplaceDetail("2.0.0");
+
+    assert(markup.includes("Version history"));
+    assert(markup.includes("Install into"));
+    assert(markup.includes(">Install</button>"));
+    assert(!markup.includes("Workspace installation"));
+  });
+
   test("offers the selected artifact version when it is outside the current page", () => {
     const markup = renderMarketplaceDetail("1.0.0");
 
-    assert(markup.includes('<option value="1.0.0" selected="">1.0.0</option>'));
+    assert(markup.includes("Version history"));
+    assert(markup.includes("v1.0.0"));
+    assert(markup.includes('aria-current="page"'));
+  });
+
+  test("sorts the version dropdown from newest to oldest", () => {
+    const markup = renderMarketplaceDetail("2.0.0", undefined, [
+      { version: "1.0.0", publishedAt: "2025-01-01T00:00:00.000Z" },
+      { version: "2.0.0", publishedAt: "2026-01-01T00:00:00.000Z" },
+      { version: "1.5.0", publishedAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+    const menuStart = markup.indexOf('class="absolute top-full');
+    const versionMenu = markup.slice(menuStart, markup.indexOf("</details>", menuStart));
+
+    assert(menuStart >= 0);
+    assert(versionMenu.includes("v2.0.0"));
+    assert(versionMenu.includes("v1.5.0"));
+    assert(versionMenu.includes("v1.0.0"));
+    assert(versionMenu.indexOf("v2.0.0") < versionMenu.indexOf("v1.5.0"));
+    assert(versionMenu.indexOf("v1.5.0") < versionMenu.indexOf("v1.0.0"));
   });
 
   test("observes the workflow started by the submitted release", () => {
@@ -339,6 +367,40 @@ describe("marketplace artifact version navigation", () => {
 
     assert(markup.includes("observing:submitted-workflow-id"));
     assert(!markup.includes("observing:loader-workflow-id"));
+    assert(!markup.includes("Installation workflow started"));
+  });
+
+  test("shows installation request failures in the main area", () => {
+    const markup = renderMarketplaceDetail("1.0.0", {
+      ok: false,
+      message: "Workspace file conflict.",
+    });
+
+    assert(markup.includes("Installation could not start"));
+    assert(markup.includes("Workspace file conflict."));
+  });
+
+  test("keeps the overview tab selected when changing versions", () => {
+    const explicitOverviewPath = buildArtifactVersionPath(
+      "/backoffice/marketplace/example",
+      "?artifactTab=overview&artifactVersion=1.0.0",
+      "1.0.0",
+      "2.0.0",
+    );
+    const defaultOverviewPath = buildArtifactVersionPath(
+      "/backoffice/marketplace/example",
+      "?artifactVersion=1.0.0",
+      "1.0.0",
+      "2.0.0",
+    );
+
+    assert(
+      new URL(explicitOverviewPath, "https://example.test").searchParams.get("artifactTab") ===
+        "overview",
+    );
+    assert(
+      new URL(defaultOverviewPath, "https://example.test").searchParams.get("artifactTab") === null,
+    );
   });
 
   test("retargets the selected artifact path to the next version", () => {
@@ -411,6 +473,7 @@ describe("marketplace detail revalidation", () => {
 function renderMarketplaceDetail(
   selectedVersion: string,
   actionData?: IngestionActionDataFixture,
+  versionHistory = [{ version: "2.0.0", publishedAt: "2026-01-01T00:00:00.000Z" }],
 ): string {
   const loaderData = {
     listing: {
@@ -427,7 +490,7 @@ function renderMarketplaceDetail(
       publishedAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
     },
-    versions: [{ version: "2.0.0", publishedAt: "2026-01-01T00:00:00.000Z" }],
+    versions: versionHistory,
     nextVersionCursor: undefined,
     hasNextVersionPage: false,
     manageOrganizationId: null,

--- a/apps/backoffice/app/routes/backoffice/marketplace/detail.tsx
+++ b/apps/backoffice/app/routes/backoffice/marketplace/detail.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from "lucide-react";
 import { Suspense } from "react";
 import {
   Form,
@@ -6,6 +7,7 @@ import {
   redirect,
   useActionData,
   useLocation,
+  useNavigate,
   useNavigation,
   useOutletContext,
   type ShouldRevalidateFunctionArgs,
@@ -22,7 +24,7 @@ import { requireBackofficeContext } from "@/fragno/auth/backoffice-principal.ser
 import type { BackofficeMeData } from "@/fragno/auth/contracts";
 import { buildMarketplaceIngestionWorkflowInstanceId } from "@/fragno/automation/marketplace-ingest-identity";
 import { fetchAutomationCollectionSource } from "@/fragno/automation/tanstack/server";
-import { marketplaceListingId, marketplaceListingSlug } from "@/fragno/marketplace/owner";
+import { marketplaceListingId } from "@/fragno/marketplace/owner";
 import {
   decodeMarketplacePublishedVersionCursor,
   MarketplaceListingCursorError,
@@ -51,6 +53,30 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
 });
 
 const formatDate = (value: string) => dateFormatter.format(new Date(value));
+
+type MarketplaceVersionOption = {
+  version: string;
+  publishedAt: string | null;
+};
+
+function sortMarketplaceVersionsNewestFirst(
+  versions: readonly MarketplaceVersionOption[],
+): MarketplaceVersionOption[] {
+  return versions
+    .map((version, index) => ({ version, index }))
+    .sort((left, right) => {
+      if (left.version.publishedAt === null) {
+        return right.version.publishedAt === null ? left.index - right.index : 1;
+      }
+      if (right.version.publishedAt === null) {
+        return -1;
+      }
+
+      const publishedAtOrder = right.version.publishedAt.localeCompare(left.version.publishedAt);
+      return publishedAtOrder || left.index - right.index;
+    })
+    .map(({ version }) => version);
+}
 
 type IngestionActionData =
   | { ok: false; message: string }
@@ -322,13 +348,16 @@ export default function BackofficeMarketplaceDetail({ loaderData }: Route.Compon
   } = loaderData;
   const actionData = useActionData<IngestionActionData>();
   const navigation = useNavigation();
+  const navigate = useNavigate();
   const location = useLocation();
   const search = new URLSearchParams(location.search);
   const selectedArtifactVersion =
     artifactFiles.state === "ready" ? artifactFiles.selectedVersion : listing.latestVersion;
   const installationVersion = selectedArtifactVersion;
-  const installationVersions = Array.from(
-    new Set([installationVersion, ...versions.map(({ version }) => version)]),
+  const installationVersions = sortMarketplaceVersionsNewestFirst(
+    versions.some(({ version }) => version === installationVersion)
+      ? versions
+      : [...versions, { version: installationVersion, publishedAt: null }],
   );
   const publishedVersionParam = search.get("published");
   const publishedVersion = versions.some(({ version }) => version === publishedVersionParam)
@@ -337,17 +366,30 @@ export default function BackofficeMarketplaceDetail({ loaderData }: Route.Compon
   const reusedPublication = publishedVersion !== null && search.get("reused") === "1";
   const hasOutdatedIngestion = ingestions.some((ingestion) => ingestion.outOfDate);
   const installationActionLabel = hasOutdatedIngestion
-    ? "Update selected scope"
+    ? "Update"
     : ingestions.length
-      ? "Re-run installation"
-      : "Add to selected scope";
+      ? "Reinstall"
+      : "Install";
   const observedInstallationWorkflowInstanceId =
     actionData?.ok === true ? actionData.workflowInstanceId : installationWorkflowInstanceId;
 
+  const installedRelease = ingestions[0] ?? null;
+  const artifactContent = (
+    <Outlet context={{ artifactFiles } satisfies MarketplaceArtifactOutletContext} />
+  );
+
+  function closeInstallationResult() {
+    const overviewSearch = new URLSearchParams(location.search);
+    overviewSearch.set("artifactTab", "overview");
+    overviewSearch.delete("artifactPath");
+    overviewSearch.delete("artifactContent");
+    void navigate(`${location.pathname}?${overviewSearch}`, { preventScrollReset: true });
+  }
+
   return (
-    <div className="grid w-full gap-5 2xl:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.85fr)_minmax(20rem,0.65fr)]">
-      <header className="bo-panel-surface flex h-full flex-col bg-[var(--bo-panel)] p-5 md:p-7">
-        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+    <div className="w-full space-y-5">
+      <header className="bo-panel-surface bg-[var(--bo-panel)] p-5 md:p-7">
+        <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2.5">
               <span className="bo-product-code">PKG</span>
@@ -375,17 +417,66 @@ export default function BackofficeMarketplaceDetail({ loaderData }: Route.Compon
             ) : null}
           </div>
 
-          {manageOrganizationId ? (
-            <Link
-              to={marketplaceListingManagePath({
-                listingId: listing.listingId,
-                organizationId: manageOrganizationId,
-              })}
-              className="bo-control-surface inline-flex min-h-10 shrink-0 items-center justify-center bg-[var(--bo-panel)] px-4 text-[10px] font-semibold tracking-[0.18em] text-[var(--bo-muted)] uppercase transition-[scale,background-color,color,box-shadow] duration-150 ease-out hover:bg-[var(--bo-panel-2)] hover:text-[var(--bo-fg)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96]"
-            >
-              Manage listing
-            </Link>
-          ) : null}
+          <div className="flex shrink-0 flex-col gap-3 xl:items-end">
+            {manageOrganizationId ? (
+              <Link
+                to={marketplaceListingManagePath({
+                  listingId: listing.listingId,
+                  organizationId: manageOrganizationId,
+                })}
+                className="bo-control-surface inline-flex min-h-10 items-center justify-center self-start bg-[var(--bo-panel)] px-4 text-[10px] font-semibold tracking-[0.18em] text-[var(--bo-muted)] uppercase transition-[scale,background-color,color,box-shadow] duration-150 ease-out hover:bg-[var(--bo-panel-2)] hover:text-[var(--bo-fg)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96] xl:self-end"
+              >
+                Manage listing
+              </Link>
+            ) : null}
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-end">
+              <VersionHistoryDropdown
+                versions={installationVersions}
+                selectedVersion={selectedArtifactVersion}
+                latestVersion={listing.latestVersion}
+                selectedScope={selectedScope}
+                listingId={listing.listingId}
+                pathname={location.pathname}
+                search={location.search}
+                nextVersionCursor={nextVersionCursor}
+                hasNextVersionPage={hasNextVersionPage}
+              />
+
+              {installationOrganizationId ? (
+                <div className="flex min-h-11 items-center justify-between gap-3 sm:justify-end">
+                  <div className="min-w-0 text-left sm:max-w-52 sm:text-right">
+                    <p className="text-[9px] font-semibold tracking-[0.14em] text-[var(--bo-muted-2)] uppercase">
+                      Install into
+                    </p>
+                    <p className="mt-1 truncate text-sm font-medium text-[var(--bo-fg)]">
+                      {selectedScope.label}
+                    </p>
+                    {installedRelease ? (
+                      <p className="mt-1 font-mono text-[9px] text-[var(--bo-muted-2)]">
+                        v{installedRelease.version}
+                        {installedRelease.outOfDate ? " · update available" : " · current"}
+                      </p>
+                    ) : null}
+                  </div>
+                  <Form method="post">
+                    <input type="hidden" name="version" value={installationVersion} />
+                    <button
+                      type="submit"
+                      disabled={navigation.state !== "idle"}
+                      className="inline-flex min-h-11 shrink-0 items-center justify-center bg-[var(--bo-btn-bg)] px-5 text-[10px] font-semibold tracking-[0.16em] text-[var(--bo-btn-fg)] uppercase shadow-[0_8px_20px_rgba(var(--bo-accent-rgb),0.2)] transition-[scale,background-color,box-shadow,opacity] duration-150 ease-out hover:bg-[var(--bo-btn-bg-hover)] hover:shadow-[0_10px_24px_rgba(var(--bo-accent-rgb),0.26)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/35 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none disabled:active:scale-100"
+                    >
+                      {navigation.state === "submitting" ? "Starting…" : installationActionLabel}
+                    </button>
+                  </Form>
+                </div>
+              ) : (
+                <p className="max-w-xs text-sm leading-6 text-pretty text-[var(--bo-muted)]">
+                  Join an organization to install into {selectedScope.label}.
+                </p>
+              )}
+            </div>
+          </div>
         </div>
 
         {publishedVersion ? (
@@ -398,7 +489,7 @@ export default function BackofficeMarketplaceDetail({ loaderData }: Route.Compon
           </div>
         ) : null}
 
-        <div className="mt-auto pt-6">
+        <div className="mt-6">
           <dl className="grid gap-px bg-[var(--bo-border)] shadow-[0_0_0_1px_var(--bo-border)] sm:grid-cols-3">
             <ReleaseFact label="Latest version" value={listing.latestVersion} mono />
             <ReleaseFact label="Published" value={formatDate(listing.publishedAt)} />
@@ -407,213 +498,156 @@ export default function BackofficeMarketplaceDetail({ loaderData }: Route.Compon
         </div>
       </header>
 
-      <div className="grid items-start gap-5 xl:grid-cols-[22rem_minmax(0,1fr)] 2xl:contents">
-        <aside className="space-y-5 xl:sticky xl:top-[5.5rem] 2xl:contents 2xl:space-y-0">
-          <section className="bo-panel-surface bg-[var(--bo-panel)] p-5">
-            <PanelHeading
-              title="Workspace installation"
-              detail={ingestions.length ? `${ingestions.length} installed` : undefined}
-            />
-            <p className="mt-2 text-sm leading-6 text-pretty text-[var(--bo-muted)]">
-              {ingestions.length
-                ? "Manage the release installed in the selected Marketplace scope."
-                : "Copy an immutable release into the selected Marketplace scope."}
-            </p>
-
-            {ingestions.length ? (
-              <div className="mt-4 space-y-2">
-                {ingestions.map((ingestion) => (
-                  <div
-                    key={`${ingestion.organizationName}:${ingestion.id}`}
-                    className="bg-[var(--bo-panel-2)] p-3 shadow-[inset_0_0_0_1px_var(--bo-border)]"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <p className="min-w-0 text-xs font-medium break-all text-[var(--bo-fg)]">
-                        {ingestion.organizationName} · {ingestion.targetScopeKey}
-                      </p>
-                      <BackofficeStatusLight tone={ingestion.outOfDate ? "waiting" : "live"}>
-                        {ingestion.outOfDate ? "Update" : "Current"}
-                      </BackofficeStatusLight>
-                    </div>
-                    <p className="mt-2 font-mono text-[10px] text-[var(--bo-muted)]">
-                      v{ingestion.version}
-                      {ingestion.outOfDate ? ` → v${ingestion.latestVersion}` : " · latest"}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            ) : null}
-
-            {hasOutdatedIngestion ? (
-              <div className="mt-3 bg-[var(--bo-waiting-bg)] px-3 py-2.5 text-xs leading-5 text-[var(--bo-waiting)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--bo-waiting)_35%,transparent)]">
-                Version {listing.latestVersion} is available. Select it below to update this scope.
-              </div>
-            ) : null}
-
-            <div className="mt-5">
-              {installationOrganizationId ? (
-                <Form method="post" className="space-y-4">
-                  <div>
-                    <p className="text-[10px] font-semibold tracking-[0.14em] text-[var(--bo-muted-2)] uppercase">
-                      Destination
-                    </p>
-                    <div className="bo-control-surface mt-2 bg-[var(--bo-panel-2)] px-3 py-3">
-                      <p className="text-[9px] font-semibold tracking-[0.14em] text-[var(--bo-muted-2)] uppercase">
-                        {selectedScope.kind === "org"
-                          ? "Organisation"
-                          : selectedScope.kind === "project"
-                            ? "Project"
-                            : "Personal"}
-                      </p>
-                      <p className="mt-1.5 truncate text-sm font-medium text-[var(--bo-fg)]">
-                        {selectedScope.label}
-                      </p>
-                    </div>
-                  </div>
-
-                  <label className="block">
-                    <span className="text-[10px] font-semibold tracking-[0.14em] text-[var(--bo-muted-2)] uppercase">
-                      Release
-                    </span>
-                    <select
-                      key={installationVersion}
-                      name="version"
-                      defaultValue={installationVersion}
-                      className="mt-2 min-h-11 w-full border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 font-mono text-sm text-[var(--bo-fg)] transition-[border-color,box-shadow] duration-150 ease-out outline-none focus:border-[color:var(--bo-accent)] focus:ring-2 focus:ring-[color:var(--bo-accent)]/20"
-                    >
-                      {installationVersions.map((version) => (
-                        <option key={version} value={version}>
-                          {version}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-
-                  <button
-                    type="submit"
-                    disabled={navigation.state !== "idle"}
-                    className="inline-flex min-h-11 w-full items-center justify-center bg-[var(--bo-btn-bg)] px-4 text-[10px] font-semibold tracking-[0.16em] text-[var(--bo-btn-fg)] uppercase shadow-[0_8px_20px_rgba(var(--bo-accent-rgb),0.2)] transition-[scale,background-color,box-shadow,opacity] duration-150 ease-out hover:bg-[var(--bo-btn-bg-hover)] hover:shadow-[0_10px_24px_rgba(var(--bo-accent-rgb),0.26)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/35 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none disabled:active:scale-100"
-                  >
-                    {navigation.state === "submitting" ? "Requesting…" : installationActionLabel}
-                  </button>
-                </Form>
-              ) : (
-                <p className="text-sm leading-6 text-pretty text-[var(--bo-muted)]">
-                  Join an organization to install this automation into the selected scope.
-                </p>
-              )}
-
-              {actionData ? (
-                <div
-                  className={`mt-4 px-3 py-2.5 text-xs leading-5 ${actionData.ok ? "bg-[var(--bo-live-bg)] text-[var(--bo-live)]" : "bg-[var(--bo-failed-bg)] text-[var(--bo-failed)]"}`}
-                >
-                  {actionData.ok
-                    ? actionData.action === "restarted"
-                      ? `Installation workflow restarted for ${marketplaceListingSlug(listing.listingId)}@${actionData.version}.`
-                      : actionData.action === "created"
-                        ? `Installation workflow started for ${marketplaceListingSlug(listing.listingId)}@${actionData.version}.`
-                        : `Installation workflow is already ${actionData.workflowStatus}.`
-                    : actionData.message}
-                </div>
-              ) : null}
-
-              {installationOrganizationId && observedInstallationWorkflowInstanceId ? (
-                <ClientOnly>
-                  {() => (
-                    <Suspense
-                      fallback={
-                        <p className="mt-4 text-xs text-[var(--bo-muted)]">Loading installer…</p>
-                      }
-                    >
-                      <MarketplaceInstallationWorkflow
-                        collectionSource={installationCollectionSource}
-                        coordinatorScope={{
-                          kind: "org",
-                          orgId: installationOrganizationId,
-                        }}
-                        ingestionWorkflowInstanceId={observedInstallationWorkflowInstanceId}
-                        requested={actionData?.ok === true}
-                        targetScope={selectedScope}
-                      />
-                    </Suspense>
-                  )}
-                </ClientOnly>
-              ) : null}
-            </div>
-          </section>
-
-          <section className="bo-panel-surface bg-[var(--bo-panel)] p-5">
-            <PanelHeading
-              title="Version history"
-              detail={`${versions.length}${hasNextVersionPage ? "+" : ""} published`}
-            />
-            <div className="mt-4 space-y-2">
-              {versions.map((version) => {
-                const isLatest = version.version === listing.latestVersion;
-                const isSelected = version.version === selectedArtifactVersion;
-                return (
-                  <Link
-                    key={version.version}
-                    to={buildArtifactVersionPath(
-                      location.pathname,
-                      location.search,
-                      selectedArtifactVersion,
-                      version.version,
-                    )}
-                    preventScrollReset
-                    aria-current={isSelected ? "page" : undefined}
-                    className={
-                      isSelected
-                        ? "flex min-h-14 items-center justify-between gap-4 bg-[var(--bo-accent-bg)] px-3 py-3 text-[var(--bo-fg)] shadow-[inset_0_0_0_1px_var(--bo-accent)] transition-[scale,background-color,box-shadow] duration-150 ease-out outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 active:scale-[0.96]"
-                        : "flex min-h-14 items-center justify-between gap-4 bg-[var(--bo-panel-2)] px-3 py-3 text-[var(--bo-fg)] shadow-[inset_0_0_0_1px_var(--bo-border)] transition-[scale,background-color,box-shadow] duration-150 ease-out outline-none hover:bg-[var(--bo-panel)] hover:shadow-[inset_0_0_0_1px_var(--bo-border-strong)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 active:scale-[0.96]"
-                    }
-                  >
-                    <div className="min-w-0">
-                      <p className="font-mono text-xs font-semibold">v{version.version}</p>
-                      <p className="mt-1 text-[10px] text-[var(--bo-muted-2)]">
-                        {formatDate(version.publishedAt)}
-                      </p>
-                    </div>
-                    {isLatest ? (
-                      <BackofficeStatusLight tone="info">Latest</BackofficeStatusLight>
-                    ) : null}
-                  </Link>
-                );
-              })}
-            </div>
-            {hasNextVersionPage && nextVersionCursor ? (
-              <Link
-                to={`${marketplaceListingPath(listing.listingId, selectedScope)}?versionCursor=${encodeURIComponent(nextVersionCursor)}`}
-                className="bo-control-surface mt-3 flex min-h-10 items-center justify-center bg-[var(--bo-panel-2)] px-3 text-center text-[9px] font-semibold tracking-[0.16em] text-[var(--bo-muted)] uppercase transition-[scale,background-color,color,box-shadow] duration-150 ease-out hover:bg-[var(--bo-panel)] hover:text-[var(--bo-fg)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96]"
+      <main className="min-w-0">
+        {navigation.state === "submitting" ? (
+          <InstallationStartingSurface scopeLabel={selectedScope.label} />
+        ) : actionData?.ok === false ? (
+          <InstallationFailureSurface message={actionData.message} />
+        ) : installationOrganizationId && observedInstallationWorkflowInstanceId ? (
+          <ClientOnly fallback={artifactContent}>
+            {() => (
+              <Suspense
+                fallback={
+                  actionData?.ok ? (
+                    <InstallationStartingSurface scopeLabel={selectedScope.label} />
+                  ) : (
+                    artifactContent
+                  )
+                }
               >
-                Browse older versions →
-              </Link>
-            ) : null}
-          </section>
-        </aside>
-
-        <div className="min-w-0 space-y-5 2xl:contents 2xl:space-y-0">
-          <div className="min-w-0 2xl:col-span-3">
-            <Outlet context={{ artifactFiles } satisfies MarketplaceArtifactOutletContext} />
-          </div>
-        </div>
-      </div>
+                <MarketplaceInstallationWorkflow
+                  collectionSource={installationCollectionSource}
+                  coordinatorScope={{
+                    kind: "org",
+                    orgId: installationOrganizationId,
+                  }}
+                  fallback={artifactContent}
+                  ingestionWorkflowInstanceId={observedInstallationWorkflowInstanceId}
+                  onClose={closeInstallationResult}
+                  requested={actionData?.ok === true}
+                  targetScope={selectedScope}
+                />
+              </Suspense>
+            )}
+          </ClientOnly>
+        ) : (
+          artifactContent
+        )}
+      </main>
     </div>
   );
 }
 
-function PanelHeading({ title, detail }: { title: string; detail?: string }) {
+function VersionHistoryDropdown({
+  versions,
+  selectedVersion,
+  latestVersion,
+  selectedScope,
+  listingId,
+  pathname,
+  search,
+  nextVersionCursor,
+  hasNextVersionPage,
+}: {
+  versions: readonly MarketplaceVersionOption[];
+  selectedVersion: string;
+  latestVersion: string;
+  selectedScope: MarketplaceLayoutContext["selectedScope"];
+  listingId: string;
+  pathname: string;
+  search: string;
+  nextVersionCursor?: string;
+  hasNextVersionPage: boolean;
+}) {
   return (
-    <div className="flex items-start justify-between gap-4">
-      <h3 className="text-lg font-semibold tracking-tight text-balance text-[var(--bo-fg)]">
-        {title}
-      </h3>
-      {detail ? (
-        <span className="shrink-0 font-mono text-[9px] tracking-[0.1em] text-[var(--bo-muted-2)] uppercase">
-          {detail}
+    <details className="group relative">
+      <summary className="flex min-h-11 min-w-36 cursor-pointer list-none items-center justify-end gap-2 px-1 text-left transition-[scale,color] duration-150 ease-out hover:text-[var(--bo-accent-fg)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96] sm:text-right [&::-webkit-details-marker]:hidden">
+        <span>
+          <span className="block text-[9px] font-semibold tracking-[0.14em] text-[var(--bo-muted-2)] uppercase">
+            Version history
+          </span>
+          <span className="mt-1 block font-mono text-sm font-medium text-[var(--bo-fg)]">
+            v{selectedVersion}
+          </span>
         </span>
-      ) : null}
-    </div>
+        <ChevronDown
+          className="size-3.5 text-[var(--bo-muted-2)] transition-transform duration-150 ease-out group-open:rotate-180"
+          aria-hidden="true"
+        />
+      </summary>
+      <div className="absolute top-full right-0 z-30 mt-2 w-[min(20rem,calc(100vw-2rem))] bg-[var(--bo-panel)] p-2 shadow-[0_18px_48px_rgba(0,0,0,0.18),0_0_0_1px_var(--bo-border-strong)]">
+        <div className="max-h-80 space-y-1 overflow-y-auto">
+          {versions.map((version) => {
+            const isLatest = version.version === latestVersion;
+            const isSelected = version.version === selectedVersion;
+            return (
+              <Link
+                key={version.version}
+                to={buildArtifactVersionPath(pathname, search, selectedVersion, version.version)}
+                preventScrollReset
+                aria-current={isSelected ? "page" : undefined}
+                onClick={(event) => {
+                  event.currentTarget.closest("details")?.removeAttribute("open");
+                }}
+                className={
+                  isSelected
+                    ? "flex min-h-12 items-center justify-between gap-4 bg-[var(--bo-accent-bg)] px-3 py-2.5 text-[var(--bo-fg)] shadow-[inset_0_0_0_1px_var(--bo-accent)] outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30"
+                    : "flex min-h-12 items-center justify-between gap-4 px-3 py-2.5 text-[var(--bo-fg)] transition-colors duration-150 ease-out outline-none hover:bg-[var(--bo-panel-2)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30"
+                }
+              >
+                <span className="min-w-0">
+                  <span className="block font-mono text-xs font-semibold">v{version.version}</span>
+                  <span className="mt-1 block text-[10px] text-[var(--bo-muted-2)]">
+                    {version.publishedAt ? formatDate(version.publishedAt) : "Published release"}
+                  </span>
+                </span>
+                {isLatest ? (
+                  <BackofficeStatusLight tone="info">Latest</BackofficeStatusLight>
+                ) : null}
+              </Link>
+            );
+          })}
+        </div>
+        {hasNextVersionPage && nextVersionCursor ? (
+          <Link
+            to={`${marketplaceListingPath(listingId, selectedScope)}?versionCursor=${encodeURIComponent(nextVersionCursor)}`}
+            className="mt-2 flex min-h-10 items-center justify-center border-t border-[color:var(--bo-border)] px-3 pt-2 text-center text-[9px] font-semibold tracking-[0.16em] text-[var(--bo-muted)] uppercase transition-colors duration-150 ease-out hover:text-[var(--bo-fg)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none"
+          >
+            Browse older versions →
+          </Link>
+        ) : null}
+      </div>
+    </details>
+  );
+}
+
+function InstallationStartingSurface({ scopeLabel }: { scopeLabel: string }) {
+  return (
+    <section className="bo-panel-surface flex min-h-80 items-center justify-center bg-[var(--bo-panel)] p-6 text-center md:p-10">
+      <div className="max-w-md">
+        <span className="mx-auto block size-2 animate-pulse rounded-full bg-[var(--bo-accent)] motion-reduce:animate-none" />
+        <h3 className="mt-5 text-lg font-semibold tracking-tight text-balance text-[var(--bo-fg)]">
+          Starting installation
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-pretty text-[var(--bo-muted)]">
+          Preparing the selected release for {scopeLabel}.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function InstallationFailureSurface({ message }: { message: string }) {
+  return (
+    <section className="bo-panel-surface flex min-h-80 items-center justify-center bg-[var(--bo-panel)] p-6 text-center md:p-10">
+      <div className="max-w-md">
+        <span className="mx-auto block size-2 rounded-full bg-[var(--bo-failed)]" />
+        <h3 className="mt-5 text-lg font-semibold tracking-tight text-balance text-[var(--bo-fg)]">
+          Installation could not start
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-pretty text-[var(--bo-failed)]">{message}</p>
+      </div>
+    </section>
   );
 }
 

--- a/apps/backoffice/app/routes/backoffice/marketplace/installation-workflow-presentation.ts
+++ b/apps/backoffice/app/routes/backoffice/marketplace/installation-workflow-presentation.ts
@@ -8,6 +8,28 @@ type MarketplaceInstallationGeneratedUi =
   | { kind: "output"; value: unknown }
   | { kind: "step"; step: WorkflowRunStep };
 
+type MarketplaceInstallationObservedStatus = AutomationWorkflowRun["status"] | null;
+
+export function shouldShowMarketplaceInstallationStatus(input: {
+  requested: boolean;
+  synchronizationFailed: boolean;
+  ingestionStatus: MarketplaceInstallationObservedStatus;
+  installerStatus: MarketplaceInstallationObservedStatus;
+}): boolean {
+  if (input.requested || input.synchronizationFailed) {
+    return true;
+  }
+
+  return [input.ingestionStatus, input.installerStatus].some(
+    (status) =>
+      status === "active" ||
+      status === "paused" ||
+      status === "waiting" ||
+      status === "errored" ||
+      status === "terminated",
+  );
+}
+
 export function selectMarketplaceInstallationGeneratedUi(
   instance: AutomationWorkflowRun,
 ): MarketplaceInstallationGeneratedUi | null {

--- a/apps/backoffice/app/routes/backoffice/marketplace/installation-workflow.client.test.ts
+++ b/apps/backoffice/app/routes/backoffice/marketplace/installation-workflow.client.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, test } from "vitest";
+import { assert, describe, expect, test } from "vitest";
 
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { AutomationWorkflowRun } from "@/routes/backoffice/automations/script-view/workflow-run-presentation";
 
-import { selectMarketplaceInstallationGeneratedUi } from "./installation-workflow-presentation";
+import {
+  selectMarketplaceInstallationGeneratedUi,
+  shouldShowMarketplaceInstallationStatus,
+} from "./installation-workflow-presentation";
 import { MarketplaceInstallerGeneratedUi } from "./installation-workflow.client";
 
 const generatedUi = (label: string) => ({
@@ -39,6 +42,44 @@ const workflowRun = (input: Partial<AutomationWorkflowRun> = {}): AutomationWork
   workflowEvents: [],
   workflowStepEmissions: [],
   ...input,
+});
+
+describe("Marketplace installation status visibility", () => {
+  test("surfaces synchronization failures without a local installation request", () => {
+    assert(
+      shouldShowMarketplaceInstallationStatus({
+        requested: false,
+        synchronizationFailed: true,
+        ingestionStatus: null,
+        installerStatus: null,
+      }),
+    );
+  });
+
+  test.each(["errored", "terminated"] as const)(
+    "keeps an externally started installation visible after it becomes %s",
+    (ingestionStatus) => {
+      assert(
+        shouldShowMarketplaceInstallationStatus({
+          requested: false,
+          synchronizationFailed: false,
+          ingestionStatus,
+          installerStatus: "complete",
+        }),
+      );
+    },
+  );
+
+  test("hides a previously completed external installation", () => {
+    assert(
+      !shouldShowMarketplaceInstallationStatus({
+        requested: false,
+        synchronizationFailed: false,
+        ingestionStatus: "complete",
+        installerStatus: "complete",
+      }),
+    );
+  });
 });
 
 describe("Marketplace installation generated UI selection", () => {
@@ -108,7 +149,19 @@ describe("Marketplace installation generated UI selection", () => {
     );
 
     expect(markup).toContain("Complete");
-    expect(markup).not.toContain("Installer complete.");
+    expect(markup).not.toContain("Installation complete.");
+  });
+
+  test("renders completion in the main installation content without generated output", () => {
+    const markup = renderToStaticMarkup(
+      createElement(MarketplaceInstallerGeneratedUi, {
+        coordinatorScope: { kind: "org", orgId: "org-1" },
+        instance: workflowRun({ status: "complete", output: { installed: true } }),
+        targetScope: { kind: "org", orgId: "org-1" },
+      }),
+    );
+
+    expect(markup).toContain("Installation complete.");
   });
 
   test("ignores ordinary workflow values", () => {

--- a/apps/backoffice/app/routes/backoffice/marketplace/installation-workflow.client.tsx
+++ b/apps/backoffice/app/routes/backoffice/marketplace/installation-workflow.client.tsx
@@ -1,4 +1,5 @@
-import { use } from "react";
+import { X } from "lucide-react";
+import { use, useState, type ReactNode } from "react";
 
 import type { BackofficeContextScope } from "@/backoffice-runtime/context";
 import type { BackofficeRoutableScope } from "@/backoffice-runtime/scope-codec";
@@ -20,32 +21,46 @@ import {
 } from "@/routes/backoffice/automations/script-view/workflow-run-presentation";
 import { WorkflowStepGeneratedUi } from "@/routes/backoffice/automations/script-view/workflow-step-generated-ui";
 
-import { selectMarketplaceInstallationGeneratedUi } from "./installation-workflow-presentation";
+import {
+  selectMarketplaceInstallationGeneratedUi,
+  shouldShowMarketplaceInstallationStatus,
+} from "./installation-workflow-presentation";
 
 export function MarketplaceInstallationWorkflow({
   collectionSource,
   coordinatorScope,
+  fallback,
   ingestionWorkflowInstanceId,
+  onClose,
   requested,
   targetScope,
 }: {
   collectionSource: AutomationCollectionSource | null;
   coordinatorScope: BackofficeContextScope;
+  fallback: ReactNode;
   ingestionWorkflowInstanceId: string;
+  onClose: () => void;
   requested: boolean;
   targetScope: BackofficeRoutableScope;
 }) {
   if (!collectionSource) {
     return requested ? (
-      <InstallationWorkflowNotice message="Workflow synchronization is unavailable." />
-    ) : null;
+      <InstallationWorkflowSurface state="failed" onClose={null}>
+        <InstallationWorkflowNotice message="Workflow synchronization is unavailable." />
+      </InstallationWorkflowSurface>
+    ) : (
+      fallback
+    );
   }
 
   return (
     <SynchronizedMarketplaceInstallationWorkflow
+      key={ingestionWorkflowInstanceId}
       collectionSource={collectionSource}
       coordinatorScope={coordinatorScope}
+      fallback={fallback}
       ingestionWorkflowInstanceId={ingestionWorkflowInstanceId}
+      onClose={onClose}
       requested={requested}
       targetScope={targetScope}
     />
@@ -55,16 +70,21 @@ export function MarketplaceInstallationWorkflow({
 function SynchronizedMarketplaceInstallationWorkflow({
   collectionSource,
   coordinatorScope,
+  fallback,
   ingestionWorkflowInstanceId,
+  onClose,
   requested,
   targetScope,
 }: {
   collectionSource: AutomationCollectionSource;
   coordinatorScope: BackofficeContextScope;
+  fallback: ReactNode;
   ingestionWorkflowInstanceId: string;
+  onClose: () => void;
   requested: boolean;
   targetScope: BackofficeRoutableScope;
 }) {
+  const [resultDismissed, setResultDismissed] = useState(false);
   const database = use(getAutomationBrowserDatabase(collectionSource));
   const collections = database.collections;
   const ingestionRecords = useWorkflowRunRecords({
@@ -89,35 +109,95 @@ function SynchronizedMarketplaceInstallationWorkflow({
   const ingestion = ingestionRecords.instances[0];
   const installer = installerRecords.instances[0];
   const synchronizationError = ingestionRecords.error ?? installerRecords.error;
+  const ingestionInProgress = ingestion ? isWorkflowInProgress(ingestion.status) : false;
+  const showInstallationStatus = shouldShowMarketplaceInstallationStatus({
+    requested,
+    synchronizationFailed: synchronizationError !== null,
+    ingestionStatus: ingestion?.status ?? null,
+    installerStatus: installer?.status ?? null,
+  });
 
+  function closeInstallationResult() {
+    setResultDismissed(true);
+    onClose();
+  }
+
+  if (resultDismissed && ingestion?.status === "complete") {
+    return fallback;
+  }
   if (synchronizationError) {
-    return <InstallationWorkflowNotice message={synchronizationError} />;
+    return (
+      <InstallationWorkflowSurface state="failed" onClose={null}>
+        <InstallationWorkflowNotice message={synchronizationError} />
+      </InstallationWorkflowSurface>
+    );
   }
   if (!ingestion) {
-    return requested || ingestionRecords.isLoading ? (
-      <InstallationWorkflowNotice message="Preparing installation workflow…" />
-    ) : null;
+    return showInstallationStatus ? (
+      <InstallationWorkflowSurface state="running" onClose={null}>
+        <InstallationWorkflowNotice message="Preparing installation workflow…" />
+      </InstallationWorkflowSurface>
+    ) : (
+      fallback
+    );
   }
   if (!installer) {
-    return (
-      <InstallationWorkflowNotice
-        message={
-          ingestion.status === "complete"
-            ? "Installation complete."
-            : ingestion.status === "errored" || ingestion.status === "terminated"
+    if (ingestion.status === "complete") {
+      return requested ? (
+        <InstallationWorkflowSurface state="complete" onClose={closeInstallationResult}>
+          <InstallationWorkflowNotice message="Installation complete." />
+        </InstallationWorkflowSurface>
+      ) : (
+        fallback
+      );
+    }
+    return showInstallationStatus ? (
+      <InstallationWorkflowSurface
+        state={
+          ingestion.status === "errored" || ingestion.status === "terminated" ? "failed" : "running"
+        }
+        onClose={null}
+      >
+        <InstallationWorkflowNotice
+          message={
+            ingestion.status === "errored" || ingestion.status === "terminated"
               ? `Installation ${ingestion.status}.`
               : "Preparing installation workflow…"
-        }
-      />
+          }
+        />
+      </InstallationWorkflowSurface>
+    ) : (
+      fallback
     );
+  }
+  const generatedUi = selectMarketplaceInstallationGeneratedUi(installer);
+  if (!showInstallationStatus) {
+    return fallback;
   }
 
   return (
-    <MarketplaceInstallerGeneratedUi
-      coordinatorScope={coordinatorScope}
-      instance={installer}
-      targetScope={targetScope}
-    />
+    <InstallationWorkflowSurface
+      state={
+        ingestion.status === "errored" || ingestion.status === "terminated"
+          ? "failed"
+          : ingestion.status === "complete"
+            ? "complete"
+            : installer.status === "errored" || installer.status === "terminated"
+              ? "failed"
+              : "running"
+      }
+      onClose={ingestion.status === "complete" ? closeInstallationResult : null}
+    >
+      {ingestionInProgress && installer.status === "complete" && !generatedUi ? (
+        <InstallationWorkflowNotice message="Finalizing installation…" />
+      ) : (
+        <MarketplaceInstallerGeneratedUi
+          coordinatorScope={coordinatorScope}
+          instance={installer}
+          targetScope={targetScope}
+        />
+      )}
+    </InstallationWorkflowSurface>
   );
 }
 
@@ -132,7 +212,7 @@ export function MarketplaceInstallerGeneratedUi({
 }) {
   const generatedUi = selectMarketplaceInstallationGeneratedUi(instance);
   if (instance.status === "complete" && generatedUi?.kind !== "output") {
-    return <InstallationWorkflowNotice message="Installer complete." />;
+    return <InstallationWorkflowNotice message="Installation complete." />;
   }
   if (instance.status === "errored" || instance.status === "terminated") {
     return <InstallationWorkflowNotice message={`Installer ${instance.status}.`} />;
@@ -141,54 +221,111 @@ export function MarketplaceInstallerGeneratedUi({
     return <InstallationWorkflowNotice message="Installer is running…" />;
   }
 
+  return generatedUi.kind === "output" ? (
+    <WorkflowGeneratedUi value={generatedUi.value} />
+  ) : (
+    <WorkflowStepGeneratedUi
+      state={{
+        stepRecordId: generatedUi.step.id,
+        status: "completed",
+        attempts: generatedUi.step.attempts,
+        completedAt: generatedUi.step.updatedAt,
+        result: generatedUi.step.result,
+        emissionCount: 0,
+        current: false,
+      }}
+      workflowEvents={instance.workflowEvents}
+      workflowRunRecordId={instance.id}
+      currentScope={targetScope}
+      workflowEventSender={async ({ eventId, workflowName, instanceId, eventType, payload }) => {
+        await sendBackofficeWorkflowEvent({
+          eventId,
+          reference: { scope: coordinatorScope, workflowName, instanceId },
+          eventType,
+          payload,
+        });
+      }}
+      workflowName={instance.workflowName}
+      workflowInstanceId={instance.instanceId}
+      waitingEventTypes={currentWorkflowWaitingEventTypes(instance.workflowSteps)}
+    />
+  );
+}
+
+function InstallationWorkflowSurface({
+  children,
+  state,
+  onClose,
+}: {
+  children: ReactNode;
+  state: "running" | "failed" | "complete";
+  onClose: (() => void) | null;
+}) {
+  const status =
+    state === "running"
+      ? {
+          label: "Running",
+          title: "Installation in progress",
+          className:
+            "bg-[var(--bo-waiting-bg)] text-[var(--bo-waiting)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--bo-waiting)_35%,transparent)]",
+        }
+      : state === "failed"
+        ? {
+            label: "Failed",
+            title: "Installation needs attention",
+            className:
+              "bg-[var(--bo-failed-bg)] text-[var(--bo-failed)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--bo-failed)_35%,transparent)]",
+          }
+        : {
+            label: "Complete",
+            title: "Installation complete",
+            className:
+              "bg-[var(--bo-live-bg)] text-[var(--bo-live)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--bo-live)_35%,transparent)]",
+          };
+
   return (
-    <div className="mt-4 border-t border-[color:var(--bo-border)] pt-4">
-      <p className="mb-3 text-[10px] font-semibold tracking-[0.14em] text-[var(--bo-muted-2)] uppercase">
-        Installer
-      </p>
-      {generatedUi.kind === "output" ? (
-        <WorkflowGeneratedUi value={generatedUi.value} />
-      ) : (
-        <WorkflowStepGeneratedUi
-          state={{
-            stepRecordId: generatedUi.step.id,
-            status: "completed",
-            attempts: generatedUi.step.attempts,
-            completedAt: generatedUi.step.updatedAt,
-            result: generatedUi.step.result,
-            emissionCount: 0,
-            current: false,
-          }}
-          workflowEvents={instance.workflowEvents}
-          workflowRunRecordId={instance.id}
-          currentScope={targetScope}
-          workflowEventSender={async ({
-            eventId,
-            workflowName,
-            instanceId,
-            eventType,
-            payload,
-          }) => {
-            await sendBackofficeWorkflowEvent({
-              eventId,
-              reference: { scope: coordinatorScope, workflowName, instanceId },
-              eventType,
-              payload,
-            });
-          }}
-          workflowName={instance.workflowName}
-          workflowInstanceId={instance.instanceId}
-          waitingEventTypes={currentWorkflowWaitingEventTypes(instance.workflowSteps)}
-        />
-      )}
-    </div>
+    <section className="bo-panel-surface min-h-80 bg-[var(--bo-panel)] p-5 md:p-7">
+      <div className="mb-5 flex items-center justify-between gap-4 border-b border-[color:var(--bo-border)] pb-4">
+        <div>
+          <p className="text-[9px] font-semibold tracking-[0.16em] text-[var(--bo-muted-2)] uppercase">
+            Installation
+          </p>
+          <h3 className="mt-1 text-lg font-semibold tracking-tight text-balance text-[var(--bo-fg)]">
+            {status.title}
+          </h3>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <span
+            className={`inline-flex min-h-6 items-center px-2 font-mono text-[9px] tracking-[0.12em] uppercase ${status.className}`}
+          >
+            {status.label}
+          </span>
+          {onClose ? (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close installation result"
+              title="Close"
+              className="inline-flex size-10 items-center justify-center text-[var(--bo-muted-2)] transition-[scale,color] duration-150 ease-out hover:text-[var(--bo-fg)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96]"
+            >
+              <X className="size-4" aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+      {children}
+    </section>
   );
 }
 
 function InstallationWorkflowNotice({ message }: { message: string }) {
   return (
-    <p aria-live="polite" className="mt-4 text-xs leading-5 text-[var(--bo-muted)]">
+    <p aria-live="polite" className="text-sm leading-6 text-pretty text-[var(--bo-muted)]">
       {message}
     </p>
   );
+}
+
+function isWorkflowInProgress(status: AutomationWorkflowRun["status"]): boolean {
+  return status === "active" || status === "paused" || status === "waiting";
 }

--- a/apps/backoffice/app/routes/backoffice/marketplace/navigation.ts
+++ b/apps/backoffice/app/routes/backoffice/marketplace/navigation.ts
@@ -52,10 +52,6 @@ export function buildArtifactVersionPath(
 ): string {
   const search = new URLSearchParams(currentSearch);
   search.set("artifactVersion", nextVersion);
-  const currentTab = search.get("artifactTab");
-  if (currentTab !== "files" && currentTab !== "workflows") {
-    search.set("artifactTab", "files");
-  }
 
   const selectedPath = search.get("artifactPath")?.trim();
   const currentVersionRoot = `/artifact/${currentVersion}`;

--- a/apps/backoffice/app/routes/backoffice/marketplace/scope-layout.tsx
+++ b/apps/backoffice/app/routes/backoffice/marketplace/scope-layout.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet } from "react-router";
+import { Outlet } from "react-router";
 
 import { OverflowTabRow } from "@/components/backoffice/overflow-tab-row";
 import { findBackofficeMe } from "@/fragno/auth/auth-server";
@@ -18,7 +18,6 @@ import {
 const MARKETPLACE_TABS = [
   { id: "marketplace" as const, label: "Marketplace" },
   { id: "installed" as const, label: "Installed" },
-  { id: "my-listings" as const, label: "My listings" },
 ];
 
 const currentTabFromPath = (pathname: string): MarketplaceTab => {
@@ -99,21 +98,10 @@ function MarketplaceWorkspaceHeader({
   }));
 
   return (
-    <section className="bo-fragment-surface bo-panel-surface overflow-hidden bg-[var(--bo-header-bg)]">
+    <section className="bo-fragment-surface overflow-hidden bg-[var(--bo-header-bg)]">
       <h1 className="sr-only">Marketplace for {selectedScope.label}</h1>
-      {selectedScope.kind === "org" ? (
-        <div className="flex justify-end border-b border-[color:var(--bo-border)] p-3 md:px-4">
-          <Link
-            to={`/backoffice/marketplace/publish?ownerOrgId=${encodeURIComponent(selectedScope.orgId)}`}
-            className="flex min-h-10 shrink-0 items-center border border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] px-3 text-[9px] font-semibold tracking-[0.18em] text-[var(--bo-accent-fg)] uppercase transition-[scale,background-color,border-color,color] duration-150 ease-out hover:border-[color:var(--bo-accent-strong)] focus-visible:ring-2 focus-visible:ring-[color:var(--bo-accent)]/30 focus-visible:outline-none active:scale-[0.96]"
-          >
-            New draft
-          </Link>
-        </div>
-      ) : null}
-
-      <div className="bg-[var(--bo-header-bg)] p-2">
-        <OverflowTabRow items={tabs} ariaLabel="Marketplace workspace sections" />
+      <div className="flex flex-col bg-[color:var(--bo-sidebar-bg)] px-2 pt-4">
+        <OverflowTabRow items={tabs} ariaLabel="Marketplace workspace sections" variant="browser" />
       </div>
     </section>
   );


### PR DESCRIPTION
Present published automations as a featured catalog and simplify the
Marketplace workspace navigation.

Default package details to the README overview, move version and install
controls into the package header, and surface installation state in the
main content area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marketplace browsing now highlights install-ready packages with publisher, publication, tag, and pagination details.
  * Artifact pages open on Overview by default, with improved overview loading.
  * Package details include streamlined version selection and inline installation controls.
  * Installation workflows now show clearer progress, failure, completion, and dismissal states.

* **Improvements**
  * Removed category filtering and “My listings” navigation.
  * Artifact tabs remain preserved when changing versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->