### PR TITLE
feat(backoffice): simplify Telegram connection setup

### DIFF
--- a/apps/backoffice/app/backoffice-runtime/in-memory-object-factory.ts
+++ b/apps/backoffice/app/backoffice-runtime/in-memory-object-factory.ts
@@ -199,9 +199,10 @@ const inMemoryObjectFactories = {
       runtime,
       database: createInMemoryAuthDatabase(),
     }),
-  TELEGRAM: ({ state, runtime }) =>
+  TELEGRAM: ({ state, env, runtime }) =>
     new InMemoryTelegramObject({
       state,
+      env,
       runtime,
     }),
   RESEND: ({ state, env, runtime }) =>

--- a/apps/backoffice/app/fragno/automation/scenario.ts
+++ b/apps/backoffice/app/fragno/automation/scenario.ts
@@ -420,7 +420,6 @@ type TelegramConfiguredInput = {
   botToken?: string;
   webhookSecretToken?: string;
   apiBaseUrl?: string;
-  webhookBaseUrl?: string;
 };
 
 type TelegramMessageInput = {
@@ -2449,18 +2448,13 @@ const buildStepBuilders = <
           async (ctx) => {
             ctx.rememberOrg(input.orgId);
             const webhookSecretToken = input.webhookSecretToken ?? "telegram-webhook-secret";
-            const webhookBaseUrl = input.webhookBaseUrl ?? "https://example.com";
-            await ctx.runtime.objects.telegram.forOrg(input.orgId).setAdminConfig(
-              {
-                orgId: input.orgId,
-                botToken: input.botToken ?? "123456:telegram-bot-token",
-                webhookSecretToken,
-                botUsername: input.botUsername,
-                apiBaseUrl: input.apiBaseUrl ?? "https://telegram.test",
-                webhookBaseUrl,
-              },
-              webhookBaseUrl,
-            );
+            await ctx.runtime.objects.telegram.forOrg(input.orgId).setAdminConfig({
+              orgId: input.orgId,
+              botToken: input.botToken ?? "123456:telegram-bot-token",
+              webhookSecretToken,
+              botUsername: input.botUsername,
+              apiBaseUrl: input.apiBaseUrl ?? "https://telegram.test",
+            });
             ctx.vars[`telegram:${input.orgId}:webhookSecretToken`] = webhookSecretToken;
           },
         ),
@@ -4445,7 +4439,7 @@ const createObjectFactories = (fakes: ScenarioFakes): InMemoryObjectFactoryOverr
   const objectFactories: InMemoryObjectFactoryOverrides = {};
 
   if (fakes.telegram) {
-    objectFactories.TELEGRAM = ({ state, runtime }) => {
+    objectFactories.TELEGRAM = ({ state, env, runtime }) => {
       const fakeTelegram = fakes.telegram!;
       return new (class extends InMemoryTelegramObject {
         async getAutomationFile(input: {
@@ -4473,6 +4467,7 @@ const createObjectFactories = (fakes: ScenarioFakes): InMemoryObjectFactoryOverr
         }
       })({
         state,
+        env,
         runtime,
         api: fakeTelegram.api,
         adminApi: fakeTelegram.adminApi,

--- a/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/telegram.ts
+++ b/apps/backoffice/app/fragno/backoffice-capabilities/capabilities/telegram.ts
@@ -24,28 +24,11 @@ const absoluteUrl = optionalTrimmedString.refine((value) => !value || URL.canPar
   message: "Must be a valid absolute URL.",
 });
 
-const requiredHttpUrl = z
-  .string()
-  .trim()
-  .min(1, "Webhook base URL is required.")
-  .refine(
-    (value) => {
-      try {
-        const parsed = new URL(value);
-        return parsed.protocol === "http:" || parsed.protocol === "https:";
-      } catch {
-        return false;
-      }
-    },
-    { message: "Webhook base URL must include http:// or https://." },
-  );
-
 export const telegramConfigureInputSchema = z.object({
   botToken: z.string().trim().min(1, "Bot token is required."),
   webhookSecretToken: z.string().trim().min(1, "Webhook secret token is required."),
   botUsername: optionalTrimmedString,
   apiBaseUrl: absoluteUrl,
-  webhookBaseUrl: requiredHttpUrl,
 });
 
 const telegramAutomationExternalEntities = {
@@ -98,7 +81,7 @@ const toTelegramStatus = (response: TelegramAdminConfigResponse): ConnectionStat
     return {
       ...connectionStatusIdentity,
       configured: false,
-      missing: ["botToken", "webhookSecretToken", "webhookBaseUrl"],
+      missing: ["botToken", "webhookSecretToken"],
     };
   }
 
@@ -133,11 +116,6 @@ export const telegramCapability: BackofficeConfigurableConnectionCapability = {
         },
         { name: "botUsername", description: "Optional bot username, with or without @." },
         { name: "apiBaseUrl", description: "Optional Telegram API base URL override." },
-        {
-          name: "webhookBaseUrl",
-          required: true,
-          description: "Public http(s) base URL used when registering the Telegram webhook.",
-        },
       ],
       getStatus: async ({ objects, orgId }) =>
         toTelegramStatus(await getTelegramDo(objects, orgId).getAdminConfig()),
@@ -145,11 +123,10 @@ export const telegramCapability: BackofficeConfigurableConnectionCapability = {
         toTelegramStatus(await getTelegramDo(objects, orgId).getAdminConfig()),
       reset: async ({ objects, orgId }) =>
         toTelegramStatus(await getTelegramDo(objects, orgId).resetAdminConfig()),
-      configure: async ({ objects, orgId, origin, payload }) =>
+      configure: async ({ objects, orgId, payload }) =>
         toTelegramStatus(
           await getTelegramDo(objects, orgId).setAdminConfig(
             telegramConfigureInputSchema.parse(payload),
-            origin,
           ),
         ),
     },

--- a/apps/backoffice/app/fragno/runtime-tools/families/backoffice-capabilities.ts
+++ b/apps/backoffice/app/fragno/runtime-tools/families/backoffice-capabilities.ts
@@ -726,7 +726,7 @@ const connectionsConfigureTool = defineBackofficeRuntimeTool({
         ],
         examples: [
           'connections.configure --id reson8 --json \'{"apiKey":"..."}\' --format json',
-          'connections.configure --id telegram --json \'{"botToken":"...","webhookSecretToken":"...","webhookBaseUrl":"https://example.com"}\' --format json',
+          'connections.configure --id telegram --json \'{"botToken":"...","webhookSecretToken":"..."}\' --format json',
         ],
       },
       parse: parseConfigure,

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/configuration.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/configuration.tsx
@@ -2,42 +2,19 @@ import { useEffect, useState, type SubmitEvent } from "react";
 import { Form, useActionData, useNavigation, useOutletContext } from "react-router";
 
 import { backofficeContextScopeSinglePathSegment } from "@/backoffice-runtime/scope-codec";
-import { FormContainer, FormField, WizardStepper } from "@/components/backoffice";
+import { FormContainer, FormField } from "@/components/backoffice";
 import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
 import { resolveAuthenticatedIntegrationContext } from "../../integrations/scope";
-import { formatTimestamp } from "../formatting";
 import type { Route } from "./+types/configuration";
 import { generateSecretToken } from "./secret-token";
 import type { TelegramConfigState, TelegramLayoutContext } from "./shared";
-
-const SETUP_STEPS = [
-  {
-    title: "Create a bot",
-    description:
-      "Use BotFather in Telegram to create a bot, set its name, and copy the bot token + username.",
-    helper: "BotFather: /newbot",
-  },
-  {
-    title: "Configure webhook",
-    description:
-      "Generate a webhook secret, then register the webhook URL with Telegram so updates flow in.",
-    helper: "setWebhook with secret_token",
-  },
-  {
-    title: "Store credentials",
-    description:
-      "Save the bot token and secret for this organization. The fragment will start ingesting chats.",
-    helper: "Saved per organization",
-  },
-];
 
 type TelegramConfigForm = {
   botToken: string;
   webhookSecretToken: string;
   botUsername: string;
   apiBaseUrl: string;
-  webhookBaseUrl: string;
 };
 
 type TelegramConfigActionData = {
@@ -70,13 +47,6 @@ const validateOptionalUrl = (value: string, label: string) => {
   return null;
 };
 
-const validateRequiredUrl = (value: string, label: string) => {
-  if (!value) {
-    return `${label} is required.`;
-  }
-  return validateOptionalUrl(value, label);
-};
-
 const normalizeTelegramConfigInput = (
   input: TelegramConfigForm,
 ): TelegramConfigValidationResult => {
@@ -84,7 +54,6 @@ const normalizeTelegramConfigInput = (
   const webhookSecretToken = input.webhookSecretToken.trim();
   const botUsername = input.botUsername.trim().replace(/^@/, "");
   const apiBaseUrl = input.apiBaseUrl.trim();
-  const webhookBaseUrl = input.webhookBaseUrl.trim();
 
   if (!botToken || !webhookSecretToken) {
     return {
@@ -98,11 +67,6 @@ const normalizeTelegramConfigInput = (
     return { ok: false, message: apiBaseUrlError };
   }
 
-  const webhookBaseUrlError = validateRequiredUrl(webhookBaseUrl, "Webhook base URL");
-  if (webhookBaseUrlError) {
-    return { ok: false, message: webhookBaseUrlError };
-  }
-
   return {
     ok: true,
     payload: {
@@ -110,7 +74,6 @@ const normalizeTelegramConfigInput = (
       webhookSecretToken,
       botUsername,
       apiBaseUrl,
-      webhookBaseUrl,
     },
   };
 };
@@ -136,7 +99,6 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     webhookSecretToken: getValue("webhookSecretToken"),
     botUsername: getValue("botUsername"),
     apiBaseUrl: getValue("apiBaseUrl"),
-    webhookBaseUrl: getValue("webhookBaseUrl"),
   };
 
   const validation = normalizeTelegramConfigInput(payload);
@@ -148,12 +110,11 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     } satisfies TelegramConfigActionData;
   }
 
-  const origin = new URL(request.url).origin;
   const { runtime } = context.get(BackofficeWorkerContext);
 
   try {
     const telegramDo = runtime.objects.telegram.for(scope);
-    const status = await telegramDo.setAdminConfig(validation.payload, origin);
+    const status = await telegramDo.setAdminConfig(validation.payload);
 
     if (status.webhook && !status.webhook.ok) {
       return {
@@ -177,147 +138,23 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   }
 }
 
-function TelegramConnectionStatus({
-  configState,
-  configLoading,
-  configError,
-  statusLabel,
-  statusTone,
-  currentStep,
-  onStepChange,
-}: {
-  configState: TelegramConfigState | null;
-  configLoading: boolean;
-  configError: string | null;
-  statusLabel: string;
-  statusTone: string;
-  currentStep: number;
-  onStepChange: (step: number) => void;
-}) {
-  return (
-    <section className="grid gap-3 lg:grid-cols-[1.1fr_1fr]">
-      <div className="border border-[color:var(--bo-border)] bg-[var(--bo-panel)] p-4">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <p className="text-[10px] tracking-[0.24em] text-[var(--bo-muted-2)] uppercase">
-              Status
-            </p>
-            <h2 className="mt-2 text-xl font-semibold text-[var(--bo-fg)]">Telegram connection</h2>
-            <p className="mt-2 text-sm text-[var(--bo-muted)]">
-              Each organization gets a dedicated Telegram fragment instance and database.
-            </p>
-          </div>
-          <span
-            className={`border px-2 py-1 text-[10px] tracking-[0.22em] uppercase ${statusTone}`}
-          >
-            {statusLabel}
-          </span>
-        </div>
-
-        <div className="mt-4 space-y-2 text-sm text-[var(--bo-muted)]">
-          {configLoading ? (
-            <p>Loading configuration…</p>
-          ) : configError ? (
-            <p className="text-red-500">{configError}</p>
-          ) : configState?.configured ? (
-            <>
-              <p>
-                Bot username:{" "}
-                <span className="text-[var(--bo-fg)]">
-                  @{configState.config?.botUsername ?? "unknown"}
-                </span>
-              </p>
-              <p>
-                Last updated:{" "}
-                <span className="text-[var(--bo-fg)]">
-                  {formatTimestamp(configState.config?.updatedAt)}
-                </span>
-              </p>
-              {configState.config?.webhookBaseUrl ? (
-                <p>
-                  Webhook base URL:{" "}
-                  <span className="text-[var(--bo-fg)]">{configState.config.webhookBaseUrl}</span>
-                </p>
-              ) : null}
-              {configState.config?.botTokenPreview ? (
-                <p>
-                  Bot token:{" "}
-                  <span className="text-[var(--bo-fg)]">{configState.config.botTokenPreview}</span>
-                </p>
-              ) : null}
-              {configState.config?.webhookSecretTokenPreview ? (
-                <p>
-                  Secret token:{" "}
-                  <span className="text-[var(--bo-fg)]">
-                    {configState.config.webhookSecretTokenPreview}
-                  </span>
-                </p>
-              ) : null}
-            </>
-          ) : (
-            <p>Connect a bot to start collecting chat activity.</p>
-          )}
-        </div>
-      </div>
-
-      <FormContainer
-        title="Setup wizard"
-        eyebrow="Step-by-step"
-        description="Collect the bot credentials and register the webhook."
-      >
-        <WizardStepper steps={SETUP_STEPS} currentStep={currentStep} onStepChange={onStepChange} />
-      </FormContainer>
-    </section>
-  );
-}
-
-function TelegramAccountLinking() {
-  return (
-    <FormContainer
-      title="Account linking"
-      eyebrow="Automations"
-      description="Telegram linking now runs through the generic automations flow."
-    >
-      <div className="space-y-3 border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] p-3 text-sm text-[var(--bo-muted)]">
-        <p>
-          After configuring the bot, users should message it directly. Inbound Telegram messages are
-          forwarded into the automations fragment as canonical <code>message.received</code> events.
-        </p>
-        <p>
-          The docs app now ships with starter automation files under
-          <code> /workspace/automations </code> for the Telegram claim-linking flow:
-          <code> /start </code> issues a claim link and OTP confirmation finalizes the identity
-          binding.
-        </p>
-      </div>
-    </FormContainer>
-  );
-}
-
 export default function BackofficeOrganizationTelegramConfiguration() {
-  const { origin, scope, configState, configLoading, configError, setConfigError } =
+  const { publicBaseUrl, generatedWebhookSecretToken, scope, configState, setConfigError } =
     useOutletContext<TelegramLayoutContext>();
-  const [currentStep, setCurrentStep] = useState(0);
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const saving = navigation.state === "submitting";
   const [localError, setLocalError] = useState<string | null>(null);
   const [formState, setFormState] = useState<TelegramConfigForm>({
     botToken: "",
-    webhookSecretToken: "",
+    webhookSecretToken: generatedWebhookSecretToken,
     botUsername: "",
     apiBaseUrl: "",
-    webhookBaseUrl: origin,
   });
 
-  const webhookBaseUrl = formState.webhookBaseUrl.trim();
   const telegramScopeSegment = backofficeContextScopeSinglePathSegment(scope);
-  const webhookUrl = `${webhookBaseUrl.replace(/\/+$/, "")}/api/telegram/${telegramScopeSegment}/telegram/webhook`;
+  const webhookUrl = `${publicBaseUrl.replace(/\/+$/, "")}/api/telegram/${telegramScopeSegment}/telegram/webhook`;
   const apiBaseUrlError = validateOptionalUrl(formState.apiBaseUrl.trim(), "API base URL");
-  const webhookBaseUrlError = validateRequiredUrl(
-    formState.webhookBaseUrl.trim(),
-    "Webhook base URL",
-  );
   const botTokenPlaceholder = formState.botToken
     ? "<REDACTED_BOT_TOKEN>"
     : "<BOT_TOKEN_FROM_BOTFATHER>";
@@ -331,12 +168,10 @@ export default function BackofficeOrganizationTelegramConfiguration() {
       return;
     }
 
-    setCurrentStep(2);
     setFormState((prev) => ({
       ...prev,
       botUsername: prev.botUsername || configState.config?.botUsername || "",
       apiBaseUrl: prev.apiBaseUrl || configState.config?.apiBaseUrl || "",
-      webhookBaseUrl: prev.webhookBaseUrl || configState.config?.webhookBaseUrl || "",
     }));
   }, [configState]);
 
@@ -373,23 +208,8 @@ export default function BackofficeOrganizationTelegramConfiguration() {
     }
   };
 
-  const statusLabel = configState?.configured ? "Configured" : "Not configured";
-  const statusTone = configState?.configured
-    ? "border-[color:var(--bo-accent)] bg-[var(--bo-accent-bg)] text-[var(--bo-accent-fg)]"
-    : "border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] text-[var(--bo-muted)]";
-
   return (
     <div className="space-y-4">
-      <TelegramConnectionStatus
-        configState={configState}
-        configLoading={configLoading}
-        configError={configError}
-        statusLabel={statusLabel}
-        statusTone={statusTone}
-        currentStep={currentStep}
-        onStepChange={setCurrentStep}
-      />
-
       <FormContainer
         title="Telegram credentials"
         eyebrow="Configuration"
@@ -480,30 +300,6 @@ export default function BackofficeOrganizationTelegramConfiguration() {
               />
               {apiBaseUrlError ? <p className="text-xs text-red-500">{apiBaseUrlError}</p> : null}
             </FormField>
-
-            <FormField
-              label="Webhook base URL"
-              hint="Required. Use the public Backoffice origin or a tunnel URL."
-            >
-              <input
-                type="url"
-                name="webhookBaseUrl"
-                value={formState.webhookBaseUrl}
-                onChange={(event) => {
-                  setLocalError(null);
-                  setFormState((prev) => ({
-                    ...prev,
-                    webhookBaseUrl: event.target.value,
-                  }));
-                }}
-                placeholder={origin}
-                required
-                className="w-full border border-[color:var(--bo-border)] bg-[var(--bo-panel-2)] px-3 py-2 text-sm text-[var(--bo-fg)] placeholder:text-[var(--bo-muted-2)] focus:border-[color:var(--bo-accent)] focus:ring-2 focus:ring-[color:var(--bo-accent)]/20 focus:outline-none"
-              />
-              {webhookBaseUrlError ? (
-                <p className="text-xs text-red-500">{webhookBaseUrlError}</p>
-              ) : null}
-            </FormField>
           </div>
 
           <div className="space-y-3">
@@ -541,8 +337,6 @@ export default function BackofficeOrganizationTelegramConfiguration() {
           </button>
         </Form>
       </FormContainer>
-
-      <TelegramAccountLinking />
     </div>
   );
 }

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/organization-layout.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/organization-layout.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from "react";
 import { Outlet } from "react-router";
 
 import { findBackofficeMe } from "@/fragno/auth/auth-server";
+import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
 
 import { buildBackofficeLoginPath } from "../../auth-navigation";
 import { AutomationWorkspaceHeader } from "../../automations/shared";
 import { organizationIdFromScope, resolveIntegrationContext } from "../../integrations/scope";
 import type { Route } from "./+types/organization-layout";
 import { fetchTelegramConfig } from "./data";
+import { generateSecretToken } from "./secret-token";
 import {
   TelegramErrorBoundary,
   TelegramTabs,
@@ -31,11 +33,13 @@ export async function loader({ request, params, context, url }: Route.LoaderArgs
         ?.organization ?? null)
     : null;
 
+  const { runtime } = context.get(BackofficeWorkerContext);
   const { configState, configError } = await fetchTelegramConfig(context, integration.scope);
 
   return {
     ...integration,
-    origin: url.origin,
+    publicBaseUrl: runtime.config.docsPublicBaseUrl ?? "",
+    generatedWebhookSecretToken: generateSecretToken(),
     organization,
     configState,
     configError,
@@ -56,7 +60,8 @@ export default function BackofficeOrganizationTelegramLayout({
   matches,
 }: Route.ComponentProps) {
   const {
-    origin,
+    publicBaseUrl,
+    generatedWebhookSecretToken,
     organization,
     scope,
     uiScope,
@@ -100,7 +105,8 @@ export default function BackofficeOrganizationTelegramLayout({
       />
       <Outlet
         context={{
-          origin,
+          publicBaseUrl,
+          generatedWebhookSecretToken,
           organization,
           scope,
           scopeSegment,

--- a/apps/backoffice/app/routes/backoffice/connections/telegram/shared.tsx
+++ b/apps/backoffice/app/routes/backoffice/connections/telegram/shared.tsx
@@ -15,7 +15,6 @@ export type TelegramConfigState = {
   config?: {
     botUsername?: string | null;
     apiBaseUrl?: string | null;
-    webhookBaseUrl?: string | null;
     botTokenPreview?: string;
     webhookSecretTokenPreview?: string;
     createdAt?: string;
@@ -28,7 +27,8 @@ export type TelegramConfigState = {
 };
 
 export type TelegramLayoutContext = {
-  origin: string;
+  publicBaseUrl: string;
+  generatedWebhookSecretToken: string;
   organization: BackofficeOrganization | null;
   scope: BackofficeContextScope;
   scopeSegment: string;

--- a/apps/backoffice/content/static/skills/configuring-connections/SKILL.md
+++ b/apps/backoffice/content/static/skills/configuring-connections/SKILL.md
@@ -3,7 +3,7 @@ name: configuring-connections
 description:
   "Set up any Backoffice integration, connection, or named provider. Always use for setup requests
   such as \u2018help me set up Reson8\u2019, even when a provider-specific skill also applies; also
-  use when credentials or a public origin are missing, or connection status must be verified."
+  use when required configuration is missing or connection status must be verified."
 ---
 
 # Configuring Connections
@@ -39,14 +39,13 @@ Treat connection setup as a handshake: **inspect → collect → configure → v
    `step.do` calls so the user can finish the handshake through the rendered interface. When every
    required value was already supplied in the request, proceed directly without an input workflow.
 
-   Collect secrets, sender identities, account ids, bucket details, and public webhook origins
-   exactly as supplied. Use submitted values only as the configuration payload; keep secrets out of
-   labels, summaries, final output, and follow-up prose. **Complete when** a waiting workflow
-   displays controls for every missing required field, or every required field already has a
-   user-supplied or configured value.
+   Collect the missing values identified by the live schema exactly as supplied. Use submitted
+   values only as the configuration payload; keep secrets out of labels, summaries, final output,
+   and follow-up prose. **Complete when** a waiting workflow displays controls for every missing
+   required field, or every required field already has a user-supplied or configured value.
 
 3. Configure with a payload that matches the live schema, inside the setup workflow when step 2
-   created one. Supply `origin` only when setup instructions require a public Backoffice origin:
+   created one:
 
    ```js
    async () => {
@@ -55,7 +54,6 @@ Treat connection setup as a handshake: **inspect → collect → configure → v
        payload: {
          botToken: "...",
          webhookSecretToken: "...",
-         webhookBaseUrl: "https://public.example.com",
        },
      });
    };

--- a/apps/backoffice/content/static/skills/telegram-connection/SKILL.md
+++ b/apps/backoffice/content/static/skills/telegram-connection/SKILL.md
@@ -17,15 +17,23 @@ Configuration fields:
 
 - `botToken`: Telegram BotFather token. Secret.
 - `webhookSecretToken`: long random token Telegram includes with webhook requests. Secret.
-- `webhookBaseUrl`: public Backoffice origin or tunnel URL used to register the Telegram webhook.
 - `botUsername`: optional bot username, with or without `@`.
 - `apiBaseUrl`: optional Telegram API base URL override.
 
-Setup notes:
+Setup procedure:
 
-- Create the bot in BotFather before configuring the connection.
-- The webhook secret must match the token sent by Telegram on webhook requests.
-- The webhook base URL must be reachable by Telegram.
+1. Tell the user how to register a bot with Telegram:
+   - Open a chat with the verified `@BotFather` account in Telegram.
+   - Send `/newbot` and follow the prompts to choose a display name and a unique username.
+   - Copy the bot token BotFather returns and enter it in the Backoffice Telegram connection.
+   - Treat the bot token like a password and regenerate it in BotFather if it is exposed.
+2. Generate a cryptographically secure, high-entropy `webhookSecretToken` automatically. Do not ask
+   the user to invent or supply this secret.
+3. Save the connection configuration. Backoffice derives and registers the organisation-scoped
+   webhook URL with Telegram and supplies the generated secret as Telegram's `secret_token`.
+
+The stored secret must match the `X-Telegram-Bot-Api-Secret-Token` header Telegram sends to the
+webhook.
 
 # Telegram events
 

--- a/apps/backoffice/workers/lib/backoffice-fragment-durable-object.ts
+++ b/apps/backoffice/workers/lib/backoffice-fragment-durable-object.ts
@@ -139,8 +139,8 @@ export type BackofficeFragmentDurableObjectOptions<
    * Derives the runtime input from the full stored config.
    *
    * `source` is intentionally narrower than `stored`: it should contain only values that affect
-   * fragment runtime construction/migration. Example: Telegram stores `webhookBaseUrl`, `createdAt`,
-   * and `updatedAt`, but only `botToken`, `webhookSecretToken`, `botUsername`, and `apiBaseUrl` are
+   * fragment runtime construction/migration. Example: Telegram stores `scope`, `createdAt`, and
+   * `updatedAt`, but only `botToken`, `webhookSecretToken`, `botUsername`, and `apiBaseUrl` are
    * needed to create the Telegram fragment. Keeping those storage-only fields out of `source` avoids
    * unnecessary rebuilds/migrations when they change.
    *

--- a/apps/backoffice/workers/telegram.do.test.ts
+++ b/apps/backoffice/workers/telegram.do.test.ts
@@ -70,13 +70,13 @@ const VALID_PAYLOAD = {
   botToken: "123456:telegram-bot-token",
   webhookSecretToken: "telegram-webhook-secret",
   botUsername: "fragno_bot",
-  webhookBaseUrl: "https://example.com",
 };
 
 const createTelegramObject = (
   state: DurableObjectState,
   scope: Parameters<Telegram["init"]>[0] = { kind: "org", orgId: "acme" },
-) => new Telegram(state, {} as CloudflareEnv).init(scope);
+) =>
+  new Telegram(state, { DOCS_PUBLIC_BASE_URL: "https://example.com" } as CloudflareEnv).init(scope);
 
 const createState = (initialEntries?: Array<[string, unknown]>) => {
   const store = new Map<string, unknown>(initialEntries);
@@ -179,11 +179,21 @@ describe("Telegram Durable Object", () => {
     vi.unstubAllGlobals();
   });
 
+  test("requires the configured public origin before storing credentials", async () => {
+    const { state, store } = createState();
+    const telegram = new Telegram(state, {} as CloudflareEnv).init({ kind: "org", orgId: "acme" });
+
+    await expect(telegram.setAdminConfig(VALID_PAYLOAD)).rejects.toThrow(
+      "Telegram public origin is not configured.",
+    );
+    assert.isFalse(store.has(CONFIG_KEY));
+  });
+
   test("binds the fragment to the durable object's organization", async () => {
     const { state, store } = createState();
     const telegram = createTelegramObject(state);
 
-    await telegram.setAdminConfig(VALID_PAYLOAD, "https://example.com");
+    await telegram.setAdminConfig(VALID_PAYLOAD);
 
     expect(store.get(CONFIG_KEY)).toMatchObject({ scope: { kind: "org", orgId: "acme" } });
     expect(createTelegramServerMock).toHaveBeenCalledWith(
@@ -209,10 +219,10 @@ describe("Telegram Durable Object", () => {
     const { state } = createState();
     const telegram = createTelegramObject(state);
 
-    await telegram.setAdminConfig(
-      { ...VALID_PAYLOAD, apiBaseUrl: "https://telegram.example" },
-      "https://example.com",
-    );
+    await telegram.setAdminConfig({
+      ...VALID_PAYLOAD,
+      apiBaseUrl: "https://telegram.example",
+    });
 
     expect(fetch).toHaveBeenCalledWith(
       "https://telegram.example/bot123456:telegram-bot-token/setWebhook",
@@ -224,7 +234,7 @@ describe("Telegram Durable Object", () => {
     const { state, store } = createState();
     const telegram = createTelegramObject(state, { kind: "system" });
 
-    await telegram.setAdminConfig(VALID_PAYLOAD, "https://example.com");
+    await telegram.setAdminConfig(VALID_PAYLOAD);
 
     expect(store.get(CONFIG_KEY)).toMatchObject({ scope: { kind: "system" } });
     expect(fetch).toHaveBeenCalledWith(
@@ -239,7 +249,7 @@ describe("Telegram Durable Object", () => {
     const { state, store } = createState();
     const telegram = createTelegramObject(state, { kind: "user", userId: "user-1" });
 
-    await telegram.setAdminConfig(VALID_PAYLOAD, "https://example.com");
+    await telegram.setAdminConfig(VALID_PAYLOAD);
 
     expect(store.get(CONFIG_KEY)).toMatchObject({ scope: { kind: "user", userId: "user-1" } });
     expect(fetch).toHaveBeenCalledWith(
@@ -265,7 +275,7 @@ describe("Telegram Durable Object", () => {
     const { state } = createState();
     const telegram = createTelegramObject(state);
 
-    await telegram.setAdminConfig(VALID_PAYLOAD, "https://example.com");
+    await telegram.setAdminConfig(VALID_PAYLOAD);
 
     const response = await telegram.fetch(
       new Request("https://example.com/api/telegram/webhook?scope=org:other-org"),
@@ -304,7 +314,7 @@ describe("Telegram Durable Object", () => {
     const { state } = createState();
     const telegram = createTelegramObject(state);
 
-    await telegram.setAdminConfig(VALID_PAYLOAD, "https://example.com");
+    await telegram.setAdminConfig(VALID_PAYLOAD);
 
     await expect(telegram.getAutomationFile({ fileId: "telegram-file-1" })).resolves.toEqual({
       fileId: "telegram-file-1",
@@ -318,7 +328,7 @@ describe("Telegram Durable Object", () => {
     const { state } = createState();
     const telegram = createTelegramObject(state);
 
-    await telegram.setAdminConfig(VALID_PAYLOAD, "https://example.com");
+    await telegram.setAdminConfig(VALID_PAYLOAD);
 
     const response = await telegram.downloadAutomationFile({ fileId: "telegram-file-1" });
     expect(response).toBeInstanceOf(Response);

--- a/apps/backoffice/workers/telegram.do.ts
+++ b/apps/backoffice/workers/telegram.do.ts
@@ -32,9 +32,12 @@ import {
   type BackofficeFragmentDurableObject,
 } from "./lib/backoffice-fragment-durable-object";
 
+type TelegramObjectEnv = {
+  DOCS_PUBLIC_BASE_URL?: string;
+};
+
 type StoredTelegramConfig = TelegramConfig & {
   scope: BackofficeContextScope;
-  webhookBaseUrl?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -44,7 +47,6 @@ export type TelegramAdminConfigResponse = {
   config?: {
     botUsername?: string | null;
     apiBaseUrl?: string | null;
-    webhookBaseUrl?: string | null;
     botTokenPreview?: string;
     webhookSecretTokenPreview?: string;
     createdAt?: string;
@@ -74,6 +76,14 @@ type TelegramAdminApi = {
 };
 
 const DEFAULT_TELEGRAM_API_BASE_URL = "https://api.telegram.org";
+
+function readTelegramPublicOrigin(env: TelegramObjectEnv) {
+  const origin = env.DOCS_PUBLIC_BASE_URL?.trim();
+  if (!origin) {
+    throw new Error("Telegram public origin is not configured.");
+  }
+  return origin;
+}
 
 const maskSecret = (value: string) => {
   if (!value) {
@@ -136,7 +146,6 @@ function buildConfigResponse(config: StoredTelegramConfig | null): TelegramAdmin
     config: {
       botUsername: config.botUsername ?? null,
       apiBaseUrl: config.apiBaseUrl ?? null,
-      webhookBaseUrl: config.webhookBaseUrl ?? null,
       botTokenPreview: maskSecret(config.botToken),
       webhookSecretTokenPreview: maskSecret(config.webhookSecretToken),
       createdAt: config.createdAt,
@@ -145,9 +154,8 @@ function buildConfigResponse(config: StoredTelegramConfig | null): TelegramAdmin
   };
 }
 
-const resolveWebhookUrl = (origin: string, scope: BackofficeContextScope, baseUrl?: string) => {
-  const resolvedOrigin = baseUrl ?? origin;
-  const trimmed = resolvedOrigin.replace(/\/+$/, "");
+const resolveWebhookUrl = (origin: string, scope: BackofficeContextScope) => {
+  const trimmed = origin.replace(/\/+$/, "");
   return `${trimmed}/api/telegram/${backofficeContextScopeSinglePathSegment(scope)}/telegram/webhook`;
 };
 
@@ -266,6 +274,7 @@ const createFetchTelegramAdminApi = (): TelegramAdminApi => ({
 });
 
 export class InMemoryTelegramObject extends RpcTarget implements TelegramObject {
+  readonly #env: TelegramObjectEnv;
   readonly #state: BackofficeObjectState;
   readonly #runtime: BackofficeRuntimeServices;
   readonly #api?: TelegramApi;
@@ -279,16 +288,19 @@ export class InMemoryTelegramObject extends RpcTarget implements TelegramObject 
 
   constructor({
     state,
+    env,
     runtime,
     api,
     adminApi,
   }: {
     state: BackofficeObjectState;
+    env?: TelegramObjectEnv;
     runtime: BackofficeRuntimeServices;
     api?: TelegramApi;
     adminApi?: TelegramAdminApi;
   }) {
     super();
+    this.#env = env ?? {};
     this.#state = state;
     this.#runtime = runtime;
     this.#api = api;
@@ -490,9 +502,10 @@ export class InMemoryTelegramObject extends RpcTarget implements TelegramObject 
     return { configured: false };
   }
 
-  async setAdminConfig(payload: unknown, origin: string): Promise<TelegramAdminConfigResponse> {
+  async setAdminConfig(payload: unknown): Promise<TelegramAdminConfigResponse> {
     const config = setAdminConfigInputSchema.parse(payload);
     const scope = this.#requireScope();
+    const webhookUrl = resolveWebhookUrl(readTelegramPublicOrigin(this.#env), scope);
 
     const existing = await this.#host.loadStored();
     this.#host.assertSameScope(existing, scope);
@@ -502,7 +515,6 @@ export class InMemoryTelegramObject extends RpcTarget implements TelegramObject 
     const stored: StoredTelegramConfig = {
       ...config,
       scope,
-      webhookBaseUrl: config.webhookBaseUrl,
       createdAt,
       updatedAt: now,
     };
@@ -521,7 +533,6 @@ export class InMemoryTelegramObject extends RpcTarget implements TelegramObject 
       throw new Error("Failed to migrate Telegram schema.");
     }
 
-    const webhookUrl = resolveWebhookUrl(origin, scope, stored.webhookBaseUrl);
     const webhookResult = await (this.#adminApi ?? createFetchTelegramAdminApi()).setWebhook({
       botToken: stored.botToken,
       apiBaseUrl: stored.apiBaseUrl,
@@ -535,7 +546,6 @@ export class InMemoryTelegramObject extends RpcTarget implements TelegramObject 
       config: {
         botUsername: stored.botUsername ?? null,
         apiBaseUrl: stored.apiBaseUrl ?? null,
-        webhookBaseUrl: stored.webhookBaseUrl ?? null,
         botTokenPreview: maskSecret(stored.botToken),
         webhookSecretTokenPreview: maskSecret(stored.webhookSecretToken),
         createdAt: stored.createdAt,
@@ -563,6 +573,7 @@ export class Telegram extends DurableObject<CloudflareEnv> {
     super(state, env);
     this.#object = new InMemoryTelegramObject({
       state,
+      env,
       runtime: createCloudflareDurableObjectRuntimeServices(env, state),
     });
   }


### PR DESCRIPTION
Generate webhook secrets automatically and derive Telegram webhook URLs
from DOCS_PUBLIC_BASE_URL. Remove the per-connection webhook base URL
across the UI, capability contract, runtime tools, scenarios, tests, and
agent guidance. Pass runtime environment configuration into in-memory
Telegram objects to match production behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Telegram webhook URLs are now generated automatically from the configured public URL.
  - Webhook secrets are generated securely and used to validate incoming requests.
  - Telegram setup is simpler, with no manual webhook URL entry required.
  - Configuration now clearly reports when the required public URL is unavailable.

- **Documentation**
  - Updated Telegram setup guidance, including BotFather registration, webhook security, and secret-header requirements.
  - Updated connection configuration examples to reflect the streamlined setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->