### PR TITLE
feat(backoffice): add scoped file transfer clients

### DIFF
--- a/.pi/extensions/backoffice/index.ts
+++ b/.pi/extensions/backoffice/index.ts
@@ -1,27 +1,55 @@
+import { createReadStream } from "node:fs";
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { dirname, posix, resolve } from "node:path";
+import { Readable } from "node:stream";
+
 import { Type } from "typebox";
 
 import {
   backofficeErrorMessage,
   connectToBackoffice,
+  downloadBackofficeFile,
   executeBackofficeCodemode,
   fetchBackofficeSystemPrompt,
   findBackofficeServers,
   parseBackofficeScope,
+  uploadBackofficeWorkspaceFile,
   type BackofficeScope,
 } from "@rejot-dev/backoffice-local";
 
 import {
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createFindToolDefinition,
+  createGrepToolDefinition,
+  createLsToolDefinition,
+  createReadToolDefinition,
+  createWriteToolDefinition,
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
   formatSize,
   getMarkdownTheme,
   truncateHead,
+  withFileMutationQueue,
 } from "@earendil-works/pi-coding-agent";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Text } from "@earendil-works/pi-tui";
 
 const BACKOFFICE_SESSION_ENTRY = "backoffice-session";
-const BACKOFFICE_TOOL_NAMES = ["read", "search", "execCodeMode"];
+const BACKOFFICE_TOOL_NAMES = [
+  "read",
+  "search",
+  "execCodeMode",
+  "upload",
+  "download",
+  "localRead",
+  "localBash",
+  "localEdit",
+  "localWrite",
+  "localGrep",
+  "localFind",
+  "localLs",
+];
 const CLOUD_BACKOFFICE_URL = "https://backoffice.rejot.dev";
 
 type BackofficeSession = {
@@ -129,6 +157,18 @@ function boundBackofficeToolOutput(
   };
 }
 
+function backofficeWorkspaceFileKey(destinationPath: string): string {
+  if (destinationPath.startsWith("/") && !destinationPath.startsWith("/workspace/")) {
+    throw new Error("Upload destination must be a file path inside /workspace.");
+  }
+  const normalized = posix.normalize(destinationPath.replace(/^\/workspace\//, ""));
+  const fileKey = normalized.replace(/^\/+/, "");
+  if (!fileKey || fileKey === "." || fileKey.startsWith("../")) {
+    throw new Error("Upload destination must be a file path inside /workspace.");
+  }
+  return fileKey;
+}
+
 function findSearchContinuation(result: unknown): Record<string, unknown> | null {
   if (!result || typeof result !== "object") {
     return null;
@@ -165,15 +205,65 @@ async function executeBackofficeCode(
   );
 }
 
-/** Registers `/backoffice` and Backoffice's read, search, and execCodeMode tools. */
+/** Registers `/backoffice` and tools for Backoffice state, local files, search, and codemode. */
 export default function registerBackofficeExtension(pi: ExtensionAPI) {
   let toolsRegistered = false;
 
-  function registerBackofficeTools() {
+  function registerBackofficeTools(cwd: string) {
     if (toolsRegistered) {
       return;
     }
     toolsRegistered = true;
+
+    const localRead = createReadToolDefinition(cwd);
+    pi.registerTool({
+      ...localRead,
+      name: "localRead",
+      label: "Local Read",
+      description: `Read from the local filesystem relative to ${cwd}. ${localRead.description}`,
+    });
+    const localBash = createBashToolDefinition(cwd);
+    pi.registerTool({
+      ...localBash,
+      name: "localBash",
+      label: "Local Bash",
+      description: `Run a local shell command from ${cwd}. ${localBash.description}`,
+    });
+    const localEdit = createEditToolDefinition(cwd);
+    pi.registerTool({
+      ...localEdit,
+      name: "localEdit",
+      label: "Local Edit",
+      description: `Edit a local file relative to ${cwd}. ${localEdit.description}`,
+    });
+    const localWrite = createWriteToolDefinition(cwd);
+    pi.registerTool({
+      ...localWrite,
+      name: "localWrite",
+      label: "Local Write",
+      description: `Write a local file relative to ${cwd}. ${localWrite.description}`,
+    });
+    const localGrep = createGrepToolDefinition(cwd);
+    pi.registerTool({
+      ...localGrep,
+      name: "localGrep",
+      label: "Local Grep",
+      description: `Search local file contents relative to ${cwd}. ${localGrep.description}`,
+    });
+    const localFind = createFindToolDefinition(cwd);
+    pi.registerTool({
+      ...localFind,
+      name: "localFind",
+      label: "Local Find",
+      description: `Find local files relative to ${cwd}. ${localFind.description}`,
+    });
+    const localLs = createLsToolDefinition(cwd);
+    pi.registerTool({
+      ...localLs,
+      name: "localLs",
+      label: "Local LS",
+      description: `List local files relative to ${cwd}. ${localLs.description}`,
+    });
 
     pi.registerTool({
       name: "read",
@@ -200,6 +290,92 @@ export default function registerBackofficeExtension(pi: ExtensionAPI) {
         return {
           content: [{ type: "text", text: output.text }],
           details: output.details,
+        };
+      },
+    });
+
+    pi.registerTool({
+      name: "upload",
+      label: "Upload",
+      description:
+        "Upload one local file into the persistent /workspace filesystem of the active Backoffice scope.",
+      parameters: Type.Object({
+        localPath: Type.String({
+          description: "Local file path, relative to the Pi working directory or absolute.",
+        }),
+        destinationPath: Type.String({
+          description: "Destination path inside Backoffice /workspace.",
+        }),
+      }),
+      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+        const session = findBackofficeSession(ctx);
+        if (!session) {
+          throw new Error("Run /backoffice before using Backoffice tools.");
+        }
+        const sourcePath = resolve(cwd, params.localPath);
+        const sourceStat = await stat(sourcePath);
+        if (!sourceStat.isFile()) {
+          throw new Error(`Local upload source is not a file: ${sourcePath}`);
+        }
+        const fileKey = backofficeWorkspaceFileKey(params.destinationPath);
+        const result = await uploadBackofficeWorkspaceFile({
+          baseUrl: session.baseUrl,
+          scope: parseBackofficeScope(session.scope),
+          fileKey,
+          content: Readable.toWeb(createReadStream(sourcePath)) as ReadableStream<Uint8Array>,
+          sizeBytes: sourceStat.size,
+          contentType: "application/octet-stream",
+          signal,
+        });
+        const output = boundBackofficeToolOutput(result, null);
+        return {
+          content: [{ type: "text", text: output.text }],
+          details: output.details,
+        };
+      },
+    });
+
+    pi.registerTool({
+      name: "download",
+      label: "Download",
+      description:
+        "Download one file from the active Backoffice scope's filesystem to the local filesystem, including /workspace and /static files.",
+      parameters: Type.Object({
+        sourcePath: Type.String({ description: "Absolute Backoffice file path." }),
+        localPath: Type.String({
+          description: "Local destination path, relative to the Pi working directory or absolute.",
+        }),
+      }),
+      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+        const session = findBackofficeSession(ctx);
+        if (!session) {
+          throw new Error("Run /backoffice before using Backoffice tools.");
+        }
+        const sourcePath = posix.normalize(params.sourcePath);
+        const localPath = resolve(cwd, params.localPath);
+        const content = await withFileMutationQueue(localPath, async () => {
+          const downloaded = await downloadBackofficeFile({
+            baseUrl: session.baseUrl,
+            scope: parseBackofficeScope(session.scope),
+            path: sourcePath,
+            signal,
+          });
+          await mkdir(dirname(localPath), { recursive: true });
+          await writeFile(localPath, downloaded);
+          return downloaded;
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Downloaded ${sourcePath} to ${localPath} (${formatSize(content.byteLength)}).`,
+            },
+          ],
+          details: {
+            sourcePath,
+            localPath,
+            bytesWritten: content.byteLength,
+          },
         };
       },
     });
@@ -325,7 +501,7 @@ export default function registerBackofficeExtension(pi: ExtensionAPI) {
     if (!session) {
       return;
     }
-    registerBackofficeTools();
+    registerBackofficeTools(ctx.cwd);
     pi.setActiveTools(BACKOFFICE_TOOL_NAMES);
     ctx.ui.setStatus("backoffice", `backoffice:${new URL(session.baseUrl).host}`);
   });

--- a/apps/backoffice-cli/README.md
+++ b/apps/backoffice-cli/README.md
@@ -10,9 +10,17 @@ pnpm --filter @rejot-dev/backoffice-cli backoffice-cli login --open
 ```
 
 The CLI discovers local Backoffice servers, authenticates through the OAuth device flow, manages
-scope-specific credentials, fetches codemode declarations, and runs scoped JavaScript or shell
-commands. `backoffice system` prints to stdout by default. When given an output path, it creates a
-new owner-only file and refuses to overwrite an existing path.
+scope-specific credentials, fetches codemode declarations, runs scoped JavaScript or shell commands,
+and transfers files between the local filesystem and scoped Backoffice filesystems. Uploads target
+`/workspace`; downloads also support read-only paths such as `/static`. `backoffice system` prints
+to stdout by default. When given an output path, it creates a new owner-only file and refuses to
+overwrite an existing path.
+
+```bash
+backoffice upload org:org_123 ./report.pdf /workspace/reports/report.pdf
+backoffice download org:org_123 /workspace/reports/report.pdf ./report.pdf
+backoffice download org:org_123 /static/SYSTEM.md ./SYSTEM.md
+```
 
 Set `BACKOFFICE_URL` to select a server, `BACKOFFICE_AUTH_FILE` to override credential storage, or
 `BACKOFFICE_OPEN_BROWSER=1` to open the device authorization page during login.

--- a/apps/backoffice-cli/src/cli.test.ts
+++ b/apps/backoffice-cli/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, assert } from "vitest";
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -18,6 +18,20 @@ describe("backoffice CLI", () => {
     expect(output).toContain("backoffice login");
     expect(output).toContain("--force");
     expect(output).toContain("Scopes:");
+  });
+
+  it("rejects absolute upload destinations outside /workspace", () => {
+    const result = spawnSync(
+      process.execPath,
+      [executable, "upload", "org:org-1", "source.txt", "/static/report.txt"],
+      {
+        cwd: packageDirectory,
+        encoding: "utf8",
+      },
+    );
+
+    assert.equal(result.status, 1);
+    expect(result.stderr).toContain("Workspace path must identify a file inside /workspace.");
   });
 
   it("prints the package version", () => {

--- a/apps/backoffice-cli/src/cli.ts
+++ b/apps/backoffice-cli/src/cli.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { createReadStream, readFileSync } from "node:fs";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
 import {
   backofficeErrorMessage,
   connectToBackoffice,
+  downloadBackofficeFile,
   executeBackofficeBash,
   executeBackofficeCodemode,
   fetchBackofficeSystemPrompt,
@@ -13,6 +16,7 @@ import {
   probeBackofficeServer,
   resolveBackofficeAuthFile,
   resolveBackofficeDefaultScopeForServer,
+  uploadBackofficeWorkspaceFile,
 } from "@rejot-dev/backoffice-local";
 
 import { writeBackofficeSystemPrompt } from "./system-prompt-output.js";
@@ -37,6 +41,10 @@ Commands:
   system [scope] [file]  Print SYSTEM.md or create an owner-only output file
   exec <scope> <code>    Execute a JavaScript codemode function
   bash <scope> <command> Execute a shell command in the scoped runtime
+  upload <scope> <local-file> <workspace-path>
+                         Upload a local file into Backoffice /workspace
+  download <scope> <backoffice-path> <local-file>
+                         Download a Backoffice file locally
 
 Scopes:
   system
@@ -59,6 +67,8 @@ Examples:
   backoffice system org:org_123 ./SYSTEM.md
   backoffice exec org:org_123 'async () => await state.readdir({ path: "/" })'
   backoffice bash org:org_123 --cwd /workspace 'find . -maxdepth 2'
+  backoffice upload org:org_123 ./report.pdf /workspace/reports/report.pdf
+  backoffice download org:org_123 /workspace/reports/report.pdf ./report.pdf
 
 Environment:
   BACKOFFICE_URL          Default Backoffice server URL
@@ -235,6 +245,65 @@ async function execCodemode(args: string[]): Promise<void> {
   console.log(JSON.stringify(result, null, 2));
 }
 
+function backofficeWorkspaceFileKey(path: string): string {
+  if (path.startsWith("/") && !path.startsWith("/workspace/")) {
+    throw new Error("Workspace path must identify a file inside /workspace.");
+  }
+  const fileKey = path.replace(/^\/workspace\//, "").replace(/^\/+/, "");
+  if (!fileKey || fileKey.split("/").includes("..")) {
+    throw new Error("Workspace path must identify a file inside /workspace.");
+  }
+  return fileKey;
+}
+
+async function uploadFile(args: string[]): Promise<void> {
+  const requestedBaseUrl = getFlag(args, "--base-url", configuredBaseUrl);
+  const scopeArg = args.shift();
+  const localFile = args.shift();
+  const workspacePath = args.shift();
+  if (!scopeArg || !localFile || !workspacePath || args.length > 0) {
+    usage();
+  }
+
+  const fileKey = backofficeWorkspaceFileKey(workspacePath);
+  const sourcePath = resolve(localFile);
+  const sourceStat = await stat(sourcePath);
+  if (!sourceStat.isFile()) {
+    throw new Error(`Local upload source is not a file: ${sourcePath}`);
+  }
+  const baseUrl = await resolveCliBaseUrl(requestedBaseUrl);
+  await uploadBackofficeWorkspaceFile({
+    baseUrl,
+    scope: parseBackofficeScope(scopeArg),
+    fileKey,
+    content: Readable.toWeb(createReadStream(sourcePath)) as ReadableStream<Uint8Array>,
+    sizeBytes: sourceStat.size,
+    contentType: "application/octet-stream",
+  });
+  console.log(`Uploaded ${sourcePath} to /workspace/${fileKey} (${sourceStat.size} bytes).`);
+}
+
+async function downloadFile(args: string[]): Promise<void> {
+  const requestedBaseUrl = getFlag(args, "--base-url", configuredBaseUrl);
+  const scopeArg = args.shift();
+  const backofficePath = args.shift();
+  const localFile = args.shift();
+  if (!scopeArg || !backofficePath || !localFile || args.length > 0) {
+    usage();
+  }
+
+  const baseUrl = await resolveCliBaseUrl(requestedBaseUrl);
+  const content = await downloadBackofficeFile({
+    baseUrl,
+    scope: parseBackofficeScope(scopeArg),
+    path: backofficePath,
+  });
+  const destination = resolve(localFile);
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, content);
+  console.log(`Downloaded ${backofficePath} to ${destination} (${content.byteLength} bytes).`);
+}
+
 async function execBash(args: string[]): Promise<void> {
   const requestedBaseUrl = getFlag(args, "--base-url", configuredBaseUrl);
   const timeout = parsePositiveInteger(getFlag(args, "--timeout", undefined), "--timeout");
@@ -288,6 +357,10 @@ export async function runBackofficeCli(argv = process.argv.slice(2)): Promise<vo
       await execCodemode(args);
     } else if (command === "bash") {
       await execBash(args);
+    } else if (command === "upload") {
+      await uploadFile(args);
+    } else if (command === "download") {
+      await downloadFile(args);
     } else {
       console.error(`Unknown command: ${command}\n`);
       usage();

--- a/apps/backoffice/app/files/contributors/upload.ts
+++ b/apps/backoffice/app/files/contributors/upload.ts
@@ -260,6 +260,11 @@ export type UploadFileAssertion = {
 };
 
 export interface UploadFileSystem extends IFileSystem {
+  writeFileStream(
+    path: string,
+    content: ReadableStream<Uint8Array>,
+    options: { sizeBytes: number; contentType: string },
+  ): Promise<void>;
   writeFileConditional(
     path: string,
     content: FileContent,
@@ -452,6 +457,76 @@ const createUploadFileSystemForContext = (
     };
   };
 
+  const resolveUploadFileStreamWriteInput = async (
+    path: string,
+    options: { sizeBytes: number; contentType: string },
+  ) => {
+    const { fileKey, isRoot } = toRelativeUploadPath(mountPoint, path);
+    if (isRoot || !fileKey) {
+      throw new Error(`Cannot write to the mounted upload root '${mountPoint}'.`);
+    }
+
+    const principal = ctx.filePrincipal ?? ROOT_FILE_PRINCIPAL;
+    const existing = await fetchUploadFileFromRuntime(ctx, provider, fileKey);
+    if (existing && !isUploadDirectoryMarker(existing)) {
+      const fsMetadata = readUploadFsMetadata(existing.metadata);
+      assertFileWritable({
+        principal,
+        node: {
+          owner: fsMetadata.owner ?? ROOT_FILE_NODE_PERMISSIONS.owner,
+          group: fsMetadata.group ?? ROOT_FILE_NODE_PERMISSIONS.group,
+          mode: normalizeUploadMode(fsMetadata.mode ?? DEFAULT_FILE_MODE),
+        },
+        operation: "write",
+        path,
+      });
+    }
+    if (!existing) {
+      await assertUploadContainingDirectoryWritable(
+        ctx,
+        provider,
+        mountPoint,
+        getParentUploadFileKey(fileKey),
+        principal,
+        "write",
+        path,
+      );
+    }
+    for (const folderKey of getAncestorFolderKeys(getParentUploadFileKey(fileKey))) {
+      await ensureUploadDirectoryMarker(ctx, provider, folderKey, principal);
+    }
+
+    const contentType =
+      isGenericBinaryContentType(options.contentType) && existing
+        ? (resolveUploadContentType(existing) ?? options.contentType)
+        : (resolveUploadContentType({ fileKey, contentType: options.contentType }) ??
+          options.contentType);
+
+    return {
+      body: {
+        provider,
+        fileKey,
+        filename: getLeafSegment(fileKey),
+        sizeBytes: options.sizeBytes,
+        contentType,
+        metadata: existing
+          ? preserveUploadMetadataForRewrite(existing.metadata)
+          : mergeUploadFsMetadata(null, {
+              owner: principal.subject,
+              group: principal.primaryGroup,
+              mode: DEFAULT_FILE_MODE,
+            }),
+        publicationMode: "batch" as const,
+      },
+      precondition: existing
+        ? ({
+            kind: "revision",
+            revision: requireUploadFileRevision(existing, path),
+          } as const)
+        : ({ kind: "absent" } as const),
+    };
+  };
+
   const writeUploadFile = async (
     path: string,
     content: FileContent,
@@ -578,6 +653,45 @@ const createUploadFileSystemForContext = (
     },
     async writeFile(path, content, options) {
       await writeUploadFile(path, content, options);
+    },
+    async writeFileStream(path, content, options) {
+      const prepared = await resolveUploadFileStreamWriteInput(path, options);
+      const createdResponse = await requestUpload(ctx, "POST", "/uploads", {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(prepared.body),
+      });
+      if (!createdResponse.ok) {
+        throw await createUploadFileSystemRequestError(
+          createdResponse,
+          "Unable to prepare streamed upload-backed file.",
+        );
+      }
+      const created = (await createdResponse.json()) as { uploadId: string };
+      const uploadedResponse = await requestUpload(
+        ctx,
+        "PUT",
+        `/uploads/${encodeURIComponent(created.uploadId)}/content`,
+        {
+          headers: { "content-type": "application/octet-stream" },
+          body: content,
+        },
+      );
+      if (!uploadedResponse.ok) {
+        throw await createUploadFileSystemRequestError(
+          uploadedResponse,
+          "Unable to stream upload-backed file content.",
+        );
+      }
+      const uploaded = (await uploadedResponse.json()) as {
+        kind: "prepared";
+        write: PreparedFileWrite;
+      };
+      if (uploaded.kind !== "prepared") {
+        throw new Error("Streamed upload did not produce a prepared file write.");
+      }
+      await fs.commitPreparedFileWrites({
+        writes: [{ ...uploaded.write, precondition: prepared.precondition }],
+      });
     },
     async writeFileConditional(path, content, options) {
       await writeUploadFile(path, content, options, options.precondition);
@@ -1360,6 +1474,13 @@ const preserveUploadMetadataForRewrite = (
   return Object.keys(nextMetadata).length > 0 ? nextMetadata : null;
 };
 
+const requireUploadFileRevision = (file: UploadFileRecord, path: string): number => {
+  if (!Number.isSafeInteger(file.revision) || file.revision === undefined || file.revision < 1) {
+    throw new Error(`Unable to write '${path}': the current file revision is unavailable.`);
+  }
+  return file.revision;
+};
+
 const normalizeUploadMode = (mode: number): number => mode & 0o7777;
 
 const normalizeUploadMtime = (mtime: Date, path: string): string => {
@@ -1722,13 +1843,15 @@ const requestUpload = async (
     headers.delete("content-type");
   }
 
-  return uploadObject.fetch(
-    new Request(url, {
-      method,
-      headers,
-      body: options.body ?? undefined,
-    }),
-  );
+  const requestInit: RequestInit & { duplex?: "half" } = {
+    method,
+    headers,
+    body: options.body ?? undefined,
+  };
+  if (options.body instanceof ReadableStream) {
+    requestInit.duplex = "half";
+  }
+  return uploadObject.fetch(new Request(url, requestInit));
 };
 
 const createUploadFileSystemRequestError = async (

--- a/apps/backoffice/app/routes.ts
+++ b/apps/backoffice/app/routes.ts
@@ -313,6 +313,7 @@ export default [
     route("github/webhooks", "routes/api/github-webhooks.ts"),
     route("github/:orgSlug/*", "routes/api/github.ts"),
     route("upload/:orgSlug/*", "routes/api/upload.ts"),
+    route("files-scoped/:scopeKind/:scopeId/workspace", "routes/api/files-scoped-workspace.ts"),
     route("upload-scoped/:scopeKind/:scopeId/*", "routes/api/upload-scoped.ts"),
     route("pi/:scopeSegment/*", "routes/api/pi.ts"),
     route("workflows/:scopeSegment/*", "routes/api/workflows.ts"),

--- a/apps/backoffice/app/routes/api/files-scoped-workspace.ts
+++ b/apps/backoffice/app/routes/api/files-scoped-workspace.ts
@@ -1,0 +1,53 @@
+import type { ActionFunctionArgs } from "react-router";
+
+import { requireBackofficeContextScopeFromRouteParams } from "@/backoffice-runtime/scope-codec";
+import { createUploadFileSystem } from "@/files/contributors/upload";
+import { requireBackofficeContext } from "@/fragno/auth/backoffice-principal.server";
+import { UPLOAD_PROVIDER_DATABASE } from "@/fragno/upload";
+import { BackofficeWorkerContext } from "@/worker-runtime/router-context";
+
+export async function action({ request, context, params }: ActionFunctionArgs) {
+  const scope = requireBackofficeContextScopeFromRouteParams(params);
+  if (scope.kind === "system") {
+    throw new Response("System scope does not have a workspace filesystem.", { status: 400 });
+  }
+  const execution = await requireBackofficeContext(request, context, scope);
+  const path = new URL(request.url).searchParams.get("path")?.trim() ?? "";
+  if (!path.startsWith("/workspace/") || path.split("/").includes("..")) {
+    throw new Response("A safe absolute /workspace file path is required.", { status: 400 });
+  }
+  const sizeBytes = Number(request.headers.get("content-length"));
+  if (!Number.isSafeInteger(sizeBytes) || sizeBytes < 0) {
+    throw new Response("A valid Content-Length header is required.", { status: 411 });
+  }
+  if (!request.body) {
+    throw new Response("A file request body is required.", { status: 400 });
+  }
+
+  const { runtime, kernel } = context.get(BackofficeWorkerContext);
+  const uploadObject = kernel.scoped("UPLOAD", scope, runtime.objects.upload);
+  const fileSystem = createUploadFileSystem(
+    {
+      origin: new URL(request.url).origin,
+      request,
+      objects: runtime.objects,
+      execution,
+      kernel,
+      filePrincipal: kernel.resolveFilePrincipal(execution),
+      staticFileArtifacts: () => ({}),
+      uploadObject,
+    },
+    {
+      mountPoint: "/workspace",
+      object: uploadObject,
+      provider: UPLOAD_PROVIDER_DATABASE,
+    },
+  );
+  const content = request.body as ReadableStream<Uint8Array>;
+  await fileSystem.writeFileStream(path, content, {
+    sizeBytes,
+    contentType: request.headers.get("content-type") ?? "application/octet-stream",
+  });
+
+  return Response.json({ path, sizeBytes });
+}

--- a/apps/backoffice/backoffice-worker-topology.ts
+++ b/apps/backoffice/backoffice-worker-topology.ts
@@ -241,6 +241,7 @@ export const BACKOFFICE_WORKER_TOPOLOGY = {
         "routes/api/backoffice-cli-token.ts",
         "routes/api/backoffice-me.ts",
         "routes/api/cloudflare.ts",
+        "routes/api/files-scoped-workspace.ts",
         "routes/api/github-webhooks.ts",
         "routes/api/github.ts",
         "routes/api/marketplace.ts",

--- a/packages/backoffice-local/src/backoffice-local.test.ts
+++ b/packages/backoffice-local/src/backoffice-local.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { parseBackofficeScope } from "./backoffice-local.js";
+import {
+  downloadBackofficeFile,
+  parseBackofficeScope,
+  uploadBackofficeWorkspaceFile,
+} from "./backoffice-local.js";
 
 describe("parseBackofficeScope", () => {
   it("parses encoded organization and project identifiers", () => {
@@ -16,4 +20,32 @@ describe("parseBackofficeScope", () => {
       "Invalid Backoffice scope",
     );
   });
+});
+
+describe("Backoffice workspace file transfers", () => {
+  it("rejects uploads in system scope before making a request", async () => {
+    await expect(
+      uploadBackofficeWorkspaceFile({
+        baseUrl: "https://backoffice.invalid",
+        scope: { kind: "system" },
+        fileKey: "report.txt",
+        content: new Blob([]).stream(),
+        sizeBytes: 0,
+        contentType: "application/octet-stream",
+      }),
+    ).rejects.toThrow("system scope does not have a /workspace filesystem");
+  });
+
+  it.each(["/workspace/report.txt", "/./workspace/report.txt", "//workspace/report.txt"])(
+    "rejects the canonical workspace path %s in system scope before making a request",
+    async (path) => {
+      await expect(
+        downloadBackofficeFile({
+          baseUrl: "https://backoffice.invalid",
+          scope: { kind: "system" },
+          path,
+        }),
+      ).rejects.toThrow("system scope does not have a /workspace filesystem");
+    },
+  );
 });

--- a/packages/backoffice-local/src/backoffice-local.ts
+++ b/packages/backoffice-local/src/backoffice-local.ts
@@ -1,6 +1,7 @@
+import { Buffer } from "node:buffer";
 import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname, posix, resolve } from "node:path";
 
 import {
   fetchBackofficeWithoutRedirect,
@@ -192,16 +193,22 @@ export function parseBackofficeScope(segment: string): BackofficeScope {
   );
 }
 
+function backofficeScopeRouteId(scope: BackofficeScope): string {
+  return scope.kind === "system"
+    ? "system"
+    : scope.kind === "org"
+      ? encodeURIComponent(scope.orgId)
+      : scope.kind === "user"
+        ? encodeURIComponent(scope.userId)
+        : `${encodeURIComponent(scope.orgId)}:${encodeURIComponent(scope.projectId)}`;
+}
+
 function backofficeScopePath(scope: BackofficeScope, suffix = ""): string {
-  const routeId =
-    scope.kind === "system"
-      ? "system"
-      : scope.kind === "org"
-        ? encodeURIComponent(scope.orgId)
-        : scope.kind === "user"
-          ? encodeURIComponent(scope.userId)
-          : `${encodeURIComponent(scope.orgId)}:${encodeURIComponent(scope.projectId)}`;
-  return `/api/backoffice/codemode/${scope.kind}/${encodeURIComponent(routeId)}${suffix}`;
+  return `/api/backoffice/codemode/${scope.kind}/${encodeURIComponent(backofficeScopeRouteId(scope))}${suffix}`;
+}
+
+function backofficeScopedUploadPath(scope: BackofficeScope, suffix = ""): string {
+  return `/api/upload-scoped/${scope.kind}/${encodeURIComponent(backofficeScopeRouteId(scope))}/files${suffix}`;
 }
 
 function isStoredAuthState(value: unknown): value is StoredAuthState {
@@ -747,14 +754,18 @@ async function authedFetch(
   const fetchWithAuth = (credentials: StoredAuthState) => {
     const headers = new Headers(fetchOptions.headers);
     headers.set("authorization", `Bearer ${credentials.backoffice.accessToken}`);
-    return fetchBackofficeWithoutRedirect(`${credentials.baseUrl}${path}`, {
+    const requestInit: RequestInit & { duplex?: "half" } = {
       ...fetchOptions,
       headers,
-    });
+    };
+    if (fetchOptions.body instanceof ReadableStream) {
+      requestInit.duplex = "half";
+    }
+    return fetchBackofficeWithoutRedirect(`${credentials.baseUrl}${path}`, requestInit);
   };
 
   const response = await fetchWithAuth(auth);
-  if (response.status !== 401) {
+  if (response.status !== 401 || fetchOptions.body instanceof ReadableStream) {
     return response;
   }
 
@@ -903,6 +914,107 @@ export async function executeBackofficeCodemode(options: {
   const body = await assertOk(response, "Codemode execution");
   assertBackofficeCodemodeSucceeded(body);
   return body;
+}
+
+function requireSafeBackofficeWorkspaceFileKey(fileKey: string): string {
+  const normalized = fileKey.replace(/^\/+/, "");
+  if (!normalized || normalized.split("/").includes("..")) {
+    throw new Error("Backoffice workspace operation requires a safe file key.");
+  }
+  return normalized;
+}
+
+function requireBackofficeWorkspaceScope(scope: BackofficeScope): void {
+  if (scope.kind === "system") {
+    throw new Error("Backoffice system scope does not have a /workspace filesystem.");
+  }
+}
+
+/** Downloads bytes from an absolute path in the selected Backoffice filesystem. */
+export async function downloadBackofficeFile(options: {
+  baseUrl: string;
+  scope: BackofficeScope;
+  path: string;
+  signal?: AbortSignal;
+}): Promise<Uint8Array> {
+  if (!options.path.startsWith("/")) {
+    throw new Error("Backoffice download requires a safe absolute file path.");
+  }
+  const path = posix.normalize(options.path);
+  if (path.startsWith("/workspace/")) {
+    requireBackofficeWorkspaceScope(options.scope);
+    const fileKey = requireSafeBackofficeWorkspaceFileKey(path.slice("/workspace/".length));
+    const query = new URLSearchParams({ provider: "database", key: fileKey });
+    const response = await authedFetch(
+      backofficeScopedUploadPath(options.scope, `/by-key/content?${query}`),
+      options.scope,
+      {
+        baseUrl: options.baseUrl,
+        signal: options.signal,
+      },
+    );
+    if (!response.ok) {
+      await assertOk(response, `Download Backoffice file '${path}'`);
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  const response = await executeBackofficeCodemode({
+    baseUrl: options.baseUrl,
+    scope: options.scope,
+    signal: options.signal,
+    code: `async () => {
+      const bytes = await state.readFileBytes({ path: ${JSON.stringify(path)} });
+      let binary = "";
+      for (let offset = 0; offset < bytes.length; offset += 32768) {
+        binary += String.fromCharCode(...bytes.subarray(offset, offset + 32768));
+      }
+      return { base64: btoa(binary) };
+    }`,
+  });
+  if (!response || typeof response !== "object") {
+    throw new Error(`Download Backoffice file '${path}' returned an invalid response.`);
+  }
+  const result = (response as Record<string, unknown>)["result"];
+  if (!result || typeof result !== "object") {
+    throw new Error(`Download Backoffice file '${path}' returned an invalid result.`);
+  }
+  const base64 = (result as Record<string, unknown>)["base64"];
+  if (typeof base64 !== "string") {
+    throw new Error(`Download Backoffice file '${path}' returned invalid file content.`);
+  }
+  return Uint8Array.from(Buffer.from(base64, "base64"));
+}
+
+/** Uploads bytes into the persistent Backoffice workspace for the selected scope. */
+export async function uploadBackofficeWorkspaceFile(options: {
+  baseUrl: string;
+  scope: BackofficeScope;
+  fileKey: string;
+  content: ReadableStream<Uint8Array>;
+  sizeBytes: number;
+  contentType: string;
+  signal?: AbortSignal;
+}): Promise<unknown> {
+  requireBackofficeWorkspaceScope(options.scope);
+  const fileKey = requireSafeBackofficeWorkspaceFileKey(options.fileKey);
+  const path = `/workspace/${fileKey}`;
+  const query = new URLSearchParams({ path });
+  const response = await authedFetch(
+    `/api/files-scoped/${options.scope.kind}/${encodeURIComponent(backofficeScopeRouteId(options.scope))}/workspace?${query}`,
+    options.scope,
+    {
+      baseUrl: options.baseUrl,
+      method: "POST",
+      headers: {
+        "content-length": String(options.sizeBytes),
+        "content-type": options.contentType,
+      },
+      body: options.content,
+      signal: options.signal,
+    },
+  );
+  return await assertOk(response, `Upload Backoffice workspace file '${fileKey}'`);
 }
 
 export async function executeBackofficeBash(options: {


### PR DESCRIPTION
Add permission-aware workspace uploads and binary downloads to the
local Backoffice client.

Expose upload and download commands through the CLI and Pi extension,
including local filesystem tools, path and scope validation, serialized
local writes, documentation, and regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CLI commands to upload local files to `/workspace` and download files from Backoffice.
  - Added Backoffice tools for file transfers and local filesystem operations.
  - Support is available for binary file transfers.

- **Bug Fixes**
  - Added path validation to prevent unsafe destinations and directory traversal.
  - System scopes now clearly reject unsupported workspace file operations.

- **Documentation**
  - Updated CLI help and README examples for file uploads and downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->