### PR TITLE
feat(backoffice): enable production account provisioning

### DIFF
--- a/apps/backoffice/.dev.vars.example
+++ b/apps/backoffice/.dev.vars.example
@@ -8,6 +8,10 @@ GITHUB_CLIENT_SECRET=
 # For auth access-token cookies. Set a strong secret in production.
 AUTH_ACCESS_TOKEN_SECRET=dev-auth-access-token-secret-replace-me
 
+# Allows POST /api/admin/grant to promote an existing verified account.
+# Leave unset to disable administrator granting entirely.
+AUTH_ADMIN_GRANT_TOKEN=
+
 # Require Auth email verification and deliver challenges through the singleton Resend connection.
 # DOCS_PUBLIC_BASE_URL must be an absolute HTTP(S) URL when this is true.
 AUTH_EMAIL_VERIFICATION_ENABLED=false

--- a/apps/backoffice/app/backoffice-runtime/in-memory-runtime-env.ts
+++ b/apps/backoffice/app/backoffice-runtime/in-memory-runtime-env.ts
@@ -12,6 +12,7 @@ export type InMemoryBackofficeRuntimeEnv = {
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;
   AUTH_ACCESS_TOKEN_SECRET?: string;
+  AUTH_ADMIN_GRANT_TOKEN?: string;
   AUTH_EMAIL_VERIFICATION_ENABLED?: string;
   GITHUB_APP_ID?: string;
   GITHUB_APP_SLUG?: string;
@@ -103,6 +104,7 @@ export const defaultInMemoryBackofficeRuntimeEnv = (): InMemoryBackofficeRuntime
   GITHUB_CLIENT_ID: "in-memory-github-client-id",
   GITHUB_CLIENT_SECRET: "in-memory-github-client-secret",
   AUTH_ACCESS_TOKEN_SECRET: "in-memory-auth-access-token-secret",
+  AUTH_ADMIN_GRANT_TOKEN: "in-memory-admin-grant-token",
   AUTH_EMAIL_VERIFICATION_ENABLED: "false",
   GITHUB_APP_ID: "1",
   GITHUB_APP_SLUG: "in-memory-github-app",

--- a/apps/backoffice/app/backoffice-runtime/object-registry.ts
+++ b/apps/backoffice/app/backoffice-runtime/object-registry.ts
@@ -155,6 +155,12 @@ export type ScenarioAuthFixture = {
   removedMembers?: ReadonlyArray<{ organizationId: string; userId: string }>;
 };
 
+export type GrantBackofficeAdminResult =
+  | { status: "granted"; userId: string }
+  | { status: "already_admin"; userId: string }
+  | { status: "user_not_found" }
+  | { status: "user_not_active" };
+
 export type AuthObject = FetchObject &
   AlarmableObject &
   DurableHookObject & {
@@ -182,6 +188,8 @@ export type AuthObject = FetchObject &
       userId: string;
       organizationId?: string;
     }): Promise<UserAuthorityFacts>;
+    /** Grants global administrator access to an existing, verified account. */
+    grantBackofficeAdminByEmail(input: { email: string }): Promise<GrantBackofficeAdminResult>;
     getAllOrganizations(): Promise<Organization[]>;
     getOrganizationBySlug(slug: string): Promise<Pick<Organization, "id" | "slug"> | null>;
     hasOrganizationMember(input: { organizationId: string; userId: string }): Promise<boolean>;

--- a/apps/backoffice/app/layouts/backoffice-layout.tsx
+++ b/apps/backoffice/app/layouts/backoffice-layout.tsx
@@ -29,10 +29,6 @@ export default function BackofficeLayoutRoute(props: Route.ComponentProps) {
 }
 
 export async function loader({ request, params, context, url }: Route.LoaderArgs) {
-  if (import.meta.env.MODE !== "development") {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const returnTo = `${url.pathname}${url.search}`;
   const jwtMe = await getBackofficeMe(request, context);
   if (jwtMe.status !== "authenticated") {

--- a/apps/backoffice/app/routes/backoffice/auth-bootstrap.tsx
+++ b/apps/backoffice/app/routes/backoffice/auth-bootstrap.tsx
@@ -29,10 +29,6 @@ type BackofficeBootstrapLoaderData = {
 };
 
 export async function loader({ request, context, url }: Route.LoaderArgs) {
-  if (import.meta.env.MODE !== "development") {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const returnTo = readBackofficeReturnTo(url);
   const organizationId = readBackofficeOrganizationSwitchId(url);
   const jwtMe = await getBackofficeMe(request, context);

--- a/apps/backoffice/app/routes/backoffice/login.tsx
+++ b/apps/backoffice/app/routes/backoffice/login.tsx
@@ -124,10 +124,6 @@ async function exchangeSignedInSessionForBackofficeJwt(
 }
 
 export async function loader({ request, context, url }: Route.LoaderArgs) {
-  if (import.meta.env.MODE !== "development") {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const returnTo = readBackofficeReturnTo(url);
   if (!requiresBetterAuthBrowserSession(returnTo)) {
     const jwtMe = await getBackofficeMe(request, context);
@@ -144,10 +140,6 @@ export async function loader({ request, context, url }: Route.LoaderArgs) {
 }
 
 export async function action({ request, context, url }: Route.ActionArgs) {
-  if (import.meta.env.MODE !== "development") {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const formData = await request.formData();
   const returnTo = readBackofficeReturnTo(url);
   const input = loginActionInputSchema.safeParse(Object.fromEntries(formData));

--- a/apps/backoffice/app/routes/backoffice/sign-up.test.ts
+++ b/apps/backoffice/app/routes/backoffice/sign-up.test.ts
@@ -40,6 +40,19 @@ describe("backoffice sign-up route", () => {
     vi.unstubAllEnvs();
   });
 
+  it("allows registration in production", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.mocked(callBetterAuth).mockResolvedValue(
+      Response.json({ user: { id: "user_123", email: "new-user@example.com" } }),
+    );
+
+    await expect(action(createActionArgs(validSignUpForm))).resolves.toEqual({
+      state: "verification_required",
+      email: "new-user@example.com",
+      resend: "available",
+    });
+  });
+
   it("shows verification-required when Better Auth does not issue a session", async () => {
     vi.stubEnv("MODE", "development");
     vi.mocked(callBetterAuth).mockResolvedValue(

--- a/apps/backoffice/app/routes/backoffice/sign-up.tsx
+++ b/apps/backoffice/app/routes/backoffice/sign-up.tsx
@@ -48,10 +48,6 @@ const signUpActionInputSchema = z.discriminatedUnion("intent", [
 ]);
 
 export async function loader({ request, context, url }: Route.LoaderArgs) {
-  if (import.meta.env.MODE !== "development") {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const returnTo = readBackofficeReturnTo(url);
   const me = await getBackofficeMe(request, context);
   if (me.status === "authenticated") {
@@ -62,10 +58,6 @@ export async function loader({ request, context, url }: Route.LoaderArgs) {
 }
 
 export async function action({ request, context, url }: Route.ActionArgs) {
-  if (import.meta.env.MODE !== "development") {
-    throw new Response("Not Found", { status: 404 });
-  }
-
   const formData = await request.formData();
   const returnTo = readBackofficeReturnTo(url);
   const input = signUpActionInputSchema.safeParse(Object.fromEntries(formData));
@@ -136,7 +128,7 @@ export async function action({ request, context, url }: Route.ActionArgs) {
 export function meta() {
   return [
     { title: "Fragno Backoffice Sign Up" },
-    { name: "description", content: "Create a backoffice account for local development." },
+    { name: "description", content: "Create a Fragno Backoffice account." },
   ];
 }
 
@@ -162,10 +154,10 @@ export default function BackofficeSignUp() {
             Fragno Backoffice
           </p>
           <h1 className="text-3xl leading-tight font-semibold text-[var(--bo-fg)] md:text-4xl">
-            Create a backoffice account for local development access.
+            Create a Fragno Backoffice account.
           </h1>
           <p className="text-sm text-[var(--bo-muted)]">
-            Set up an email and password to enter the backoffice and configure fragments locally.
+            Register your email to enter the backoffice and configure fragments.
           </p>
           <div className="flex flex-wrap gap-2">
             <Link

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "auth:migration:generate": "auth generate --config scripts/better-auth-cli.ts --output workers/auth/migrations/better-auth.sql --yes",
+    "admin:grant": "bash scripts/grant-admin.sh",
     "build": "react-router build",
     "deploy": "pnpm run build && wrangler deploy",
     "dev": "react-router dev",

--- a/apps/backoffice/scripts/grant-admin.sh
+++ b/apps/backoffice/scripts/grant-admin.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKOFFICE_URL="${BACKOFFICE_URL:-https://backoffice.rejot.dev}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEV_VARS_FILE="${BACKOFFICE_DEV_VARS_FILE:-${SCRIPT_DIR}/../.dev.vars}"
+LOCAL_PORT=5173
+email=""
+
+usage() {
+  echo "Usage: pnpm --filter @fragno-apps/backoffice-rr admin:grant -- [--local] [--port PORT] EMAIL" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --local)
+      BACKOFFICE_URL="http://localhost:${LOCAL_PORT}"
+      shift
+      ;;
+    -p|--port)
+      if [[ $# -lt 2 || ! "$2" =~ ^[0-9]+$ ]]; then
+        echo "--port requires a numeric port." >&2
+        usage
+        exit 1
+      fi
+      LOCAL_PORT="$2"
+      BACKOFFICE_URL="http://localhost:${LOCAL_PORT}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -* )
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -n "$email" ]]; then
+        echo "Only one email address may be provided." >&2
+        usage
+        exit 1
+      fi
+      email="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$email" ]]; then
+  usage
+  exit 1
+fi
+
+token="${AUTH_ADMIN_GRANT_TOKEN:-}"
+
+if [[ -z "$token" && -f "$DEV_VARS_FILE" ]]; then
+  token_line="$(grep -m 1 '^AUTH_ADMIN_GRANT_TOKEN=' "$DEV_VARS_FILE" || true)"
+  token="${token_line#AUTH_ADMIN_GRANT_TOKEN=}"
+fi
+
+if [[ -z "$token" ]]; then
+  echo "AUTH_ADMIN_GRANT_TOKEN is not set in the environment or $DEV_VARS_FILE." >&2
+  exit 1
+fi
+
+body="$(EMAIL="$email" node -e '
+  process.stdout.write(JSON.stringify({ email: process.env.EMAIL }));
+')"
+response_file="$(mktemp)"
+trap 'rm -f "$response_file"' EXIT
+
+status="$(curl \
+  --silent \
+  --show-error \
+  --output "$response_file" \
+  --write-out "%{http_code}" \
+  --header "Authorization: Bearer $token" \
+  --header "Content-Type: application/json" \
+  --request POST \
+  --data "$body" \
+  "${BACKOFFICE_URL%/}/api/admin/grant")"
+
+if [[ "$status" != "200" ]]; then
+  echo "Failed to grant Backoffice administrator access: HTTP $status" >&2
+  cat "$response_file" >&2
+  exit 1
+fi
+
+result="$(node - "$response_file" <<'NODE'
+const fs = require("node:fs");
+const response = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+if (response.status === "granted") {
+  process.stdout.write(`Granted administrator access to ${response.userId}.`);
+} else if (response.status === "already_admin") {
+  process.stdout.write(`Account ${response.userId} is already an administrator.`);
+} else {
+  process.stderr.write(`Administrator access was not granted: ${response.status}.\n`);
+  process.exit(1);
+}
+NODE
+)"
+
+echo "$result"

--- a/apps/backoffice/secrets.d.ts
+++ b/apps/backoffice/secrets.d.ts
@@ -7,6 +7,7 @@ interface CloudflareEnv {
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
   AUTH_ACCESS_TOKEN_SECRET?: string;
+  AUTH_ADMIN_GRANT_TOKEN?: string;
   AUTH_EMAIL_VERIFICATION_ENABLED?: string;
   GITHUB_APP_ID: string;
   GITHUB_APP_SLUG: string;

--- a/apps/backoffice/vite.config.ts
+++ b/apps/backoffice/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig(({ mode }) => {
         }
       : undefined,
     preview: {
-      allowedHosts: [".trycloudflare.com"],
+      allowedHosts: [".trycloudflare.com", "local-wilco.recivo.email"],
     },
     server: {
       hmr: false,

--- a/apps/backoffice/workers/app.ts
+++ b/apps/backoffice/workers/app.ts
@@ -8,6 +8,7 @@ import { BackofficeWorkerContext } from "../app/worker-runtime/router-context";
 import { Api } from "./api.do";
 import { Auth } from "./auth.do";
 import { Automations } from "./automations.do";
+import { handleBackofficeAdminGrantRequest } from "./backoffice-admin-grant";
 import { Billing } from "./billing.do";
 import { Cloudflare } from "./cloudflare.do";
 import { GitHubWebhookRouter } from "./github-webhook-router.do";
@@ -63,6 +64,13 @@ System.Settings.Set({ useAcceleration: false });
 export default {
   async fetch(request, env, ctx) {
     const runtime = createCloudflareBackofficeRuntimeServices(env);
+    if (new URL(request.url).pathname === "/api/admin/grant") {
+      return await handleBackofficeAdminGrantRequest(request, {
+        configuredToken: env.AUTH_ADMIN_GRANT_TOKEN,
+        auth: runtime.objects.auth.singleton(),
+      });
+    }
+
     const context = new RouterContextProvider();
     context.set(BackofficeWorkerContext, {
       runtime,

--- a/apps/backoffice/workers/auth.do.test.ts
+++ b/apps/backoffice/workers/auth.do.test.ts
@@ -80,7 +80,7 @@ afterEach(async () => {
 });
 
 describe("Auth Durable Object account creation policy", () => {
-  test("rejects rejot.dev account creation outside development", async () => {
+  test("creates rejot.dev accounts as users outside development", async () => {
     vi.stubEnv("MODE", "production");
     const runtime = await createInMemoryBackofficeRuntime();
     runtimes.push(runtime);
@@ -97,7 +97,10 @@ describe("Auth Durable Object account creation policy", () => {
       }),
     );
 
-    assert(!response.ok);
+    assert(response.ok);
+    expect(await response.json()).toMatchObject({
+      user: { role: "user" },
+    });
   });
 
   test("creates rejot.dev administrators in development", async () => {
@@ -121,6 +124,47 @@ describe("Auth Durable Object account creation policy", () => {
     expect(await response.json()).toMatchObject({
       user: { role: "admin" },
     });
+  });
+});
+
+describe("Auth Durable Object administrator granting", () => {
+  test("promotes an existing verified account and remains idempotent", async () => {
+    const runtime = await createInMemoryBackofficeRuntime();
+    runtimes.push(runtime);
+    const auth = runtime.objects.auth.singleton();
+    await auth.applyScenarioFixture({
+      users: [
+        {
+          id: "user-1",
+          email: "admin@rejot.dev",
+          role: "user",
+          status: "active",
+        },
+      ],
+    });
+
+    await expect(auth.grantBackofficeAdminByEmail({ email: "ADMIN@rejot.dev" })).resolves.toEqual({
+      status: "granted",
+      userId: "user-1",
+    });
+    await expect(auth.grantBackofficeAdminByEmail({ email: "admin@rejot.dev" })).resolves.toEqual({
+      status: "already_admin",
+      userId: "user-1",
+    });
+    await expect(auth.getUserAuthorityFacts({ userId: "user-1" })).resolves.toMatchObject({
+      role: "admin",
+    });
+  });
+
+  test("reports a missing rejot.dev account", async () => {
+    const runtime = await createInMemoryBackofficeRuntime();
+    runtimes.push(runtime);
+
+    await expect(
+      runtime.objects.auth.singleton().grantBackofficeAdminByEmail({
+        email: "missing@rejot.dev",
+      }),
+    ).resolves.toEqual({ status: "user_not_found" });
   });
 });
 

--- a/apps/backoffice/workers/auth.do.ts
+++ b/apps/backoffice/workers/auth.do.ts
@@ -7,7 +7,11 @@ import { Kysely } from "kysely";
 import { extractW3CRequestPropagationContext } from "@fragno-dev/core";
 
 import type { BackofficeContextScope } from "@/backoffice-runtime/context";
-import type { AuthObject, ScenarioAuthFixture } from "@/backoffice-runtime/object-registry";
+import type {
+  AuthObject,
+  GrantBackofficeAdminResult,
+  ScenarioAuthFixture,
+} from "@/backoffice-runtime/object-registry";
 import {
   createCloudflareDurableObjectRuntimeServices,
   type BackofficeRuntimeServices,
@@ -183,6 +187,7 @@ const toIsoString = (date: Date | string): string =>
   date instanceof Date ? date.toISOString() : new Date(date).toISOString();
 const normalizeRole = (role: string | null | undefined): Role =>
   role?.split(",").includes("admin") ? "admin" : "user";
+const isRejotEmail = (email: string): boolean => email.trim().toLowerCase().endsWith("@rejot.dev");
 const normalizeBoolean = (value: boolean | number | null | undefined): boolean =>
   value === true || value === 1;
 
@@ -862,18 +867,15 @@ export class InMemoryAuthObject implements AuthObject {
       databaseHooks: {
         user: {
           create: {
-            before: async (user: Record<string, unknown> & { email: string }) => {
-              const isRejotAccount = user.email.trim().toLowerCase().endsWith("@rejot.dev");
-              if (isRejotAccount && import.meta.env.MODE !== "development") {
-                throw new Error("Rejot accounts can only be created in development.");
-              }
-              return {
-                data: {
-                  ...user,
-                  role: isRejotAccount ? "admin" : "user",
-                },
-              };
-            },
+            before: async (user: Record<string, unknown> & { email: string }) => ({
+              data: {
+                ...user,
+                role:
+                  isRejotEmail(user.email) && import.meta.env.MODE === "development"
+                    ? "admin"
+                    : "user",
+              },
+            }),
           },
         },
       },
@@ -1156,6 +1158,31 @@ export class InMemoryAuthObject implements AuthObject {
       input,
       resolveBackofficeScopeTokenGrant,
     );
+  }
+
+  async grantBackofficeAdminByEmail(input: { email: string }): Promise<GrantBackofficeAdminResult> {
+    const { adapter } = await this.#authContext();
+    const email = input.email.trim().toLowerCase();
+    const user = await adapter.findOne<StoreUser>({
+      model: "user",
+      where: [{ field: "email", value: email }],
+    });
+    if (!user) {
+      return { status: "user_not_found" };
+    }
+    if (normalizeBoolean(user.banned)) {
+      return { status: "user_not_active" };
+    }
+    if (normalizeRole(user.role) === "admin") {
+      return { status: "already_admin", userId: user.id };
+    }
+
+    await adapter.update<StoreUser>({
+      model: "user",
+      where: [{ field: "id", value: user.id }],
+      update: { role: "admin", updatedAt: new Date() },
+    });
+    return { status: "granted", userId: user.id };
   }
 
   async getUserAuthorityFacts(input: {
@@ -1455,6 +1482,10 @@ export class Auth extends DurableObject<CloudflareEnv> implements AuthObject {
 
   async getUserAuthorityFacts(input: { userId: string; organizationId?: string }) {
     return await this.#object.getUserAuthorityFacts(input);
+  }
+
+  async grantBackofficeAdminByEmail(input: { email: string }) {
+    return await this.#object.grantBackofficeAdminByEmail(input);
   }
 
   async getAllOrganizations() {

--- a/apps/backoffice/workers/backoffice-admin-grant.test.ts
+++ b/apps/backoffice/workers/backoffice-admin-grant.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, assert } from "vitest";
+
+import { handleBackofficeAdminGrantRequest } from "./backoffice-admin-grant";
+
+const createRequest = (token = "grant-secret", body: unknown = { email: "Admin@Rejot.dev" }) =>
+  new Request("https://backoffice.example.com/api/admin/grant", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+describe("Backoffice administrator grant endpoint", () => {
+  it("is unavailable when the grant token is not configured", async () => {
+    const grantBackofficeAdminByEmail = vi.fn();
+
+    const response = await handleBackofficeAdminGrantRequest(createRequest(), {
+      configuredToken: undefined,
+      auth: { grantBackofficeAdminByEmail },
+    });
+
+    assert(response.status === 404);
+    expect(grantBackofficeAdminByEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid grant token", async () => {
+    const grantBackofficeAdminByEmail = vi.fn();
+
+    const response = await handleBackofficeAdminGrantRequest(createRequest("wrong-secret"), {
+      configuredToken: "grant-secret",
+      auth: { grantBackofficeAdminByEmail },
+    });
+
+    assert(response.status === 401);
+    expect(grantBackofficeAdminByEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects administrator access outside rejot.dev", async () => {
+    const grantBackofficeAdminByEmail = vi.fn();
+
+    const response = await handleBackofficeAdminGrantRequest(
+      createRequest("grant-secret", { email: "admin@example.com" }),
+      {
+        configuredToken: "grant-secret",
+        auth: { grantBackofficeAdminByEmail },
+      },
+    );
+
+    assert(response.status === 400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Administrator access requires a @rejot.dev email address.",
+    });
+    expect(grantBackofficeAdminByEmail).not.toHaveBeenCalled();
+  });
+
+  it("grants administrator access to the normalized email", async () => {
+    const grantBackofficeAdminByEmail = vi
+      .fn()
+      .mockResolvedValue({ status: "granted", userId: "user-1" });
+
+    const response = await handleBackofficeAdminGrantRequest(createRequest(), {
+      configuredToken: "grant-secret",
+      auth: { grantBackofficeAdminByEmail },
+    });
+
+    assert(response.status === 200);
+    await expect(response.json()).resolves.toEqual({ status: "granted", userId: "user-1" });
+    expect(grantBackofficeAdminByEmail).toHaveBeenCalledWith({ email: "admin@rejot.dev" });
+  });
+
+  it("rejects invalid input before calling Auth", async () => {
+    const grantBackofficeAdminByEmail = vi.fn();
+
+    const response = await handleBackofficeAdminGrantRequest(createRequest("grant-secret", {}), {
+      configuredToken: "grant-secret",
+      auth: { grantBackofficeAdminByEmail },
+    });
+
+    assert(response.status === 400);
+    expect(grantBackofficeAdminByEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backoffice/workers/backoffice-admin-grant.ts
+++ b/apps/backoffice/workers/backoffice-admin-grant.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+import type { AuthObject } from "@/backoffice-runtime/object-registry";
+
+const grantBackofficeAdminInputSchema = z.object({
+  email: z.string().trim().toLowerCase().pipe(z.email().max(191)),
+});
+
+async function adminGrantTokensMatch(providedToken: string, configuredToken: string) {
+  const encoder = new TextEncoder();
+  const [providedDigest, configuredDigest] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(providedToken)),
+    crypto.subtle.digest("SHA-256", encoder.encode(configuredToken)),
+  ]);
+  const providedBytes = new Uint8Array(providedDigest);
+  const configuredBytes = new Uint8Array(configuredDigest);
+  let difference = 0;
+  for (let index = 0; index < providedBytes.length; index += 1) {
+    difference |= providedBytes[index] ^ configuredBytes[index];
+  }
+  return difference === 0;
+}
+
+/** Handles the secret-token production operation for granting global administrator access. */
+export async function handleBackofficeAdminGrantRequest(
+  request: Request,
+  input: {
+    configuredToken: string | undefined;
+    auth: Pick<AuthObject, "grantBackofficeAdminByEmail">;
+  },
+): Promise<Response> {
+  if (!input.configuredToken) {
+    return Response.json({ error: "Admin granting is not configured." }, { status: 404 });
+  }
+  if (request.method !== "POST") {
+    return new Response(null, { status: 405, headers: { allow: "POST" } });
+  }
+
+  const authorization = request.headers.get("authorization");
+  const providedToken = authorization?.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length)
+    : "";
+  if (!providedToken || !(await adminGrantTokensMatch(providedToken, input.configuredToken))) {
+    return Response.json({ error: "Admin grant token is invalid." }, { status: 401 });
+  }
+
+  const parsedInput = grantBackofficeAdminInputSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsedInput.success) {
+    return Response.json({ error: "A valid email address is required." }, { status: 400 });
+  }
+  if (!parsedInput.data.email.endsWith("@rejot.dev")) {
+    return Response.json(
+      { error: "Administrator access requires a @rejot.dev email address." },
+      { status: 400 },
+    );
+  }
+
+  const result = await input.auth.grantBackofficeAdminByEmail({ email: parsedInput.data.email });
+  return Response.json(result);
+}


### PR DESCRIPTION
Enable login, registration, auth bootstrap, and authenticated Backoffice
routes in production while keeping development routes private.

Add a token-protected administrator grant endpoint restricted to active
@rejot.dev accounts, plus a script for production and local targets.
